### PR TITLE
Make concurrent move_base_flex melodic compatible

### DIFF
--- a/mbf_abstract_nav/CMakeLists.txt
+++ b/mbf_abstract_nav/CMakeLists.txt
@@ -50,9 +50,13 @@ catkin_package(
   DEPENDS Boost
 )
 
-if("$ENV{ROS_DISTRO}" STREQUAL "melodic")
-  add_definitions(-DCOSTMAP_HAS_TF2)
-  message("melodic compatible build")
+if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
+  add_definitions(-DUSE_OLD_TF)
+  message("kinetic compatible build")
+endif()
+if("$ENV{ROS_DISTRO}" STREQUAL "lunar")
+  add_definitions(-DUSE_OLD_TF)
+  message("lunar compatible build")
 endif()
 
 

--- a/mbf_abstract_nav/CMakeLists.txt
+++ b/mbf_abstract_nav/CMakeLists.txt
@@ -50,6 +50,12 @@ catkin_package(
   DEPENDS Boost
 )
 
+if("$ENV{ROS_DISTRO}" STREQUAL "melodic")
+  add_definitions(-DCOSTMAP_HAS_TF2)
+  message("melodic compatible build")
+endif()
+
+
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -52,6 +52,7 @@
 
 #include <mbf_utility/navigation_utility.h>
 #include <mbf_abstract_core/abstract_controller.h>
+#include <mbf_utility/types.h>
 
 #include "mbf_abstract_nav/MoveBaseFlexConfig.h"
 #include "mbf_abstract_nav/abstract_execution_base.h"
@@ -89,7 +90,7 @@ namespace mbf_abstract_nav
     AbstractControllerExecution(
         const std::string name,
         const mbf_abstract_core::AbstractController::Ptr& controller_ptr,
-        const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr,
+        const TFPtr &tf_listener_ptr,
         const MoveBaseFlexConfig &config,
         boost::function<void()> setup_fn,
         boost::function<void()> cleanup_fn);
@@ -218,7 +219,7 @@ namespace mbf_abstract_nav
     mbf_abstract_core::AbstractController::Ptr controller_;
 
     //! shared pointer to the shared tf listener
-    const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr;
+    const TFPtr &tf_listener_ptr;
 
     //! The current cycle start time of the last cycle run. Will by updated each cycle.
     ros::Time last_call_time_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
@@ -215,36 +215,36 @@ typedef boost::shared_ptr<dynamic_reconfigure::Server<mbf_abstract_nav::MoveBase
      * @param goal SimpleActionServer goal containing all necessary parameters for the action execution. See the action
      *        definitions in mbf_msgs.
      */
-    virtual void callActionGetPath(ActionServerGetPath::GoalHandle &goal_handle);
+    virtual void callActionGetPath(ActionServerGetPath::GoalHandle goal_handle);
 
-    virtual void cancelActionGetPath(ActionServerGetPath::GoalHandle &goal_handle);
+    virtual void cancelActionGetPath(ActionServerGetPath::GoalHandle goal_handle);
 
     /**
      * @brief ExePath action execution method. This method will be called if the action server receives a goal
      * @param goal SimpleActionServer goal containing all necessary parameters for the action execution. See the action
      *        definitions in mbf_msgs.
      */
-    virtual void callActionExePath(ActionServerExePath::GoalHandle &goal_handle);
+    virtual void callActionExePath(ActionServerExePath::GoalHandle goal_handle);
 
-    virtual void cancelActionExePath(ActionServerExePath::GoalHandle &goal_handle);
+    virtual void cancelActionExePath(ActionServerExePath::GoalHandle goal_handle);
 
     /**
      * @brief Recovery action execution method. This method will be called if the action server receives a goal
      * @param goal SimpleActionServer goal containing all necessary parameters for the action execution. See the action
      *        definitions in mbf_msgs.
      */
-    virtual void callActionRecovery(ActionServerRecovery::GoalHandle &goal_handle);
+    virtual void callActionRecovery(ActionServerRecovery::GoalHandle goal_handle);
 
-    virtual void cancelActionRecovery(ActionServerRecovery::GoalHandle &goal_handle);
+    virtual void cancelActionRecovery(ActionServerRecovery::GoalHandle goal_handle);
 
     /**
      * @brief MoveBase action execution method. This method will be called if the action server receives a goal
      * @param goal SimpleActionServer goal containing all necessary parameters for the action execution. See the action
      *        definitions in mbf_msgs.
      */
-    virtual void callActionMoveBase(ActionServerMoveBase::GoalHandle &goal_handle);
+    virtual void callActionMoveBase(ActionServerMoveBase::GoalHandle goal_handle);
 
-    virtual void cancelActionMoveBase(ActionServerMoveBase::GoalHandle &goal_handle);
+    virtual void cancelActionMoveBase(ActionServerMoveBase::GoalHandle goal_handle);
 
     /**
      * @brief starts all action server.

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
@@ -128,7 +128,7 @@ typedef boost::shared_ptr<dynamic_reconfigure::Server<mbf_abstract_nav::MoveBase
      * @param moving_ptr shared pointer to an object of the concrete derived implementation of the AbstractControllerExecution
      * @param recovery_ptr shared pointer to an object of the concrete derived implementation of the AbstractRecoveryExecution
      */
-    AbstractNavigationServer(const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr);
+    AbstractNavigationServer(const TFPtr &tf_listener_ptr);
     /**
      * @brief Destructor
      */
@@ -352,7 +352,7 @@ typedef boost::shared_ptr<dynamic_reconfigure::Server<mbf_abstract_nav::MoveBase
     ros::Duration tf_timeout_;
 
     //! shared pointer to the common TransformListener
-    const boost::shared_ptr<tf::TransformListener> tf_listener_ptr_;
+    const TFPtr tf_listener_ptr_;
 
     //! current robot pose; moving controller is responsible to update it by calling getRobotPose
     geometry_msgs::PoseStamped robot_pose_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -50,6 +50,8 @@
 #include <tf/transform_listener.h>
 
 #include <mbf_abstract_core/abstract_planner.h>
+#include <mbf_utility/types.h>
+
 #include <mbf_utility/navigation_utility.h>
 
 #include "mbf_abstract_nav/abstract_execution_base.h"
@@ -290,7 +292,7 @@ namespace mbf_abstract_nav
     std::string global_frame_;
 
     //! shared pointer to a common TransformListener
-    const boost::shared_ptr<tf::TransformListener> tf_listener_ptr_;
+    const TFPtr tf_listener_ptr_;
 
     //! current internal state
     PlanningState state_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
@@ -49,6 +49,8 @@
 #include <tf/transform_listener.h>
 
 #include <mbf_abstract_core/abstract_recovery.h>
+#include <mbf_utility/types.h>
+
 #include <mbf_utility/navigation_utility.h>
 
 #include "mbf_abstract_nav/MoveBaseFlexConfig.h"
@@ -84,7 +86,7 @@ namespace mbf_abstract_nav
      */
     AbstractRecoveryExecution(const std::string name,
                               const mbf_abstract_core::AbstractRecovery::Ptr recovery_ptr,
-                              const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr,
+                              const TFPtr &tf_listener_ptr,
                               const MoveBaseFlexConfig &config,
                               boost::function<void()> setup_fn,
                               boost::function<void()> cleanup_fn);
@@ -146,7 +148,7 @@ namespace mbf_abstract_nav
     mbf_abstract_core::AbstractRecovery::Ptr behavior_;
 
     //! shared pointer to common TransformListener
-    const boost::shared_ptr<tf::TransformListener> tf_listener_ptr_;
+    const TFPtr tf_listener_ptr_;
 
   private:
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/robot_information.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/robot_information.h
@@ -46,6 +46,7 @@
 #include <string>
 #include <tf/transform_listener.h>
 
+#include <mbf_utility/types.h>
 
 namespace mbf_abstract_nav{
 
@@ -56,7 +57,7 @@ class RobotInformation{
   typedef boost::shared_ptr<RobotInformation> Ptr;
 
   RobotInformation(
-      tf::TransformListener &tf_listener,
+      TF &tf_listener,
       const std::string &global_frame,
       const std::string &robot_frame,
       const ros::Duration &tf_timeout);
@@ -69,12 +70,12 @@ class RobotInformation{
 
   const std::string& getRobotFrame() const;
 
-  const tf::TransformListener& getTransformListener() const;
+  const TF& getTransformListener() const;
 
   const ros::Duration& getTfTimeout() const;
 
  private:
-  const tf::TransformListener& tf_listener_;
+  const TF& tf_listener_;
 
   const std::string &global_frame_;
 

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -49,7 +49,7 @@ namespace mbf_abstract_nav
   AbstractControllerExecution::AbstractControllerExecution(
       const std::string name,
       const mbf_abstract_core::AbstractController::Ptr& controller_ptr,
-      const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr,
+      const TFPtr &tf_listener_ptr,
       const MoveBaseFlexConfig &config,
       boost::function<void()> setup_fn,
       boost::function<void()> cleanup_fn) :

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -45,7 +45,7 @@
 namespace mbf_abstract_nav
 {
 
-AbstractNavigationServer::AbstractNavigationServer(const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr)
+AbstractNavigationServer::AbstractNavigationServer(const TFPtr &tf_listener_ptr)
     : tf_listener_ptr_(tf_listener_ptr), private_nh_("~"),
       planner_plugin_manager_("planners",
           boost::bind(&AbstractNavigationServer::loadPlannerPlugin, this, _1),

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -122,7 +122,7 @@ AbstractNavigationServer::~AbstractNavigationServer()
 
 }
 
-void AbstractNavigationServer::callActionGetPath(ActionServerGetPath::GoalHandle &goal_handle)
+void AbstractNavigationServer::callActionGetPath(ActionServerGetPath::GoalHandle goal_handle)
 {
   ROS_INFO_STREAM_NAMED("get_path", "Start action \"get_path\"");
   const mbf_msgs::GetPathGoal &goal = *(goal_handle.getGoal().get());
@@ -177,13 +177,13 @@ void AbstractNavigationServer::callActionGetPath(ActionServerGetPath::GoalHandle
   }
 }
 
-void AbstractNavigationServer::cancelActionGetPath(ActionServerGetPath::GoalHandle &goal_handle)
+void AbstractNavigationServer::cancelActionGetPath(ActionServerGetPath::GoalHandle goal_handle)
 {
   ROS_INFO_STREAM_NAMED("get_path", "Cancel action \"get_path\"");
   planner_action_.cancel(goal_handle);
 }
 
-void AbstractNavigationServer::callActionExePath(ActionServerExePath::GoalHandle &goal_handle)
+void AbstractNavigationServer::callActionExePath(ActionServerExePath::GoalHandle goal_handle)
 {
   ROS_INFO_STREAM_NAMED("exe_path", "Start action \"exe_path\"");
 
@@ -238,13 +238,13 @@ void AbstractNavigationServer::callActionExePath(ActionServerExePath::GoalHandle
   }
 }
 
-void AbstractNavigationServer::cancelActionExePath(ActionServerExePath::GoalHandle &goal_handle)
+void AbstractNavigationServer::cancelActionExePath(ActionServerExePath::GoalHandle goal_handle)
 {
   ROS_INFO_STREAM_NAMED("exe_path", "Cancel action \"exe_path\"");
   controller_action_.cancel(goal_handle);
 }
 
-void AbstractNavigationServer::callActionRecovery(ActionServerRecovery::GoalHandle &goal_handle)
+void AbstractNavigationServer::callActionRecovery(ActionServerRecovery::GoalHandle goal_handle)
 {
   ROS_INFO_STREAM_NAMED("recovery", "Start action \"recovery\"");
   const mbf_msgs::RecoveryGoal &goal = *(goal_handle.getGoal().get());
@@ -298,19 +298,19 @@ void AbstractNavigationServer::callActionRecovery(ActionServerRecovery::GoalHand
   }
 }
 
-void AbstractNavigationServer::cancelActionRecovery(ActionServerRecovery::GoalHandle &goal_handle)
+void AbstractNavigationServer::cancelActionRecovery(ActionServerRecovery::GoalHandle goal_handle)
 {
   ROS_INFO_STREAM_NAMED("recovery", "Cancel action \"recovery\"");
   recovery_action_.cancel(goal_handle);
 }
 
-void AbstractNavigationServer::callActionMoveBase(ActionServerMoveBase::GoalHandle &goal_handle)
+void AbstractNavigationServer::callActionMoveBase(ActionServerMoveBase::GoalHandle goal_handle)
 {
   ROS_INFO_STREAM_NAMED("move_base", "Start action \"move_base\"");
   move_base_action_.start(goal_handle);
 }
 
-void AbstractNavigationServer::cancelActionMoveBase(ActionServerMoveBase::GoalHandle &goal_handle)
+void AbstractNavigationServer::cancelActionMoveBase(ActionServerMoveBase::GoalHandle goal_handle)
 {
   ROS_INFO_STREAM_NAMED("move_base", "Cancel action \"move_base\"");
   move_base_action_.cancel();

--- a/mbf_abstract_nav/src/abstract_recovery_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_recovery_execution.cpp
@@ -50,7 +50,7 @@ namespace mbf_abstract_nav
   AbstractRecoveryExecution::AbstractRecoveryExecution(
       const std::string name,
       mbf_abstract_core::AbstractRecovery::Ptr recovery_ptr,
-      const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr,
+      const TFPtr &tf_listener_ptr,
       const MoveBaseFlexConfig &config,
       boost::function<void()> setup_fn,
       boost::function<void()> cleanup_fn) :

--- a/mbf_abstract_nav/src/robot_Information.cpp
+++ b/mbf_abstract_nav/src/robot_Information.cpp
@@ -41,7 +41,7 @@
 
 namespace mbf_abstract_nav{
 
-RobotInformation::RobotInformation(tf::TransformListener &tf_listener,
+RobotInformation::RobotInformation(TF &tf_listener,
                                    const std::string &global_frame,
                                    const std::string &robot_frame,
                                    const ros::Duration &tf_timeout)
@@ -76,7 +76,7 @@ const std::string& RobotInformation::getGlobalFrame() const {return global_frame
 
 const std::string& RobotInformation::getRobotFrame() const {return robot_frame_;};
 
-const tf::TransformListener& RobotInformation::getTransformListener() const {return tf_listener_;};
+const TF& RobotInformation::getTransformListener() const {return tf_listener_;};
 
 const ros::Duration& RobotInformation::getTfTimeout() const {return tf_timeout_;}
 

--- a/mbf_costmap_core/CMakeLists.txt
+++ b/mbf_costmap_core/CMakeLists.txt
@@ -23,6 +23,10 @@ catkin_package(
             nav_core
 )
 
+if("$ENV{ROS_DISTRO}" STREQUAL "melodic")
+  add_definitions(-DCOSTMAP_HAS_TF2)
+  message("melodic compatible build")
+endif()
 
 ## Install project namespaced headers
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/mbf_costmap_core/CMakeLists.txt
+++ b/mbf_costmap_core/CMakeLists.txt
@@ -23,9 +23,13 @@ catkin_package(
             nav_core
 )
 
-if("$ENV{ROS_DISTRO}" STREQUAL "melodic")
-  add_definitions(-DCOSTMAP_HAS_TF2)
-  message("melodic compatible build")
+if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
+  add_definitions(-DUSE_OLD_TF)
+  message("kinetic compatible build")
+endif()
+if("$ENV{ROS_DISTRO}" STREQUAL "lunar")
+  add_definitions(-DUSE_OLD_TF)
+  message("lunar compatible build")
 endif()
 
 ## Install project namespaced headers

--- a/mbf_costmap_core/include/mbf_costmap_core/costmap_controller.h
+++ b/mbf_costmap_core/include/mbf_costmap_core/costmap_controller.h
@@ -41,7 +41,7 @@
 
 #include <mbf_abstract_core/abstract_controller.h>
 #include <costmap_2d/costmap_2d_ros.h>
-#include <tf/transform_listener.h>
+#include <mbf_utility/types.h>
 
 namespace mbf_costmap_core {
   /**
@@ -116,7 +116,7 @@ namespace mbf_costmap_core {
        * @param tf A pointer to a transform listener
        * @param costmap_ros The cost map to use for assigning costs to local plans
        */
-      virtual void initialize(std::string name, tf::TransformListener *tf, costmap_2d::Costmap2DROS *costmap_ros) = 0;
+      virtual void initialize(std::string name, TF *tf, costmap_2d::Costmap2DROS *costmap_ros) = 0;
 
       /**
        * @brief  Virtual destructor for the interface

--- a/mbf_costmap_core/include/mbf_costmap_core/costmap_recovery.h
+++ b/mbf_costmap_core/include/mbf_costmap_core/costmap_recovery.h
@@ -41,7 +41,7 @@
 
 #include <mbf_abstract_core/abstract_recovery.h>
 #include <costmap_2d/costmap_2d_ros.h>
-#include <tf/transform_listener.h>
+#include <mbf_utility/types.h>
 
 namespace mbf_costmap_core
 {
@@ -62,7 +62,7 @@ class CostmapRecovery : public mbf_abstract_core::AbstractRecovery{
    * @param global_costmap A pointer to the global_costmap used by the navigation stack
    * @param local_costmap A pointer to the local_costmap used by the navigation stack
    */
-  virtual void initialize(std::string name, tf::TransformListener* tf,
+  virtual void initialize(std::string name, TF* tf,
                           costmap_2d::Costmap2DROS* global_costmap,
                           costmap_2d::Costmap2DROS* local_costmap) = 0;
 

--- a/mbf_costmap_nav/CMakeLists.txt
+++ b/mbf_costmap_nav/CMakeLists.txt
@@ -58,9 +58,13 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
 )
 
-if("$ENV{ROS_DISTRO}" STREQUAL "melodic")
-  add_definitions(-DCOSTMAP_HAS_TF2)
-  message("melodic compatible build")
+if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
+  add_definitions(-DUSE_OLD_TF)
+  message("kinetic compatible build")
+endif()
+if("$ENV{ROS_DISTRO}" STREQUAL "lunar")
+  add_definitions(-DUSE_OLD_TF)
+  message("lunar compatible build")
 endif()
 
 

--- a/mbf_costmap_nav/CMakeLists.txt
+++ b/mbf_costmap_nav/CMakeLists.txt
@@ -58,6 +58,12 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
 )
 
+if("$ENV{ROS_DISTRO}" STREQUAL "melodic")
+  add_definitions(-DCOSTMAP_HAS_TF2)
+  message("melodic compatible build")
+endif()
+
+
 add_library(${MBF_NAV_CORE_WRAPPER_LIB}
   src/nav_core_wrapper/wrapper_global_planner.cpp
   src/nav_core_wrapper/wrapper_local_planner.cpp

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
@@ -70,7 +70,7 @@ public:
   CostmapControllerExecution(
       const std::string name,
       const mbf_costmap_core::CostmapController::Ptr &controller_ptr,
-      const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr,
+      const TFPtr &tf_listener_ptr,
       CostmapPtr &costmap_ptr,
       const MoveBaseFlexConfig &config,
       boost::function<void()> setup_fn,

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
@@ -86,7 +86,7 @@ public:
    * @brief Constructor
    * @param tf_listener_ptr Shared pointer to a common TransformListener
    */
-  CostmapNavigationServer(const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr);
+  CostmapNavigationServer(const TFPtr &tf_listener_ptr);
 
   /**
    * @brief Destructor

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_recovery_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_recovery_execution.h
@@ -71,7 +71,7 @@ public:
   CostmapRecoveryExecution(
       const std::string name,
       const mbf_costmap_core::CostmapRecovery::Ptr &recovery_ptr,
-      const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr,
+      const TFPtr &tf_listener_ptr,
       CostmapPtr &global_costmap,
       CostmapPtr &local_costmap,
       const MoveBaseFlexConfig &config,

--- a/mbf_costmap_nav/include/nav_core_wrapper/wrapper_local_planner.h
+++ b/mbf_costmap_nav/include/nav_core_wrapper/wrapper_local_planner.h
@@ -44,6 +44,8 @@
 #include <nav_core/base_local_planner.h>
 #include "mbf_costmap_core/costmap_controller.h"
 
+#include <mbf_utility/types.h>
+
 namespace mbf_nav_core_wrapper {
   /**
    * @class LocalPlanner
@@ -104,7 +106,7 @@ namespace mbf_nav_core_wrapper {
        * @param tf A pointer to a transform listener
        * @param costmap_ros The cost map to use for assigning costs to local plans
        */
-      virtual void initialize(std::string name, tf::TransformListener *tf, costmap_2d::Costmap2DROS *costmap_ros);
+      virtual void initialize(std::string name, TF *tf, costmap_2d::Costmap2DROS *costmap_ros);
 
       /**
        * @brief Public constructor used for handling a nav_core-based plugin

--- a/mbf_costmap_nav/include/nav_core_wrapper/wrapper_recovery_behavior.h
+++ b/mbf_costmap_nav/include/nav_core_wrapper/wrapper_recovery_behavior.h
@@ -44,6 +44,7 @@
 #include <nav_core/recovery_behavior.h>
 #include "mbf_costmap_core/costmap_recovery.h"
 
+#include <mbf_utility/types.h>
 namespace mbf_nav_core_wrapper {
   /**
    * @class CostmapRecovery
@@ -60,7 +61,7 @@ namespace mbf_nav_core_wrapper {
        * @param global_costmap A pointer to the global_costmap used by the navigation stack
        * @param local_costmap A pointer to the local_costmap used by the navigation stack
        */
-      virtual void initialize(std::string name, tf::TransformListener* tf,
+      virtual void initialize(std::string name, TF* tf,
                               costmap_2d::Costmap2DROS* global_costmap,
                               costmap_2d::Costmap2DROS* local_costmap);
 

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
@@ -45,7 +45,7 @@ namespace mbf_costmap_nav
 CostmapControllerExecution::CostmapControllerExecution(
     const std::string name,
     const mbf_costmap_core::CostmapController::Ptr &controller_ptr,
-    const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr,
+    const TFPtr &tf_listener_ptr,
     CostmapPtr &costmap_ptr,
     const MoveBaseFlexConfig &config,
     boost::function<void()> setup_fn,

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -55,7 +55,7 @@ namespace mbf_costmap_nav
 {
 
 
-CostmapNavigationServer::CostmapNavigationServer(const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr) :
+CostmapNavigationServer::CostmapNavigationServer(const TFPtr &tf_listener_ptr) :
   AbstractNavigationServer(tf_listener_ptr),
   recovery_plugin_loader_("mbf_costmap_core", "mbf_costmap_core::CostmapRecovery"),
   nav_core_recovery_plugin_loader_("nav_core", "nav_core::RecoveryBehavior"),

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_recovery_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_recovery_execution.cpp
@@ -47,7 +47,7 @@ namespace mbf_costmap_nav
 CostmapRecoveryExecution::CostmapRecoveryExecution(
     const std::string name,
     const mbf_costmap_core::CostmapRecovery::Ptr &recovery_ptr,
-    const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr,
+    const TFPtr &tf_listener_ptr,
     CostmapPtr &global_costmap, CostmapPtr &local_costmap,
     const MoveBaseFlexConfig &config,
     boost::function<void()> setup_fn,

--- a/mbf_costmap_nav/src/move_base_server_node.cpp
+++ b/mbf_costmap_nav/src/move_base_server_node.cpp
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
   tf2_ros::TransformListener tf_listener(*tf_listener_ptr);
 
 #else  
-  TransformListenerPtr tf_listener_ptr(new TF(nh, ros::Duration(cache_time), true));
+  TFPtr tf_listener_ptr(new TF(nh, ros::Duration(cache_time), true));
 #endif
   costmap_nav_srv_ptr = boost::make_shared<mbf_costmap_nav::CostmapNavigationServer>(tf_listener_ptr);
   ros::MultiThreadedSpinner spinner;

--- a/mbf_costmap_nav/src/move_base_server_node.cpp
+++ b/mbf_costmap_nav/src/move_base_server_node.cpp
@@ -67,12 +67,11 @@ int main(int argc, char **argv)
   private_nh.param("tf_cache_time", cache_time, 10.0);
 
   signal(SIGINT, sigintHandler);
-#ifdef COSTMAP_HAS_TF2
+#ifdef USE_OLD_TF
+  TFPtr tf_listener_ptr(new TF(nh, ros::Duration(cache_time), true));
+#else  
   TFPtr tf_listener_ptr(new TF(ros::Duration(cache_time)));
   tf2_ros::TransformListener tf_listener(*tf_listener_ptr);
-
-#else  
-  TFPtr tf_listener_ptr(new TF(nh, ros::Duration(cache_time), true));
 #endif
   costmap_nav_srv_ptr = boost::make_shared<mbf_costmap_nav::CostmapNavigationServer>(tf_listener_ptr);
   ros::MultiThreadedSpinner spinner;

--- a/mbf_costmap_nav/src/move_base_server_node.cpp
+++ b/mbf_costmap_nav/src/move_base_server_node.cpp
@@ -40,6 +40,8 @@
 
 #include "mbf_costmap_nav/costmap_navigation_server.h"
 #include <signal.h>
+#include <mbf_utility/types.h>
+#include <tf2_ros/transform_listener.h>
 
 typedef boost::shared_ptr<mbf_costmap_nav::CostmapNavigationServer> CostmapNavigationServerPtr;
 mbf_costmap_nav::CostmapNavigationServer::Ptr costmap_nav_srv_ptr;
@@ -58,8 +60,6 @@ int main(int argc, char **argv)
 {
   ros::init(argc, argv, "mbf_2d_nav_server", ros::init_options::NoSigintHandler);
 
-  typedef boost::shared_ptr<tf::TransformListener> TransformListenerPtr;
-
   ros::NodeHandle nh;
   ros::NodeHandle private_nh("~");
 
@@ -67,8 +67,13 @@ int main(int argc, char **argv)
   private_nh.param("tf_cache_time", cache_time, 10.0);
 
   signal(SIGINT, sigintHandler);
+#ifdef COSTMAP_HAS_TF2
+  TFPtr tf_listener_ptr(new TF(ros::Duration(cache_time)));
+  tf2_ros::TransformListener tf_listener(*tf_listener_ptr);
 
-  TransformListenerPtr tf_listener_ptr(new tf::TransformListener(nh, ros::Duration(cache_time), true));
+#else  
+  TransformListenerPtr tf_listener_ptr(new TF(nh, ros::Duration(cache_time), true));
+#endif
   costmap_nav_srv_ptr = boost::make_shared<mbf_costmap_nav::CostmapNavigationServer>(tf_listener_ptr);
   ros::MultiThreadedSpinner spinner;
   spinner.spin();

--- a/mbf_costmap_nav/src/nav_core_wrapper/wrapper_local_planner.cpp
+++ b/mbf_costmap_nav/src/nav_core_wrapper/wrapper_local_planner.cpp
@@ -75,7 +75,7 @@ bool WrapperLocalPlanner::cancel()
 }
 
 void WrapperLocalPlanner::initialize(std::string name,
-                                     tf::TransformListener *tf,
+                                     TF *tf,
                                      costmap_2d::Costmap2DROS *costmap_ros)
 {
   nav_core_plugin_->initialize(name, tf, costmap_ros);

--- a/mbf_costmap_nav/src/nav_core_wrapper/wrapper_recovery_behavior.cpp
+++ b/mbf_costmap_nav/src/nav_core_wrapper/wrapper_recovery_behavior.cpp
@@ -43,7 +43,7 @@
 
 namespace mbf_nav_core_wrapper
 {
-void WrapperRecoveryBehavior::initialize(std::string name, tf::TransformListener *tf,
+void WrapperRecoveryBehavior::initialize(std::string name, TF *tf,
                                          costmap_2d::Costmap2DROS *global_costmap,
                                          costmap_2d::Costmap2DROS *local_costmap)
 {

--- a/mbf_simple_nav/CMakeLists.txt
+++ b/mbf_simple_nav/CMakeLists.txt
@@ -47,9 +47,13 @@ catkin_package(
   DEPENDS Boost
 )
 
-if("$ENV{ROS_DISTRO}" STREQUAL "melodic")
-  add_definitions(-DCOSTMAP_HAS_TF2)
-  message("melodic compatible build")
+if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
+  add_definitions(-DUSE_OLD_TF)
+  message("kinetic compatible build")
+endif()
+if("$ENV{ROS_DISTRO}" STREQUAL "lunar")
+  add_definitions(-DUSE_OLD_TF)
+  message("lunar compatible build")
 endif()
 
 include_directories(

--- a/mbf_simple_nav/CMakeLists.txt
+++ b/mbf_simple_nav/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(catkin REQUIRED
   std_msgs
   std_srvs
   tf
+  tf2
+  tf2_ros
   )
 
 find_package(Boost COMPONENTS thread chrono REQUIRED)
@@ -40,8 +42,15 @@ catkin_package(
   std_msgs
   std_srvs
   tf
+  tf2
+  tf2_ros
   DEPENDS Boost
 )
+
+if("$ENV{ROS_DISTRO}" STREQUAL "melodic")
+  add_definitions(-DCOSTMAP_HAS_TF2)
+  message("melodic compatible build")
+endif()
 
 include_directories(
   include

--- a/mbf_simple_nav/include/mbf_simple_nav/simple_navigation_server.h
+++ b/mbf_simple_nav/include/mbf_simple_nav/simple_navigation_server.h
@@ -43,6 +43,7 @@
 
 #include <mbf_abstract_nav/abstract_navigation_server.h>
 #include <pluginlib/class_loader.h>
+#include <mbf_utility/types.h>
 
 namespace mbf_simple_nav
 {
@@ -67,7 +68,7 @@ public:
    * @brief Constructor
    * @param tf_listener_ptr Shared pointer to a common TransformListener
    */
-  SimpleNavigationServer(const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr);
+  SimpleNavigationServer(const TFPtr &tf_listener_ptr);
 
   /**
    * @brief Destructor

--- a/mbf_simple_nav/package.xml
+++ b/mbf_simple_nav/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
     <name>mbf_simple_nav</name>
     <version>0.2.0</version>
     <description>
@@ -14,35 +14,22 @@
 
     <buildtool_depend>catkin</buildtool_depend>
 
-    <build_depend>tf</build_depend>
-    <build_depend>roscpp</build_depend>
-    <build_depend>pluginlib</build_depend>
-    <build_depend>actionlib</build_depend>
-    <build_depend>actionlib_msgs</build_depend>
-    <build_depend>dynamic_reconfigure</build_depend>
-    <build_depend>std_msgs</build_depend>
-    <build_depend>std_srvs</build_depend>
-    <build_depend>nav_msgs</build_depend>
-    <build_depend>geometry_msgs</build_depend>
-    <build_depend>mbf_abstract_nav</build_depend>
-    <build_depend>mbf_abstract_core</build_depend>
-    <build_depend>mbf_msgs</build_depend>
+    <depend>tf</depend>
+    <depend>roscpp</depend>
+    <depend>pluginlib</depend>
+    <depend>actionlib</depend>
+    <depend>actionlib_msgs</depend>
+    <depend>dynamic_reconfigure</depend>
+    <depend>std_msgs</depend>
+    <depend>std_srvs</depend>
+    <depend>nav_msgs</depend>
+    <depend>geometry_msgs</depend>
+    <depend>mbf_abstract_nav</depend>
+    <depend>mbf_abstract_core</depend>
+    <depend>mbf_msgs</depend>
 
-    <run_depend>tf</run_depend>
-    <run_depend>roscpp</run_depend>
-    <run_depend>pluginlib</run_depend>
-    <run_depend>actionlib</run_depend>
-    <run_depend>actionlib_msgs</run_depend>
-    <run_depend>base_local_planner</run_depend>
-    <run_depend>dynamic_reconfigure</run_depend>
-    <run_depend>std_msgs</run_depend>
-    <run_depend>std_srvs</run_depend>
-    <run_depend>nav_msgs</run_depend>
-    <run_depend>geometry_msgs</run_depend>
-    <run_depend>mbf_abstract_nav</run_depend>
-    <run_depend>mbf_abstract_core</run_depend>
-    <run_depend>mbf_msgs</run_depend>
-
+    <depend>tf2</depend>
+    <depend>tf2_ros</depend>
     <export>
       <rosdoc config="rosdoc.yaml" />
     </export>

--- a/mbf_simple_nav/src/simple_navigation_server.cpp
+++ b/mbf_simple_nav/src/simple_navigation_server.cpp
@@ -43,7 +43,7 @@
 namespace mbf_simple_nav
 {
 
-SimpleNavigationServer::SimpleNavigationServer(const boost::shared_ptr<tf::TransformListener> &tf_listener_ptr) :
+SimpleNavigationServer::SimpleNavigationServer(const TFPtr &tf_listener_ptr) :
     mbf_abstract_nav::AbstractNavigationServer(tf_listener_ptr),
     planner_plugin_loader_("mbf_abstract_core", "mbf_abstract_core::AbstractPlanner"),
     controller_plugin_loader_("mbf_abstract_core", "mbf_abstract_core::AbstractController"),

--- a/mbf_simple_nav/src/simple_server_node.cpp
+++ b/mbf_simple_nav/src/simple_server_node.cpp
@@ -39,12 +39,13 @@
  */
 
 #include "mbf_simple_nav/simple_navigation_server.h"
+#include <mbf_utility/types.h>
+#include <tf2_ros/transform_listener.h>
 
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "mbf_simple_server");
 
-  typedef boost::shared_ptr<tf::TransformListener> TransformListenerPtr;
   typedef boost::shared_ptr<mbf_simple_nav::SimpleNavigationServer> SimpleNavigationServerPtr;
 
   ros::NodeHandle nh;
@@ -53,9 +54,15 @@ int main(int argc, char **argv)
   double cache_time;
   private_nh.param("tf_cache_time", cache_time, 10.0);
 
-  TransformListenerPtr tf_listener_ptr(new tf::TransformListener(nh, ros::Duration(cache_time), true));
+#ifdef COSTMAP_HAS_TF2
+  TFPtr tf_listener_ptr(new TF(ros::Duration(cache_time)));
+  tf2_ros::TransformListener tf_listener(*tf_listener_ptr);
+#else
+  TFPtr tf_listener_ptr(new TF(nh, ros::Duration(cache_time), true));
+#endif 
+  
   SimpleNavigationServerPtr controller_ptr(
-      new mbf_simple_nav::SimpleNavigationServer(TransformListenerPtr(tf_listener_ptr)));
+      new mbf_simple_nav::SimpleNavigationServer(tf_listener_ptr));
 
   ros::spin();
   return EXIT_SUCCESS;

--- a/mbf_simple_nav/src/simple_server_node.cpp
+++ b/mbf_simple_nav/src/simple_server_node.cpp
@@ -54,11 +54,11 @@ int main(int argc, char **argv)
   double cache_time;
   private_nh.param("tf_cache_time", cache_time, 10.0);
 
-#ifdef COSTMAP_HAS_TF2
+#ifdef USE_OLD_TF
+  TFPtr tf_listener_ptr(new TF(nh, ros::Duration(cache_time), true));
+#else
   TFPtr tf_listener_ptr(new TF(ros::Duration(cache_time)));
   tf2_ros::TransformListener tf_listener(*tf_listener_ptr);
-#else
-  TFPtr tf_listener_ptr(new TF(nh, ros::Duration(cache_time), true));
 #endif 
   
   SimpleNavigationServerPtr controller_ptr(

--- a/mbf_utility/CMakeLists.txt
+++ b/mbf_utility/CMakeLists.txt
@@ -17,9 +17,13 @@ catkin_package(
 
 )
 
-if("$ENV{ROS_DISTRO}" STREQUAL "melodic")
-  add_definitions(-DCOSTMAP_HAS_TF2)
-  message("melodic compatible build")
+if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
+  add_definitions(-DUSE_OLD_TF)
+  message("kinetic compatible build")
+endif()
+if("$ENV{ROS_DISTRO}" STREQUAL "lunar")
+  add_definitions(-DUSE_OLD_TF)
+  message("lunar compatible build")
 endif()
 
 include_directories(

--- a/mbf_utility/CMakeLists.txt
+++ b/mbf_utility/CMakeLists.txt
@@ -5,13 +5,22 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   roscpp
   tf
+  tf2
+  tf2_ros
+  tf2_geometry_msgs
 )
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES mbf_utility
-  CATKIN_DEPENDS geometry_msgs roscpp tf
+  CATKIN_DEPENDS geometry_msgs roscpp tf tf2 tf2_ros   tf2_geometry_msgs
+
 )
+
+if("$ENV{ROS_DISTRO}" STREQUAL "melodic")
+  add_definitions(-DCOSTMAP_HAS_TF2)
+  message("melodic compatible build")
+endif()
 
 include_directories(
   include

--- a/mbf_utility/include/mbf_utility/navigation_utility.h
+++ b/mbf_utility/include/mbf_utility/navigation_utility.h
@@ -46,6 +46,11 @@
 #include <ros/time.h>
 #include <string>
 #include <tf/transform_listener.h>
+#include <tf2/convert.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+#include <mbf_utility/types.h>
 
 namespace mbf_utility
 {
@@ -61,7 +66,7 @@ namespace mbf_utility
  * @param out Transformed pose.
  * @return true, if the transformation succeeded.
  */
-bool transformPose(const tf::TransformListener &tf_listener,
+bool transformPose(const TF &tf_listener,
                    const std::string &target_frame,
                    const ros::Time &target_time,
                    const ros::Duration &timeout,
@@ -78,7 +83,7 @@ bool transformPose(const tf::TransformListener &tf_listener,
  * @param robot_pose the computed rebot pose in the global frame.
  * @return true, if succeeded, false otherwise.
  */
-bool getRobotPose(const tf::TransformListener &tf_listener,
+bool getRobotPose(const TF &tf_listener,
                   const std::string &robot_frame,
                   const std::string &global_frame,
                   const ros::Duration &timeout,

--- a/mbf_utility/include/mbf_utility/types.h
+++ b/mbf_utility/include/mbf_utility/types.h
@@ -41,14 +41,14 @@
 
 #include <boost/shared_ptr.hpp>
 
-#ifdef COSTMAP_HAS_TF2
-#include <tf2_ros/buffer.h>
-typedef boost::shared_ptr<tf2_ros::Buffer> TFPtr;
-typedef tf2_ros::Buffer TF;
-#else
+#ifdef USE_OLD_TF
 #include <tf/transform_listener.h>
 typedef boost::shared_ptr<tf::TransformListener> TFPtr;
 typedef tf::TransformListener TF;
+#else
+#include <tf2_ros/buffer.h>
+typedef boost::shared_ptr<tf2_ros::Buffer> TFPtr;
+typedef tf2_ros::Buffer TF;
 #endif
 
 #endif

--- a/mbf_utility/include/mbf_utility/types.h
+++ b/mbf_utility/include/mbf_utility/types.h
@@ -1,0 +1,54 @@
+/*
+ *  Copyright 2018, Sebastian Pütz
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  abstract_planner.h
+ *
+ *  author: Jannik Abbenseth <jba@ipa.fhg.de>
+ *
+ */
+
+#ifndef MBF_ABSTRACT_CORE__TYPES_H_
+#define MBF_ABSTRACT_CORE__TYPES_H_
+
+#include <boost/shared_ptr.hpp>
+
+#ifdef COSTMAP_HAS_TF2
+#include <tf2_ros/buffer.h>
+typedef boost::shared_ptr<tf2_ros::Buffer> TFPtr;
+typedef tf2_ros::Buffer TF;
+#else
+#include <tf/transform_listener.h>
+typedef boost::shared_ptr<tf::TransformListener> TFPtr;
+typedef tf::TransformListener TF;
+#endif
+
+#endif

--- a/mbf_utility/package.xml
+++ b/mbf_utility/package.xml
@@ -21,4 +21,8 @@
   <exec_depend>roscpp</exec_depend>
   <exec_depend>tf</exec_depend>
 
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
+
 </package>

--- a/mbf_utility/src/navigation_utility.cpp
+++ b/mbf_utility/src/navigation_utility.cpp
@@ -74,20 +74,18 @@ bool transformPose(const TF &tf_listener,
 {
   std::string error_msg;
 
-#ifdef COSTMAP_HAS_TF2
-  bool success = tf_listener.canTransform(target_frame,
-                                              in.header.frame_id,
-                                              in.header.stamp,
-                                              timeout,
-                                              &error_msg);
-#else
-
-
+#ifdef USE_OLD_TF
   bool success = tf_listener.waitForTransform(target_frame,
                                               in.header.frame_id,
                                               in.header.stamp,
                                               timeout,
                                               ros::Duration(0.01),
+                                              &error_msg);
+#else
+  bool success = tf_listener.canTransform(target_frame,
+                                              in.header.frame_id,
+                                              in.header.stamp,
+                                              timeout,
                                               &error_msg);
 #endif
 
@@ -100,11 +98,11 @@ bool transformPose(const TF &tf_listener,
 
   try
   {
-#ifdef COSTMAP_HAS_TF2
+#ifdef USE_OLD_TF
+    tf_listener.transformPose(target_frame, target_time, in, fixed_frame, out);
+#else
     geometry_msgs::TransformStamped transform = tf_listener.lookupTransform(target_frame, fixed_frame, ros::Time::now(), timeout);
     tf2::doTransform(in, out, transform);
-#else
-    tf_listener.transformPose(target_frame, target_time, in, fixed_frame, out);
 #endif  
   }
   catch (tf::TransformException &ex)


### PR DESCRIPTION
The main changes were
1) somehow the signature of actionlib::ActionServer doesn't support goal and cancel callbacks with references anymore (although I have not found out how it worked before)

2) Use tf2 if running on melodic: costmap2d switched to tf2 with melodic. Depending on the ros-distro different typedefs are used and in mbf_utility the pose transformation is done with tf2 for melodic