### PR TITLE
move_base_flex: don't use relative urls in package description.

### DIFF
--- a/move_base_flex/package.xml
+++ b/move_base_flex/package.xml
@@ -5,7 +5,7 @@
   <description>
        Move Base Flex (MBF) is a backwards-compatible replacement for move_base. MBF can use existing plugins for move_base, and provides an enhanced version of the planner, controller and recovery plugin ROS interfaces. It exposes action servers for planning, controlling and recovering, providing detailed information of the current state and the plugin’s feedback. An external executive logic can use MBF and its actions to perform smart and flexible navigation strategies. Furthermore, MBF enables the use of other map representations, e.g. meshes or grid_map
        
-       This package is a meta package and refers to the Move Base Flex stack packages.The abstract core of MBF – without any binding to a map representation – is represented by the <a href="wiki.ros.org/mbf_abstract_nav">mbf_abstract_nav</a> and the <a href="wiki.ros.org/mbf_abstract_core">mbf_abstract_core</a>. For navigation on costmaps see <a href="wiki.ros.org/mbf_costmap_nav">mbf_costmap_nav</a> and <a href="wiki.ros.org/mbf_costmap_core">mbf_costmap_core</a>.
+       This package is a meta package and refers to the Move Base Flex stack packages.The abstract core of MBF – without any binding to a map representation – is represented by the <a href="http://wiki.ros.org/mbf_abstract_nav">mbf_abstract_nav</a> and the <a href="http://wiki.ros.org/mbf_abstract_core">mbf_abstract_core</a>. For navigation on costmaps see <a href="http://wiki.ros.org/mbf_costmap_nav">mbf_costmap_nav</a> and <a href="http://wiki.ros.org/mbf_costmap_core">mbf_costmap_core</a>.
   </description>
 
   <maintainer email="spuetz@uos.de">Sebastian Pütz</maintainer>


### PR DESCRIPTION
As per subject.
