### PR TITLE
Abstract recovery execution

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
@@ -184,12 +184,6 @@ namespace mbf_abstract_nav
     void setState(RecoveryState state);
 
     /**
-     * @brief Initialize all recovery behaviors
-     * @return true if init succeeded, false otherwise
-     */
-    bool initPlugins(){}
-
-    /**
      * @brief Pure virtual method, the derived class has to implement. Depending on the plugin base class,
      *        some plugins need to be initialized!
      * @param name The name of the recovery behavior

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
@@ -88,7 +88,7 @@ namespace mbf_abstract_nav
      * @brief starts the recovery behavior thread, which calls the recovery behavior plugin.
      * @param name The name of the recovery behavior loaded.
      */
-    void startRecovery(const std::string name);
+    void startRecovery(const std::string &name);
 
     /**
      * @brief Tries to stop the recovery behavior thread by an interrupt
@@ -118,6 +118,7 @@ namespace mbf_abstract_nav
 
     /**
      * @brief Reads the parameter server and tries to load and initialize the recovery behaviors
+     * @return true, if successful
      */
     bool initialize();
 
@@ -186,7 +187,7 @@ namespace mbf_abstract_nav
      * @brief Initialize all recovery behaviors
      * @return true if init succeeded, false otherwise
      */
-    bool initPlugins();
+    bool initPlugins(){}
 
     /**
      * @brief Pure virtual method, the derived class has to implement. Depending on the plugin base class,

--- a/mbf_abstract_nav/src/abstract_recovery_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_recovery_execution.cpp
@@ -41,7 +41,7 @@
 #include <XmlRpcException.h>
 #include <boost/exception/diagnostic_information.hpp>
 
-#include "mbf_abstract_nav/abstract_recovery_execution.h"
+#include <mbf_abstract_nav/abstract_recovery_execution.h>
 
 namespace mbf_abstract_nav
 {
@@ -146,7 +146,7 @@ namespace mbf_abstract_nav
   }
 
 
-  void AbstractRecoveryExecution::startRecovery(const std::string name)
+  void AbstractRecoveryExecution::startRecovery(const std::string &name)
   {
     requested_behavior_name_ = name;
     setState(STARTED);


### PR DESCRIPTION
Pull request changes the call signature of startRecovery to take a const reference and removes redundant initPlugins() function 