### PR TITLE
chore: Typo 'to much' to 'too much'

### DIFF
--- a/mbf_abstract_core/include/mbf_abstract_core/abstract_controller.h
+++ b/mbf_abstract_core/include/mbf_abstract_core/abstract_controller.h
@@ -107,7 +107,7 @@ namespace mbf_abstract_core{
       virtual bool setPlan(const std::vector<geometry_msgs::PoseStamped> &plan) = 0;
 
       /**
-       * @brief Requests the planner to cancel, e.g. if it takes to much time.
+       * @brief Requests the planner to cancel, e.g. if it takes too much time.
        * @return True if a cancel has been successfully requested, false if not implemented.
        */
       virtual bool cancel() = 0;

--- a/mbf_abstract_core/include/mbf_abstract_core/abstract_planner.h
+++ b/mbf_abstract_core/include/mbf_abstract_core/abstract_planner.h
@@ -88,7 +88,7 @@ namespace mbf_abstract_core
                                 std::string &message) = 0;
 
       /**
-       * @brief Requests the planner to cancel, e.g. if it takes to much time.
+       * @brief Requests the planner to cancel, e.g. if it takes too much time.
        * @return True if a cancel has been successfully requested, false if not implemented.
        */
       virtual bool cancel() = 0;

--- a/mbf_abstract_core/include/mbf_abstract_core/abstract_recovery.h
+++ b/mbf_abstract_core/include/mbf_abstract_core/abstract_recovery.h
@@ -67,7 +67,7 @@ namespace mbf_abstract_core {
       virtual ~AbstractRecovery(){}
 
       /**
-       * @brief Requests the recovery behavior to cancel, e.g. if it takes to much time.
+       * @brief Requests the recovery behavior to cancel, e.g. if it takes too much time.
        * @return True if a cancel has been successfully requested, false if not implemented.
        */
       virtual bool cancel() = 0;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -159,7 +159,7 @@ namespace mbf_abstract_nav
 
     /**
      * @brief Cancel the planner execution. This calls the cancel method of the planner plugin. This could be useful if the
-     * computation takes to much time.
+     * computation takes too much time.
      * @return true, if the planner plugin tries / tried to cancel the planning step.
      */
     bool cancel();

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -449,7 +449,7 @@ namespace mbf_abstract_nav
           }
           else
           {
-            ROS_WARN_THROTTLE(1.0, "Calculation needs to much time to stay in the moving frequency!");
+            ROS_WARN_THROTTLE(1.0, "Calculation needs too much time to stay in the moving frequency!");
           }
         }
       }

--- a/mbf_costmap_core/include/mbf_costmap_core/costmap_controller.h
+++ b/mbf_costmap_core/include/mbf_costmap_core/costmap_controller.h
@@ -103,7 +103,7 @@ namespace mbf_costmap_core {
       virtual bool setPlan(const std::vector<geometry_msgs::PoseStamped> &plan) = 0;
 
       /**
-       * @brief Requests the planner to cancel, e.g. if it takes to much time
+       * @brief Requests the planner to cancel, e.g. if it takes too much time
        * @remark New on MBF API
        * @return True if a cancel has been successfully requested, false if not implemented.
        */

--- a/mbf_costmap_core/include/mbf_costmap_core/costmap_planner.h
+++ b/mbf_costmap_core/include/mbf_costmap_core/costmap_planner.h
@@ -84,7 +84,7 @@ namespace mbf_costmap_core {
                                 std::string &message) = 0;
 
       /**
-       * @brief Requests the planner to cancel, e.g. if it takes to much time.
+       * @brief Requests the planner to cancel, e.g. if it takes too much time.
        * @remark New on MBF API
        * @return True if a cancel has been successfully requested, false if not implemented.
        */

--- a/mbf_costmap_core/include/mbf_costmap_core/costmap_recovery.h
+++ b/mbf_costmap_core/include/mbf_costmap_core/costmap_recovery.h
@@ -74,7 +74,7 @@ class CostmapRecovery : public mbf_abstract_core::AbstractRecovery{
   virtual uint32_t runBehavior(std::string& message) = 0;
 
   /**
-   * @brief Requests the planner to cancel, e.g. if it takes to much time
+   * @brief Requests the planner to cancel, e.g. if it takes too much time
    * @remark New on MBF API
    * @return True if a cancel has been successfully requested, false if not implemented.
    */

--- a/mbf_costmap_nav/include/nav_core_wrapper/wrapper_global_planner.h
+++ b/mbf_costmap_nav/include/nav_core_wrapper/wrapper_global_planner.h
@@ -71,7 +71,7 @@ namespace mbf_nav_core_wrapper {
                                 std::string &message);
 
       /**
-       * @brief Requests the planner to cancel, e.g. if it takes to much time.
+       * @brief Requests the planner to cancel, e.g. if it takes too much time.
        * @remark New on MBF API
        * @return True if a cancel has been successfully requested, false if not implemented.
        */

--- a/mbf_costmap_nav/include/nav_core_wrapper/wrapper_local_planner.h
+++ b/mbf_costmap_nav/include/nav_core_wrapper/wrapper_local_planner.h
@@ -92,7 +92,7 @@ namespace mbf_nav_core_wrapper {
       virtual bool setPlan(const std::vector<geometry_msgs::PoseStamped> &plan);
 
       /**
-       * @brief Requests the planner to cancel, e.g. if it takes to much time
+       * @brief Requests the planner to cancel, e.g. if it takes too much time
        * @remark New on MBF API
        * @return True if a cancel has been successfully requested, false if not implemented.
        */

--- a/mbf_costmap_nav/include/nav_core_wrapper/wrapper_recovery_behavior.h
+++ b/mbf_costmap_nav/include/nav_core_wrapper/wrapper_recovery_behavior.h
@@ -70,7 +70,7 @@ namespace mbf_nav_core_wrapper {
       virtual uint32_t runBehavior(std::string& message);
 
       /**
-       * @brief Requests the planner to cancel, e.g. if it takes to much time
+       * @brief Requests the planner to cancel, e.g. if it takes too much time
        * @remark New on MBF API
        * @return True if a cancel has been successfully requested, false if not implemented.
        */


### PR DESCRIPTION
Achieved by command:

```
find . -type f -exec sed -i 's/to much/too much/g' {} \;
```