### PR TITLE
Issue #66: ensure prototypes match between abstract and costmap classes

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -200,11 +200,18 @@ namespace mbf_abstract_nav
   protected:
 
     /**
-     * @brief Request plugin for a new velocity command. We use this virtual method to give concrete implementations
-     *        as move_base the chance to override it and do additional stuff, for example locking the costmap.
-     * @param vel_cmd_stamped current velocity command
+     * @brief Request plugin for a new velocity command, given the current position, orientation, and velocity of the
+     * robot. We use this virtual method to give concrete implementations as move_base the chance to override it and do
+     * additional stuff, for example locking the costmap.
+     * @param pose the current pose of the robot.
+     * @param velocity the current velocity of the robot.
+     * @param cmd_vel Will be filled with the velocity command to be passed to the robot base.
+     * @param message Optional more detailed outcome as a string.
+     * @return Result code as described on ExePath action result and plugin's header.
      */
-    virtual uint32_t computeVelocityCmd(geometry_msgs::TwistStamped& vel_cmd_stamped, std::string& message);
+    virtual uint32_t computeVelocityCmd(const geometry_msgs::PoseStamped& pose,
+                                        const geometry_msgs::TwistStamped& velocity,
+                                        geometry_msgs::TwistStamped& vel_cmd, std::string& message);
 
     /**
      * @brief Sets the velocity command, to make it available for another thread

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -277,7 +277,6 @@ namespace mbf_abstract_nav
      * @return An outcome number, see also the action definition in the GetPath.action file
      */
     virtual uint32_t makePlan(
-        const mbf_abstract_core::AbstractPlanner::Ptr &planner_ptr,
         const geometry_msgs::PoseStamped &start,
         const geometry_msgs::PoseStamped &goal,
         double tolerance,

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -267,11 +267,12 @@ namespace mbf_abstract_nav
   }
 
 
-  uint32_t AbstractControllerExecution::computeVelocityCmd(geometry_msgs::TwistStamped &vel_cmd, std::string& message)
+  uint32_t AbstractControllerExecution::computeVelocityCmd(const geometry_msgs::PoseStamped& robot_pose,
+                                                           const geometry_msgs::TwistStamped& robot_velocity,
+                                                           geometry_msgs::TwistStamped& vel_cmd,
+                                                           std::string& message)
   {
-    // TODO compute velocity
-    geometry_msgs::TwistStamped robot_velocity;
-    return controller_->computeVelocityCommands(robot_pose_, robot_velocity, vel_cmd, message);
+    return controller_->computeVelocityCommands(robot_pose, robot_velocity, vel_cmd, message);
   }
 
 
@@ -399,7 +400,8 @@ namespace mbf_abstract_nav
 
           // call plugin to compute the next velocity command
           geometry_msgs::TwistStamped cmd_vel_stamped;
-          outcome_ = computeVelocityCmd(cmd_vel_stamped, message_);
+          geometry_msgs::TwistStamped robot_velocity;   // TODO pass current velocity to the plugin!
+          outcome_ = computeVelocityCmd(robot_pose_, robot_velocity, cmd_vel_stamped, message_);
 
           if (outcome_ < 10)
           {

--- a/mbf_abstract_nav/src/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_planner_execution.cpp
@@ -294,15 +294,14 @@ namespace mbf_abstract_nav
     return planner_->cancel();
   }
 
-  uint32_t AbstractPlannerExecution::makePlan(const mbf_abstract_core::AbstractPlanner::Ptr &planner_ptr,
-                                              const geometry_msgs::PoseStamped &start,
+  uint32_t AbstractPlannerExecution::makePlan(const geometry_msgs::PoseStamped &start,
                                               const geometry_msgs::PoseStamped &goal,
                                               double tolerance,
                                               std::vector<geometry_msgs::PoseStamped> &plan,
                                               double &cost,
                                               std::string &message)
   {
-    return planner_ptr->makePlan(start, goal, tolerance, plan, cost, message);
+    return planner_->makePlan(start, goal, tolerance, plan, cost, message);
   }
 
   void AbstractPlannerExecution::run()
@@ -362,7 +361,7 @@ namespace mbf_abstract_nav
         setState(PLANNING);
         if (make_plan)
         {
-          outcome_ = makePlan(planner_, current_start, current_goal, current_tolerance, plan, cost, message_);
+          outcome_ = makePlan(current_start, current_goal, current_tolerance, plan, cost, message_);
           success = outcome_ < 10;
 
           if (cancel_ && !isPatienceExceeded())

--- a/mbf_costmap_core/include/mbf_costmap_core/costmap_controller.h
+++ b/mbf_costmap_core/include/mbf_costmap_core/costmap_controller.h
@@ -56,8 +56,8 @@ namespace mbf_costmap_core {
       typedef boost::shared_ptr< ::mbf_costmap_core::CostmapController > Ptr;
 
       /**
-       * @brief Given the current position, orientation, and velocity of the robot,
-       * compute velocity commands to send to the base.
+       * @brief Given the current position, orientation, and velocity of the robot, compute velocity commands
+       * to send to the base.
        * @param pose the current pose of the robot.
        * @param velocity the current velocity of the robot.
        * @param cmd_vel Will be filled with the velocity command to be passed to the robot base.
@@ -86,6 +86,7 @@ namespace mbf_costmap_core {
                                                const geometry_msgs::TwistStamped& velocity,
                                                geometry_msgs::TwistStamped &cmd_vel,
                                                std::string &message) = 0;
+
       /**
        * @brief Check if the goal pose has been achieved by the local planner within tolerance limits
        * @remark New on MBF API

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
@@ -67,8 +67,8 @@ public:
    * @param costmap_ptr Shared pointer to the costmap.
    */
   CostmapControllerExecution(boost::condition_variable &condition,
-                              const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr,
-                              CostmapPtr &costmap_ptr);
+                             const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr,
+                             CostmapPtr &costmap_ptr);
 
   /**
    * @brief Destructor
@@ -80,7 +80,11 @@ protected:
   /**
    * @brief Request plugin for a new velocity command. We override this method so we can lock the local costmap
    *        before calling the planner.
-   * @param vel_cmd_stamped current velocity command
+   * @param pose the current pose of the robot.
+   * @param velocity the current velocity of the robot.
+   * @param cmd_vel Will be filled with the velocity command to be passed to the robot base.
+   * @param message Optional more detailed outcome as a string.
+   * @return Result code as described on ExePath action result and plugin's header.
    */
   virtual uint32_t computeVelocityCmd(
       const geometry_msgs::PoseStamped& robot_pose,

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_planner_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_planner_execution.h
@@ -91,7 +91,7 @@ private:
   );
 
   /**
-   * @brief calls the planner plugin to make a plan from the start pose to the goal pose with the given tolerance,
+   * @brief Calls the planner plugin to make a plan from the start pose to the goal pose with the given tolerance,
    *        if a goal tolerance is enabled in the planner plugin.
    * @param start The start pose for planning
    * @param goal The goal pose for planning
@@ -102,9 +102,8 @@ private:
    * @return An outcome number, see also the action definition in the GetPath.action file
    */
   virtual uint32_t makePlan(
-      const mbf_abstract_core::AbstractPlanner::Ptr& planner_ptr,
-      const geometry_msgs::PoseStamped start,
-      const geometry_msgs::PoseStamped goal,
+      const geometry_msgs::PoseStamped &start,
+      const geometry_msgs::PoseStamped &goal,
       double tolerance,
       std::vector<geometry_msgs::PoseStamped> &plan,
       double &cost,

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_planner_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_planner_execution.cpp
@@ -94,8 +94,7 @@ mbf_abstract_core::AbstractPlanner::Ptr CostmapPlannerExecution::loadPlannerPlug
 
 bool CostmapPlannerExecution::initPlugin(
     const std::string& name,
-    const mbf_abstract_core::AbstractPlanner::Ptr& planner_ptr
-)
+    const mbf_abstract_core::AbstractPlanner::Ptr& planner_ptr)
 {
   mbf_costmap_core::CostmapPlanner::Ptr costmap_planner_ptr
       = boost::static_pointer_cast<mbf_costmap_core::CostmapPlanner>(planner_ptr);
@@ -107,29 +106,27 @@ bool CostmapPlannerExecution::initPlugin(
     return false;
   }
 
+  ros::NodeHandle private_nh("~");
+  private_nh.param("planner_lock_costmap", lock_costmap_, true);
+
   costmap_planner_ptr->initialize(name, costmap_ptr_.get());
   ROS_INFO("Global planner plugin initialized.");
   return true;
 }
 
-uint32_t CostmapPlannerExecution::makePlan(const mbf_abstract_core::AbstractPlanner::Ptr &planner_ptr,
-                                           const geometry_msgs::PoseStamped start,
-                                           const geometry_msgs::PoseStamped goal,
+uint32_t CostmapPlannerExecution::makePlan(const geometry_msgs::PoseStamped &start,
+                                           const geometry_msgs::PoseStamped &goal,
                                            double tolerance,
                                            std::vector<geometry_msgs::PoseStamped> &plan,
                                            double &cost,
                                            std::string &message)
 {
-
-  ros::NodeHandle private_nh("~");
-  private_nh.param("planner_lock_costmap", lock_costmap_, true);
-
   if (lock_costmap_)
   {
     boost::unique_lock<costmap_2d::Costmap2D::mutex_t> lock(*(costmap_ptr_->getCostmap()->getMutex()));
-    return planner_ptr->makePlan(start, goal, tolerance, plan, cost, message);
+    return planner_->makePlan(start, goal, tolerance, plan, cost, message);
   }
-  return planner_ptr->makePlan(start, goal, tolerance, plan, cost, message);
+  return planner_->makePlan(start, goal, tolerance, plan, cost, message);
 }
 
 } /* namespace mbf_costmap_nav */


### PR DESCRIPTION
As reported in #66 by @SHTseng, now they don't, so we are calling the abstract methods (so we don't lock/unlock costmaps)