### PR TITLE
Rename references to move_base_flex_msgs with mbf_msgs

### DIFF
--- a/doc/images/move_base_flex.svg
+++ b/doc/images/move_base_flex.svg
@@ -9934,7 +9934,7 @@
 		</g>
 	</g>
 </g>
-<text transform="matrix(1 0 0 1 563.8802 169.2559)"><tspan x="0" y="0" class="st2 st3">Action</tspan><tspan x="-2" y="12" class="st4 st5">/recovery</tspan><tspan x="-35.4" y="21.6" class="st4 st18">move_base_flex_msgs/Recovery</tspan></text>
+<text transform="matrix(1 0 0 1 563.8802 169.2559)"><tspan x="0" y="0" class="st2 st3">Action</tspan><tspan x="-2" y="12" class="st4 st5">/recovery</tspan><tspan x="-35.4" y="21.6" class="st4 st18">mbf_msgs/Recovery</tspan></text>
 <g>
 	<g>
 		<g>
@@ -10493,7 +10493,7 @@
 		</g>
 	</g>
 </g>
-<text transform="matrix(1 0 0 1 563.8798 110.8194)"><tspan x="0" y="0" class="st2 st3">Action</tspan><tspan x="-3.8" y="12" class="st4 st5">/exe_path</tspan><tspan x="-34" y="21.6" class="st4 st18">move_base_flex_msgs/ExePath</tspan></text>
+<text transform="matrix(1 0 0 1 563.8798 110.8194)"><tspan x="0" y="0" class="st2 st3">Action</tspan><tspan x="-3.8" y="12" class="st4 st5">/exe_path</tspan><tspan x="-34" y="21.6" class="st4 st18">mbf_msgs/ExePath</tspan></text>
 <g>
 	<g>
 		<g>
@@ -11052,7 +11052,7 @@
 		</g>
 	</g>
 </g>
-<text transform="matrix(1 0 0 1 563.8798 52.8331)"><tspan x="0" y="0" class="st2 st3">Action</tspan><tspan x="-3.5" y="12" class="st4 st5">/get_path</tspan><tspan x="-34.1" y="21.6" class="st4 st18">move_base_flex_msgs/GetPath</tspan></text>
+<text transform="matrix(1 0 0 1 563.8798 52.8331)"><tspan x="0" y="0" class="st2 st3">Action</tspan><tspan x="-3.5" y="12" class="st4 st5">/get_path</tspan><tspan x="-34.1" y="21.6" class="st4 st18">mbf_msgs/GetPath</tspan></text>
 <g>
 	<g>
 		<g>
@@ -11609,7 +11609,7 @@
 		</g>
 	</g>
 </g>
-<text transform="matrix(1 0 0 1 562.2178 370.7475)"><tspan x="0" y="0" class="st2 st3">Service</tspan><tspan x="-17.5" y="12" class="st4 st5">/check_pose_cost</tspan><tspan x="-36.6" y="21.6" class="st4 st18">move_base_flex_msgs/CheckPose</tspan></text>
+<text transform="matrix(1 0 0 1 562.2178 370.7475)"><tspan x="0" y="0" class="st2 st3">Service</tspan><tspan x="-17.5" y="12" class="st4 st5">/check_pose_cost</tspan><tspan x="-36.6" y="21.6" class="st4 st18">mbf_msgs/CheckPose</tspan></text>
 <g>
 	<g>
 		<g>
@@ -12725,7 +12725,7 @@
 		</g>
 	</g>
 </g>
-<text transform="matrix(1 0 0 1 563.8802 227.6918)"><tspan x="0" y="0" class="st2 st3">Action</tspan><tspan x="-8.1" y="12" class="st4 st5">/move_base</tspan><tspan x="-37.4" y="21.6" class="st4 st18">move_base_flex_msgs/MoveBase</tspan></text>
+<text transform="matrix(1 0 0 1 563.8802 227.6918)"><tspan x="0" y="0" class="st2 st3">Action</tspan><tspan x="-8.1" y="12" class="st4 st5">/move_base</tspan><tspan x="-37.4" y="21.6" class="st4 st18">mbf_msgs/MoveBase</tspan></text>
 <text transform="matrix(0 -1 1 0 660.3375 460.5384)" class="st13 st2 st7">Action &amp; Service Interface</text>
 <g>
 	<g>

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
@@ -143,35 +143,35 @@ typedef boost::shared_ptr<dynamic_reconfigure::Server<mbf_abstract_nav::MoveBase
     /**
      * @brief GetPath action execution method. This method will be called if the action server receives a goal
      * @param goal SimpleActionServer goal containing all necessary parameters for the action execution. See the action
-     *        definitions in move_base_flex_msgs.
+     *        definitions in mbf_msgs.
      */
     virtual void callActionGetPath(const mbf_msgs::GetPathGoalConstPtr &goal);
 
     /**
      * @brief ExePath action execution method. This method will be called if the action server receives a goal
      * @param goal SimpleActionServer goal containing all necessary parameters for the action execution. See the action
-     *        definitions in move_base_flex_msgs.
+     *        definitions in mbf_msgs.
      */
     virtual void callActionExePath(const mbf_msgs::ExePathGoalConstPtr &goal);
 
     /**
      * @brief Recovery action execution method. This method will be called if the action server receives a goal
      * @param goal SimpleActionServer goal containing all necessary parameters for the action execution. See the action
-     *        definitions in move_base_flex_msgs.
+     *        definitions in mbf_msgs.
      */
     virtual void callActionRecovery(const mbf_msgs::RecoveryGoalConstPtr &goal);
 
     /**
      * @brief MoveBase action execution method. This method will be called if the action server receives a goal
      * @param goal SimpleActionServer goal containing all necessary parameters for the action execution. See the action
-     *        definitions in move_base_flex_msgs.
+     *        definitions in mbf_msgs.
      */
     virtual void callActionMoveBase(const mbf_msgs::MoveBaseGoalConstPtr &goal);
 
     /**
      * @brief Callback function of the MoveBase action, while is executes the GetPath action part to compute a path
      * @param feedback SimpleActionServer feedback containing all feedback information for the MoveBase action. See the
-     *        action definitions in move_base_flex_msgs.
+     *        action definitions in mbf_msgs.
      */
     virtual void actionMoveBaseExePathFeedback(const mbf_msgs::ExePathFeedbackConstPtr &feedback);
 

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
@@ -105,8 +105,8 @@ private:
 
   /**
    * @brief Callback method for the check_pose_cost service
-   * @param request Request object, see the move_base_flex_msgs/CheckPose service definition file.
-   * @param response Response object, see the move_base_flex_msgs/CheckPose service definition file.
+   * @param request Request object, see the mbf_msgs/CheckPose service definition file.
+   * @param response Response object, see the mbf_msgs/CheckPose service definition file.
    * @return true, if the service completed successfully, false otherwise
    */
   bool callServiceCheckPoseCost(mbf_msgs::CheckPose::Request &request,
@@ -124,7 +124,7 @@ private:
    * @brief GetPath action execution method. This method will be called if the action server receives a goal. It
    *        extends the base class method by calling the checkActivateCostmaps() and checkDeactivateCostmaps().
    * @param goal SimpleActionServer goal containing all necessary parameters for the action execution. See the action
-   *        definitions in move_base_flex_msgs.
+   *        definitions in mbf_msgs.
    */
   virtual void callActionGetPath(const mbf_msgs::GetPathGoalConstPtr &goal);
 
@@ -132,7 +132,7 @@ private:
    * @brief ExePath action execution method. This method will be called if the action server receives a goal. It
    *        extends the base class method by calling the checkActivateCostmaps() and checkDeactivateCostmaps().
    * @param goal SimpleActionServer goal containing all necessary parameters for the action execution. See the action
-   *        definitions in move_base_flex_msgs.
+   *        definitions in mbf_msgs.
    */
   virtual void callActionExePath(const mbf_msgs::ExePathGoalConstPtr &goal);
 
@@ -140,7 +140,7 @@ private:
    * @brief Recovery action execution method. This method will be called if the action server receives a goal. It
    *        extends the base class method by calling the checkActivateCostmaps() and checkDeactivateCostmaps().
    * @param goal SimpleActionServer goal containing all necessary parameters for the action execution. See the action
-   *        definitions in move_base_flex_msgs.
+   *        definitions in mbf_msgs.
    */
   virtual void callActionRecovery(const mbf_msgs::RecoveryGoalConstPtr &goal);
 


### PR DESCRIPTION
Fixes old references that were introduced by 6141190c13527bd0ffdff009262ab0af492c127a

Command:
  sed -i 's/move_base_flex_msgs/mbf_msgs/g' ...