### PR TITLE
Check ROS version on code instead of on CMake

### DIFF
--- a/mbf_abstract_nav/CMakeLists.txt
+++ b/mbf_abstract_nav/CMakeLists.txt
@@ -49,18 +49,6 @@ catkin_package(
       xmlrpcpp
   DEPENDS Boost
 )
-if("$ENV{ROS_DISTRO}" STREQUAL "indigo")
-  add_definitions(-DUSE_OLD_TF)
-  message("indigo compatible build")
-endif()
-if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
-  add_definitions(-DUSE_OLD_TF)
-  message("kinetic compatible build")
-endif()
-if("$ENV{ROS_DISTRO}" STREQUAL "lunar")
-  add_definitions(-DUSE_OLD_TF)
-  message("lunar compatible build")
-endif()
 
 
 include_directories(

--- a/mbf_costmap_core/CMakeLists.txt
+++ b/mbf_costmap_core/CMakeLists.txt
@@ -25,19 +25,6 @@ catkin_package(
             nav_core
 )
 
-if("$ENV{ROS_DISTRO}" STREQUAL "indigo")
-  add_definitions(-DUSE_OLD_TF)
-  message("indigo compatible build")
-endif()
-if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
-  add_definitions(-DUSE_OLD_TF)
-  message("kinetic compatible build")
-endif()
-if("$ENV{ROS_DISTRO}" STREQUAL "lunar")
-  add_definitions(-DUSE_OLD_TF)
-  message("lunar compatible build")
-endif()
-
 ## Install project namespaced headers
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}

--- a/mbf_costmap_nav/CMakeLists.txt
+++ b/mbf_costmap_nav/CMakeLists.txt
@@ -58,21 +58,6 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
 )
 
-if("$ENV{ROS_DISTRO}" STREQUAL "indigo")
-  add_definitions(-DUSE_OLD_TF)
-  add_definitions(-DUSE_OLD_NAV_CORE)
-  message("indigo compatible build")
-endif()
-if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
-  add_definitions(-DUSE_OLD_TF)
-  message("kinetic compatible build")
-endif()
-if("$ENV{ROS_DISTRO}" STREQUAL "lunar")
-  add_definitions(-DUSE_OLD_TF)
-  message("lunar compatible build")
-endif()
-
-
 add_library(${MBF_NAV_CORE_WRAPPER_LIB}
   src/nav_core_wrapper/wrapper_global_planner.cpp
   src/nav_core_wrapper/wrapper_local_planner.cpp

--- a/mbf_costmap_nav/src/nav_core_wrapper/wrapper_global_planner.cpp
+++ b/mbf_costmap_nav/src/nav_core_wrapper/wrapper_global_planner.cpp
@@ -50,11 +50,13 @@ uint32_t WrapperGlobalPlanner::makePlan(const geometry_msgs::PoseStamped &start,
                                         double &cost,
                                         std::string &message)
 {
-#ifdef USE_OLD_NAV_CORE
+#if ROS_VERSION_MINIMUM(1, 12, 0) // if current ros version is >= 1.12.0
+  // Kinetic and beyond
+  bool success = nav_core_plugin_->makePlan(start, goal, plan, cost);
+#else
+  // Indigo
   bool success = nav_core_plugin_->makePlan(start, goal, plan);
   cost = 0;
-#else
-  bool success = nav_core_plugin_->makePlan(start, goal, plan, cost);
 #endif
   message = success ? "Plan found" : "Planner failed";
   return success ? 0 : 50;  // SUCCESS | FAILURE

--- a/mbf_simple_nav/CMakeLists.txt
+++ b/mbf_simple_nav/CMakeLists.txt
@@ -47,19 +47,6 @@ catkin_package(
   DEPENDS Boost
 )
 
-if("$ENV{ROS_DISTRO}" STREQUAL "indigo")
-  add_definitions(-DUSE_OLD_TF)
-  message("indigo compatible build")
-endif()
-if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
-  add_definitions(-DUSE_OLD_TF)
-  message("kinetic compatible build")
-endif()
-if("$ENV{ROS_DISTRO}" STREQUAL "lunar")
-  add_definitions(-DUSE_OLD_TF)
-  message("lunar compatible build")
-endif()
-
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}

--- a/mbf_utility/CMakeLists.txt
+++ b/mbf_utility/CMakeLists.txt
@@ -17,19 +17,6 @@ catkin_package(
 
 )
 
-if("$ENV{ROS_DISTRO}" STREQUAL "indigo")
-  add_definitions(-DUSE_OLD_TF)
-  message("indigo compatible build")
-endif()
-if("$ENV{ROS_DISTRO}" STREQUAL "kinetic")
-  add_definitions(-DUSE_OLD_TF)
-  message("kinetic compatible build")
-endif()
-if("$ENV{ROS_DISTRO}" STREQUAL "lunar")
-  add_definitions(-DUSE_OLD_TF)
-  message("lunar compatible build")
-endif()
-
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}

--- a/mbf_utility/include/mbf_utility/types.h
+++ b/mbf_utility/include/mbf_utility/types.h
@@ -41,14 +41,17 @@
 
 #include <boost/shared_ptr.hpp>
 
-#ifdef USE_OLD_TF
-#include <tf/transform_listener.h>
-typedef boost::shared_ptr<tf::TransformListener> TFPtr;
-typedef tf::TransformListener TF;
+#if ROS_VERSION_MINIMUM(1, 14, 0) // if current ros version is >= 1.14.0
+  // Melodic uses TF2
+  #include <tf2_ros/buffer.h>
+  typedef boost::shared_ptr<tf2_ros::Buffer> TFPtr;
+  typedef tf2_ros::Buffer TF;
 #else
-#include <tf2_ros/buffer.h>
-typedef boost::shared_ptr<tf2_ros::Buffer> TFPtr;
-typedef tf2_ros::Buffer TF;
+  // Previous versions still using TF
+  #define USE_OLD_TF
+  #include <tf/transform_listener.h>
+  typedef boost::shared_ptr<tf::TransformListener> TFPtr;
+  typedef tf::TransformListener TF;
 #endif
 
 #endif


### PR DESCRIPTION
Otherwise, we force external plugins to do the same. Now MBF and plugins should compile on all ROS versions.

Please @ipa-jba, can you verify that you can still compile on melodic and indigo?
