### PR TITLE
Mbf abstract core cleanup

### DIFF
--- a/mbf_abstract_core/CMakeLists.txt
+++ b/mbf_abstract_core/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin REQUIRED
         COMPONENTS
             std_msgs
             geometry_msgs
-            tf
+
         )
 
 catkin_package(
@@ -14,7 +14,6 @@ catkin_package(
     CATKIN_DEPENDS
             std_msgs
             geometry_msgs
-            tf
 )
 
 

--- a/mbf_abstract_core/include/mbf_abstract_core/abstract_recovery.h
+++ b/mbf_abstract_core/include/mbf_abstract_core/abstract_recovery.h
@@ -73,7 +73,10 @@ namespace mbf_abstract_core {
       virtual bool cancel() = 0;
 
     protected:
-      AbstractRecovery(){}
+      /**
+       * @brief Constructor
+       */
+      AbstractRecovery(){};
   };
 };  /* namespace mbf_abstract_core */
 

--- a/mbf_abstract_core/package.xml
+++ b/mbf_abstract_core/package.xml
@@ -20,8 +20,7 @@
     <buildtool_depend>catkin</buildtool_depend>
     <depend>geometry_msgs</depend>
     <depend>std_msgs</depend>
-    <depend>tf</depend>
-    
+
     <export>
       <rosdoc config="rosdoc.yaml" />
     </export>


### PR DESCRIPTION
This branch cleans up the existing mbf_abstract_core project.
It removes the unused TF dependecy and also add the missing doxygen documentation line for AbstractRecovery