### PR TITLE
Fixes leaking of threads in abstract_action.

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action.h
@@ -110,7 +110,9 @@ class AbstractAction
     concurrency_slots_.right.erase(goal_handle.getGoalID().id);
     ROS_DEBUG_STREAM("Exiting run method with goal status: " << goal_handle.getGoalStatus().text << " and code: "
         << static_cast<int>(goal_handle.getGoalStatus().status));
-    threads_.remove_thread(threads_ptrs_[goal_handle.getGoalID().id]);
+    boost::thread* self = threads_ptrs_[goal_handle.getGoalID().id];
+    threads_.remove_thread(self);
+    self->detach();
     threads_ptrs_.erase(goal_handle.getGoalID().id);
     if (execution_ptr->cleanup_fn_)
       execution_ptr->cleanup_fn_();


### PR DESCRIPTION
There is no convenient place for anyone to join() the wrapper thread which
runs runAndCleanup(), so make the thread detach itself just before exiting.

Fixes #87 "get_path and exe_path actions leak a thread every invocation"