### PR TITLE
Mbf abstract nav

### DIFF
--- a/mbf_abstract_core/CMakeLists.txt
+++ b/mbf_abstract_core/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin REQUIRED
         COMPONENTS
             std_msgs
             geometry_msgs
-            tf
+
         )
 
 catkin_package(
@@ -14,7 +14,6 @@ catkin_package(
     CATKIN_DEPENDS
             std_msgs
             geometry_msgs
-            tf
 )
 
 

--- a/mbf_abstract_core/include/mbf_abstract_core/abstract_recovery.h
+++ b/mbf_abstract_core/include/mbf_abstract_core/abstract_recovery.h
@@ -73,7 +73,10 @@ namespace mbf_abstract_core {
       virtual bool cancel() = 0;
 
     protected:
-      AbstractRecovery(){}
+      /**
+       * @brief Constructor
+       */
+      AbstractRecovery(){};
   };
 };  /* namespace mbf_abstract_core */
 

--- a/mbf_abstract_core/package.xml
+++ b/mbf_abstract_core/package.xml
@@ -20,8 +20,7 @@
     <buildtool_depend>catkin</buildtool_depend>
     <depend>geometry_msgs</depend>
     <depend>std_msgs</depend>
-    <depend>tf</depend>
-    
+
     <export>
       <rosdoc config="rosdoc.yaml" />
     </export>

--- a/mbf_abstract_nav/CMakeLists.txt
+++ b/mbf_abstract_nav/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(catkin REQUIRED
   std_msgs
   std_srvs
   tf
+  visualization_msgs
+  xmlrpcpp
   )
 
 find_package(Boost COMPONENTS thread chrono exception REQUIRED)
@@ -47,6 +49,8 @@ catkin_package(
   std_msgs
   std_srvs
   tf
+  visualization_msgs
+  xmlrpcpp
   DEPENDS Boost
 )
 

--- a/mbf_abstract_nav/CMakeLists.txt
+++ b/mbf_abstract_nav/CMakeLists.txt
@@ -11,12 +11,10 @@ find_package(catkin REQUIRED
   mbf_abstract_core
   mbf_utility
   nav_msgs
-  pluginlib
   roscpp
   std_msgs
   std_srvs
   tf
-  visualization_msgs
   xmlrpcpp
   )
 
@@ -36,21 +34,19 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${MBF_ABSTRACT_SERVER_LIB}
   CATKIN_DEPENDS
-  actionlib
-  actionlib_msgs
-  dynamic_reconfigure
-  geometry_msgs
-  mbf_msgs
-  mbf_abstract_core
-  mbf_utility
-  nav_msgs
-  pluginlib
-  roscpp
-  std_msgs
-  std_srvs
-  tf
-  visualization_msgs
-  xmlrpcpp
+      actionlib
+      actionlib_msgs
+      dynamic_reconfigure
+      geometry_msgs
+      mbf_msgs
+      mbf_abstract_core
+      mbf_utility
+      nav_msgs
+      roscpp
+      std_msgs
+      std_srvs
+      tf
+      xmlrpcpp
   DEPENDS Boost
 )
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -174,7 +174,7 @@ namespace mbf_abstract_nav
      *        if a user uses dynamic reconfigure to reconfigure the current state.
      * @param config MoveBaseFlexConfig object
      */
-    void reconfigure(mbf_abstract_nav::MoveBaseFlexConfig &config);
+    void reconfigure(const MoveBaseFlexConfig &config);
 
     /**
      * @brief Returns weather the robot should normally move or not. True if the local planner seems to work properly.

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -51,7 +51,6 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/thread.hpp>
 
-#include <pluginlib/class_loader.h>
 #include <tf/transform_listener.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Twist.h>

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -41,16 +41,24 @@
 #ifndef MBF_ABSTRACT_NAV__ABSTRACT_CONTROLLER_EXECUTION_H_
 #define MBF_ABSTRACT_NAV__ABSTRACT_CONTROLLER_EXECUTION_H_
 
-#include <pluginlib/class_loader.h>
-#include <boost/chrono/thread_clock.hpp>
+#include <map>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
 #include <boost/chrono/duration.hpp>
+#include <boost/chrono/thread_clock.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/thread.hpp>
+
+#include <pluginlib/class_loader.h>
 #include <tf/transform_listener.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Twist.h>
-#include <mbf_abstract_core/abstract_controller.h>
-#include <mbf_utility/navigation_utility.h>
 
-#include "mbf_abstract_nav/MoveBaseFlexConfig.h"
+#include <mbf_abstract_core/abstract_controller.h>
+#include <mbf_abstract_nav/MoveBaseFlexConfig.h>
+#include <mbf_utility/navigation_utility.h>
 
 namespace mbf_abstract_nav
 {

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -55,9 +55,10 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Twist.h>
 
-#include <mbf_abstract_core/abstract_controller.h>
-#include <mbf_abstract_nav/MoveBaseFlexConfig.h>
 #include <mbf_utility/navigation_utility.h>
+#include <mbf_abstract_core/abstract_controller.h>
+
+#include "mbf_abstract_nav/MoveBaseFlexConfig.h"
 
 namespace mbf_abstract_nav
 {

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -125,7 +125,7 @@ namespace mbf_abstract_nav
     };
 
     /**
-     * Return the current state of the controller execution. Thread communication safe.
+     * @brief Return the current state of the controller execution. Thread communication safe.
      * @return current state, enum value of ControllerState
      */
     ControllerState getState();
@@ -154,9 +154,9 @@ namespace mbf_abstract_nav
 
     /**
      * @brief Returns the last valid velocity command set by setVelocityCmd method
-     * @param vel_cmd_stamped Returns the last valid velocity command.
+     * @return The last valid velocity command.
      */
-    void getLastValidCmdVel(geometry_msgs::TwistStamped &vel_cmd_stamped);
+    geometry_msgs::TwistStamped getLastValidCmdVel();
 
     /**
      * @brief Checks whether the patience duration time has been exceeded, ot not
@@ -311,9 +311,9 @@ namespace mbf_abstract_nav
 
     /**
      * @brief Gets the new available plan. This method is thread safe.
-     * @param plan A reference to a plan which will then be filled with the new plan
+     * @return The plan
      */
-    void getNewPlan(std::vector<geometry_msgs::PoseStamped> &plan);
+    std::vector<geometry_msgs::PoseStamped> getNewPlan();
 
     //! the last calculated velocity command
     geometry_msgs::TwistStamped vel_cmd_stamped_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
@@ -41,27 +41,27 @@
 #ifndef MBF_ABSTRACT_NAV__ABSTRACT_NAVIGATION_SERVER_H_
 #define MBF_ABSTRACT_NAV__ABSTRACT_NAVIGATION_SERVER_H_
 
-#include "abstract_planner_execution.h"
-#include "abstract_controller_execution.h"
-#include "abstract_recovery_execution.h"
+#include <string>
+#include <stdint.h>
 
-#include "mbf_abstract_nav/MoveBaseFlexConfig.h"
+#include <boost/shared_ptr.hpp>
+#include <boost/thread/recursive_mutex.hpp>
 
-#include <geometry_msgs/PoseStamped.h>
-
-#include <tf/transform_listener.h>
-#include <dynamic_reconfigure/server.h>
-#include <actionlib/server/simple_action_server.h>
 #include <actionlib/client/simple_action_client.h>
+#include <actionlib/server/simple_action_server.h>
+#include <dynamic_reconfigure/server.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <tf/transform_listener.h>
 
+#include <mbf_abstract_nav/abstract_planner_execution.h>
+#include <mbf_abstract_nav/abstract_controller_execution.h>
+#include <mbf_abstract_nav/abstract_recovery_execution.h>
+#include <mbf_abstract_nav/MoveBaseFlexConfig.h>
 #include <mbf_msgs/GetPathAction.h>
 #include <mbf_msgs/ExePathAction.h>
 #include <mbf_msgs/RecoveryAction.h>
 #include <mbf_msgs/MoveBaseAction.h>
-
 #include <mbf_utility/navigation_utility.h>
-
-#include "abstract_navigation_server.h"
 
 namespace mbf_abstract_nav
 {

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
@@ -53,15 +53,16 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <tf/transform_listener.h>
 
-#include <mbf_abstract_nav/abstract_planner_execution.h>
-#include <mbf_abstract_nav/abstract_controller_execution.h>
-#include <mbf_abstract_nav/abstract_recovery_execution.h>
-#include <mbf_abstract_nav/MoveBaseFlexConfig.h>
 #include <mbf_msgs/GetPathAction.h>
 #include <mbf_msgs/ExePathAction.h>
 #include <mbf_msgs/RecoveryAction.h>
 #include <mbf_msgs/MoveBaseAction.h>
 #include <mbf_utility/navigation_utility.h>
+
+#include "mbf_abstract_nav/abstract_planner_execution.h"
+#include "mbf_abstract_nav/abstract_controller_execution.h"
+#include "mbf_abstract_nav/abstract_recovery_execution.h"
+#include "mbf_abstract_nav/MoveBaseFlexConfig.h"
 
 namespace mbf_abstract_nav
 {

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -203,7 +203,7 @@ namespace mbf_abstract_nav
      *        to reconfigure the current state.
      * @param config MoveBaseFlexConfig object
      */
-    void reconfigure(mbf_abstract_nav::MoveBaseFlexConfig &config);
+    void reconfigure(const MoveBaseFlexConfig &config);
 
     /**
      * @brief Switches the planner to planner with the given name

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -52,7 +52,6 @@
 #include <boost/thread.hpp>
 
 #include <geometry_msgs/PoseStamped.h>
-#include <pluginlib/class_loader.h>
 #include <tf/transform_listener.h>
 
 #include <mbf_abstract_core/abstract_planner.h>

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -195,6 +195,7 @@ namespace mbf_abstract_nav
 
     /**
      * @brief Loads the plugin given by the parameter "local_planner"
+     * @return true, if successful
      */
     bool initialize();
 
@@ -240,7 +241,7 @@ namespace mbf_abstract_nav
     /**
      * @brief Loads the plugin associated with the given planner_type parameter.
      * @param planner_type The type of the planner plugin to load.
-     * @return true, if the local planner plugin was successfully loaded.
+     * @return Pointer to the loaded plugin
      */
     virtual mbf_abstract_core::AbstractPlanner::Ptr loadPlannerPlugin(const std::string& planner_type) = 0;
 
@@ -268,9 +269,9 @@ namespace mbf_abstract_nav
      * @return An outcome number, see also the action definition in the GetPath.action file
      */
     virtual uint32_t makePlan(
-        const mbf_abstract_core::AbstractPlanner::Ptr& planner_ptr,
-        const geometry_msgs::PoseStamped start,
-        const geometry_msgs::PoseStamped goal,
+        const mbf_abstract_core::AbstractPlanner::Ptr &planner_ptr,
+        const geometry_msgs::PoseStamped &start,
+        const geometry_msgs::PoseStamped &goal,
         double tolerance,
         std::vector<geometry_msgs::PoseStamped> &plan,
         double &cost,

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -41,15 +41,23 @@
 #ifndef MBF_ABSTRACT_NAV__ABSTRACT_PLANNER_EXECUTION_H_
 #define MBF_ABSTRACT_NAV__ABSTRACT_PLANNER_EXECUTION_H_
 
-#include <pluginlib/class_loader.h>
-#include <boost/chrono/thread_clock.hpp>
-#include <boost/chrono/duration.hpp>
-#include <tf/transform_listener.h>
-#include <geometry_msgs/PoseStamped.h>
-#include <mbf_abstract_core/abstract_planner.h>
-#include <mbf_utility/navigation_utility.h>
+#include <map>
+#include <stdint.h>
+#include <string>
+#include <vector>
 
-#include "mbf_abstract_nav/MoveBaseFlexConfig.h"
+#include <boost/chrono/duration.hpp>
+#include <boost/chrono/thread_clock.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/thread.hpp>
+
+#include <geometry_msgs/PoseStamped.h>
+#include <pluginlib/class_loader.h>
+#include <tf/transform_listener.h>
+
+#include <mbf_abstract_core/abstract_planner.h>
+#include <mbf_abstract_nav/MoveBaseFlexConfig.h>
+#include <mbf_utility/navigation_utility.h>
 
 namespace mbf_abstract_nav
 {

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -55,8 +55,9 @@
 #include <tf/transform_listener.h>
 
 #include <mbf_abstract_core/abstract_planner.h>
-#include <mbf_abstract_nav/MoveBaseFlexConfig.h>
 #include <mbf_utility/navigation_utility.h>
+
+#include "mbf_abstract_nav/MoveBaseFlexConfig.h"
 
 namespace mbf_abstract_nav
 {

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
@@ -50,7 +50,6 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/thread.hpp>
 
-#include <pluginlib/class_loader.h>
 #include <tf/transform_listener.h>
 
 #include <mbf_abstract_core/abstract_recovery.h>
@@ -66,7 +65,7 @@ namespace mbf_abstract_nav
  */
 
 /**
- * @brief The AbstractiRecoveryExecution class loads and binds the recovery behavior plugin. It contains a thread
+ * @brief The AbstractRecoveryExecution class loads and binds the recovery behavior plugin. It contains a thread
  *        running the plugin, executing the recovery behavior. An internal state is saved and will be pulled by the
  *        server, which controls the recovery behavior execution. Due to a state change it wakes up all threads
  *        connected to the condition variable.

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
@@ -53,8 +53,9 @@
 #include <tf/transform_listener.h>
 
 #include <mbf_abstract_core/abstract_recovery.h>
-#include <mbf_abstract_nav/MoveBaseFlexConfig.h>
 #include <mbf_utility/navigation_utility.h>
+
+#include "mbf_abstract_nav/MoveBaseFlexConfig.h"
 
 namespace mbf_abstract_nav
 {

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
@@ -41,13 +41,21 @@
 #ifndef MBF_ABSTRACT_NAV__ABSTRACT_RECOVERY_EXECUTION_H_
 #define MBF_ABSTRACT_NAV__ABSTRACT_RECOVERY_EXECUTION_H_
 
-#include <pluginlib/class_loader.h>
-#include <boost/chrono/thread_clock.hpp>
-#include <tf/transform_listener.h>
-#include <mbf_abstract_core/abstract_recovery.h>
-#include <mbf_utility/navigation_utility.h>
+#include <map>
+#include <string>
+#include <stdint.h>
+#include <vector>
 
-#include "mbf_abstract_nav/MoveBaseFlexConfig.h"
+#include <boost/chrono/thread_clock.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/thread.hpp>
+
+#include <pluginlib/class_loader.h>
+#include <tf/transform_listener.h>
+
+#include <mbf_abstract_core/abstract_recovery.h>
+#include <mbf_abstract_nav/MoveBaseFlexConfig.h>
+#include <mbf_utility/navigation_utility.h>
 
 namespace mbf_abstract_nav
 {

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
@@ -126,7 +126,7 @@ namespace mbf_abstract_nav
      *        reconfigure tool.
      * @param config Current MoveBaseFlexConfig object. See the MoveBaseFlex.cfg definition.
      */
-    void reconfigure(mbf_abstract_nav::MoveBaseFlexConfig &config);
+    void reconfigure(const MoveBaseFlexConfig &config);
 
     /**
      * @brief Tries to cancel the execution of the recovery behavior plugin.

--- a/mbf_abstract_nav/package.xml
+++ b/mbf_abstract_nav/package.xml
@@ -34,6 +34,8 @@
     <build_depend>mbf_abstract_core</build_depend>
     <build_depend>mbf_msgs</build_depend>
     <build_depend>mbf_utility</build_depend>
+    <build_depend>xmlrpcpp</build_depend>
+    <build_depend>visualization_msgs</build_depend>
 
     <run_depend>tf</run_depend>
     <run_depend>roscpp</run_depend>
@@ -48,6 +50,8 @@
     <run_depend>mbf_abstract_core</run_depend>
     <run_depend>mbf_msgs</run_depend>
     <run_depend>mbf_utility</run_depend>
+    <run_depend>xmlrpcpp</run_depend>
+    <run_depend>visualization_msgs</run_depend>
 
     <export>
       <rosdoc config="rosdoc.yaml" />

--- a/mbf_abstract_nav/package.xml
+++ b/mbf_abstract_nav/package.xml
@@ -23,7 +23,6 @@
 
     <build_depend>tf</build_depend>
     <build_depend>roscpp</build_depend>
-    <build_depend>pluginlib</build_depend>
     <build_depend>actionlib</build_depend>
     <build_depend>actionlib_msgs</build_depend>
     <build_depend>dynamic_reconfigure</build_depend>
@@ -35,11 +34,9 @@
     <build_depend>mbf_msgs</build_depend>
     <build_depend>mbf_utility</build_depend>
     <build_depend>xmlrpcpp</build_depend>
-    <build_depend>visualization_msgs</build_depend>
 
     <run_depend>tf</run_depend>
     <run_depend>roscpp</run_depend>
-    <run_depend>pluginlib</run_depend>
     <run_depend>actionlib</run_depend>
     <run_depend>actionlib_msgs</run_depend>
     <run_depend>dynamic_reconfigure</run_depend>
@@ -51,7 +48,6 @@
     <run_depend>mbf_msgs</run_depend>
     <run_depend>mbf_utility</run_depend>
     <run_depend>xmlrpcpp</run_depend>
-    <run_depend>visualization_msgs</run_depend>
 
     <export>
       <rosdoc config="rosdoc.yaml" />

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -241,11 +241,11 @@ namespace mbf_abstract_nav
   }
 
 
-  void AbstractControllerExecution::getNewPlan(std::vector<geometry_msgs::PoseStamped> &plan)
+  std::vector<geometry_msgs::PoseStamped> AbstractControllerExecution::getNewPlan()
   {
     boost::lock_guard<boost::mutex> guard(plan_mtx_);
     new_plan_ = false;
-    plan = plan_;
+    return plan_;
   }
 
 
@@ -284,10 +284,10 @@ namespace mbf_abstract_nav
   }
 
 
-  void AbstractControllerExecution::getLastValidCmdVel(geometry_msgs::TwistStamped &vel_cmd)
+  geometry_msgs::TwistStamped AbstractControllerExecution::getLastValidCmdVel()
   {
     boost::lock_guard<boost::mutex> guard(vel_cmd_mtx_);
-    vel_cmd = vel_cmd_stamped_;
+    return vel_cmd_stamped_;
   }
 
 
@@ -354,7 +354,7 @@ namespace mbf_abstract_nav
         // update plan dynamically
         if (hasNewPlan())
         {
-          getNewPlan(plan);
+          plan = getNewPlan();
 
           // check if plan is empty
           if (plan.empty())

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -167,7 +167,7 @@ namespace mbf_abstract_nav
     }
   }
 
-  void AbstractControllerExecution::reconfigure(mbf_abstract_nav::MoveBaseFlexConfig &config)
+  void AbstractControllerExecution::reconfigure(const MoveBaseFlexConfig &config)
   {
     boost::recursive_mutex::scoped_lock sl(configuration_mutex_);
 

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -642,8 +642,7 @@ void AbstractNavigationServer::callActionExePath(
             break;
           }
         }
-
-        moving_ptr_->getLastValidCmdVel(feedback.current_twist);
+        feedback.current_twist = moving_ptr_->getLastValidCmdVel();
         feedback.current_pose = robot_pose_;
         feedback.dist_to_goal = static_cast<float>(mbf_utility::distance(robot_pose_, goal_pose_));
         feedback.angle_to_goal = static_cast<float>(mbf_utility::angle(robot_pose_, goal_pose_));

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -38,7 +38,6 @@
  *
  */
 
-#include <visualization_msgs/Marker.h>
 #include <nav_msgs/Path.h>
 #include "mbf_abstract_nav/abstract_navigation_server.h"
 

--- a/mbf_abstract_nav/src/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_planner_execution.cpp
@@ -173,7 +173,7 @@ namespace mbf_abstract_nav
     return cost_;
   }
 
-  void AbstractPlannerExecution::reconfigure(mbf_abstract_nav::MoveBaseFlexConfig &config)
+  void AbstractPlannerExecution::reconfigure(const MoveBaseFlexConfig &config)
   {
     boost::recursive_mutex::scoped_lock sl(configuration_mutex_);
 

--- a/mbf_abstract_nav/src/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_planner_execution.cpp
@@ -294,8 +294,8 @@ namespace mbf_abstract_nav
   }
 
   uint32_t AbstractPlannerExecution::makePlan(const mbf_abstract_core::AbstractPlanner::Ptr &planner_ptr,
-                                              const geometry_msgs::PoseStamped start,
-                                              const geometry_msgs::PoseStamped goal,
+                                              const geometry_msgs::PoseStamped &start,
+                                              const geometry_msgs::PoseStamped &goal,
                                               double tolerance,
                                               std::vector<geometry_msgs::PoseStamped> &plan,
                                               double &cost,

--- a/mbf_abstract_nav/src/abstract_recovery_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_recovery_execution.cpp
@@ -65,7 +65,7 @@ namespace mbf_abstract_nav
   }
 
 
-  void AbstractRecoveryExecution::reconfigure(mbf_abstract_nav::MoveBaseFlexConfig &config)
+  void AbstractRecoveryExecution::reconfigure(const MoveBaseFlexConfig &config)
   {
     boost::recursive_mutex::scoped_lock sl(configuration_mutex_);
 

--- a/mbf_simple_nav/src/simple_controller_execution.cpp
+++ b/mbf_simple_nav/src/simple_controller_execution.cpp
@@ -39,6 +39,7 @@
  */
 
 #include "mbf_simple_nav/simple_controller_execution.h"
+#include <pluginlib/class_loader.h>
 
 namespace mbf_simple_nav
 {

--- a/mbf_simple_nav/src/simple_planner_execution.cpp
+++ b/mbf_simple_nav/src/simple_planner_execution.cpp
@@ -39,6 +39,7 @@
  */
 
 #include "mbf_simple_nav/simple_planner_execution.h"
+#include <pluginlib/class_loader.h>
 
 namespace mbf_simple_nav
 {

--- a/mbf_simple_nav/src/simple_recovery_execution.cpp
+++ b/mbf_simple_nav/src/simple_recovery_execution.cpp
@@ -39,6 +39,7 @@
  */
 
 #include "mbf_simple_nav/simple_recovery_execution.h"
+#include <pluginlib/class_loader.h>
 
 namespace mbf_simple_nav
 {


### PR DESCRIPTION
This pull request cleans up the mbf_abstract_nav project by doing following:
1. Adds missing dependencies to the CMakeList and package
2. Adds missing includes to the heades and ordering them in a uniform way starting from std > boost > ROS > MBF