### PR TITLE
Fix deadlock caused by planning_ flag

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -297,6 +297,9 @@ namespace mbf_abstract_nav
     //! mutex to handle safe thread communication for the goal and start pose.
     boost::mutex goal_start_mtx_;
 
+    //! mutex to handle safe thread communication for the planning_ flag.
+    boost::mutex planning_mtx_;
+
     //! true, if a new goal pose has been set, until it is used.
     bool has_new_goal_;
 

--- a/mbf_abstract_nav/src/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_planner_execution.cpp
@@ -258,6 +258,7 @@ namespace mbf_abstract_nav
     {
       return false;
     }
+    boost::lock_guard<boost::mutex> guard(planning_mtx_);
     planning_ = true;
     cancel_ = false;
     start_ = start;
@@ -305,6 +306,7 @@ namespace mbf_abstract_nav
 
   void AbstractPlannerExecution::run()
   {
+    boost::lock_guard<boost::mutex> guard(planning_mtx_);
     int retries = 0;
     geometry_msgs::PoseStamped current_start = start_;
     geometry_msgs::PoseStamped current_goal = goal_;


### PR DESCRIPTION
I experienced a deadlock as my application integrate move_base_flex with auto exploration application.
The root cause is `mbf_abstract_nav::AbstractPlannerExecution` does not use mutex to protect its member `planning_`, which will be used in both `AbstractPlannerExecution::run` and `AbstractPlannerExecution::startPlanning` these two thread. The deadlock can be reproduced in following step:<br>
**Step 1:** Using `AbstractPlannerExecution::startPlanning` to send goal _A_.
**Step 2:** In `AbstractPlannerExecution::run()`, if it fails several times to find the plan and triggers any stop condition, it will set `planning_` to false.
**Step 3:** At the same time, in another thread, our application receives the fail from action server, then it sends next goal _B_ to exploration immediately (Calling `AbstractPlannerExecution::startPlanning` again).
**Step 4:** `AbstractPlannerExecution::startPlanning` will check `planning_` and set it to true again. (`planning_` has been set to false in the thread created in **Step 2**.)
**Step 5:** If the thread created in **Step 2** does not leave its while loop yet, then the dead lock will be triggered.