### PR TITLE
Issue #64: Stop the robot on aborting exe_path action

### DIFF
--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -373,7 +373,6 @@ namespace mbf_abstract_nav
             moving_ = false;
             return;
           }
-
         }
 
         // compute robot pose and store it in robot_pose_
@@ -459,12 +458,13 @@ namespace mbf_abstract_nav
       // Controller thread interrupted; in most cases we have started a new plan
       // Can also be that robot is oscillating or we have exceeded planner patience
       ROS_DEBUG_STREAM("Controller thread interrupted!");
-      // publishZeroVelocity();  TODO comment this makes sense for continuous replanning
+      publishZeroVelocity();  // TODO this penalizes continuous replanning, so we must handle better (see #64)
       setState(STOPPED);
       condition_.notify_all();
       moving_ = false;
     }
-    catch (...){
+    catch (...)
+    {
       message_ = "Unknown error occurred: " + boost::current_exception_diagnostic_information();
       ROS_FATAL_STREAM(message_);
       setState(INTERNAL_ERROR);


### PR DESCRIPTION
This penalizes continuous replanning introducing a zero-velocity message every new plan, so we must handle better