### PR TITLE
Revert "fix for empty argument"

### DIFF
--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -66,7 +66,7 @@ void ControllerAction::start(
         = executions_.find(slot->second);
     if(elem != executions_.end())
     {
-      if(elem->second->getName() == goal_handle.getGoal()->controller || goal_handle.getGoal()->controller.empty())
+      if(elem->second->getName() == goal_handle.getGoal()->controller)
       {
         execution_ptr = elem->second;
         execution_ptr->setNewPlan(goal_handle.getGoal()->path.poses);


### PR DESCRIPTION
This reverts commit 2f953dc55feef61d4a730d90d3cc198ab5660db9.

We have been testing move base flex and it crashes everytime when we send a goal when a previous goal is running. Reverting the following commit fixes the issue.

Our test was as follows:
1. run mbf_costmap_nav & mbf_legacy_relay
2. send a goal
3. while the first goal is running, immediately send a new goal
4. when the robot is arriving, the robot will crash with the following segfault:
```
#0  mbf_abstract_nav::MoveBaseAction::actionExePathDone (this=0x6386d8, state=..., result_ptr=...) at /home/ramon/ros/fleet/src/mbf_abstract_nav/src/move_base_action.cpp:368
#1  0x00007ffff5e362e8 in boost::function2<void, actionlib::SimpleClientGoalState const&, boost::shared_ptr<mbf_msgs::ExePathResult_<std::allocator<void> > const> const&>::operator() (a1=..., a0=..., this=0x638c18)
    at /usr/include/boost/function/function_template.hpp:773
#2  actionlib::SimpleActionClient<mbf_msgs::ExePathAction_<std::allocator<void> > >::handleTransition (this=0x638a98, gh=...) at /opt/ros/kinetic/include/actionlib/client/simple_action_client.h:546
#3  0x00007ffff5e0062b in boost::_mfi::mf1<void, actionlib::SimpleActionClient<mbf_msgs::ExePathAction_<std::allocator<void> > >, actionlib::ClientGoalHandle<mbf_msgs::ExePathAction_<std::allocator<void> > > >::operator() (a1=..., p=<optimized out>,
    this=<optimized out>) at /usr/include/boost/bind/mem_fn_template.hpp:165
#4  boost::_bi::list2<boost::_bi::value<actionlib::SimpleActionClient<mbf_msgs::ExePathAction_<std::allocator<void> > >*>, boost::arg<1> >::operator()<boost::_mfi::mf1<void, actionlib::SimpleActionClient<mbf_msgs::ExePathAction_<std::allocator<void> > >, actionlib::ClientGoalHandle<mbf_msgs::ExePathAction_<std::allocator<void> > > >, boost::_bi::list1<actionlib::ClientGoalHandle<mbf_msgs::ExePathAction_<std::allocator<void> > >&> > (a=<synthetic pointer>, f=..., this=<optimized out>) at /usr/include/boost/bind/bind.hpp:313
#5  boost::_bi::bind_t<void, boost::_mfi::mf1<void, actionlib::SimpleActionClient<mbf_msgs::ExePathAction_<std::allocator<void> > >, actionlib::ClientGoalHandle<mbf_msgs::ExePathAction_<std::allocator<void> > > >, boost::_bi::list2<boost::_bi::value<actionlib::SimpleActionClient<mbf_msgs::ExePathAction_<std::allocator<void> > >*>, boost::arg<1> > >::operator()<actionlib::ClientGoalHandle<mbf_msgs::ExePathAction_<std::allocator<void> > > > (a1=..., this=<optimized out>) at /usr/include/boost/bind/bind_template.hpp:32
#6  boost::detail::function::void_function_obj_invoker1<boost::_bi::bind_t<void, boost::_mfi::mf1<void, actionlib::SimpleActionClient<mbf_msgs::ExePathAction_<std::allocator<void> > >, actionlib::ClientGoalHandle<mbf_msgs::ExePathAction_<std::allocator<void> > > >,
boost::_bi::list2<boost::_bi::value<actionlib::SimpleActionClient<mbf_msgs::ExePathAction_<std::allocator<void> > >*>, boost::arg<1> > >, void, actionlib::ClientGoalHandle<mbf_msgs::ExePathAction_<std::allocator<void> > > >::invoke (function_obj_ptr=..., a0=...)
    at /usr/include/boost/function/function_template.hpp:159
#7  0x00007ffff5e001a6 in boost::function1<void, actionlib::ClientGoalHandle<mbf_msgs::ExePathAction_<std::allocator<void> > > >::operator() (a0=..., this=<optimized out>) at /usr/include/boost/function/function_template.hpp:773
#8  boost::detail::function::void_function_obj_invoker1<boost::function<void (actionlib::ClientGoalHandle<mbf_msgs::ExePathAction_<std::allocator<void> > >)>, void, actionlib::ClientGoalHandle<mbf_msgs::ExePathAction_<std::allocator<void> > > const&>::invoke(boost::detail::function::function_buffer&, actionlib::ClientGoalHandle<mbf_msgs::ExePathAction_<std::allocator<void> > > const&) (function_obj_ptr=..., a0=...) at /usr/include/boost/function/function_template.hpp:159
#9  0x00007ffff5e117b4 in boost::function1<void, actionlib::ClientGoalHandle<mbf_msgs::ExePathAction_<std::allocator<void> > > const&>::operator() (a0=..., this=0x7fffd4002838) at /usr/include/boost/function/function_template.hpp:773
#10 actionlib::CommStateMachine<mbf_msgs::ExePathAction_<std::allocator<void> > >::transitionToState (this=this@entry=0x7fffd40027c0, gh=..., next_state=...) at /opt/ros/kinetic/include/actionlib/client/comm_state_machine_imp.h:481
#11 0x00007ffff5e21f1c in actionlib::CommStateMachine<mbf_msgs::ExePathAction_<std::allocator<void> > >::transitionToState (next_state=<optimized out>, gh=..., this=0x7fffd40027c0) at /opt/ros/kinetic/include/actionlib/client/comm_state_machine_imp.h:472
#12 actionlib::CommStateMachine<mbf_msgs::ExePathAction_<std::allocator<void> > >::processLost (this=this@entry=0x7fffd40027c0, gh=...) at /opt/ros/kinetic/include/actionlib/client/comm_state_machine_imp.h:465
#13 0x00007ffff5e22216 in actionlib::CommStateMachine<mbf_msgs::ExePathAction_<std::allocator<void> > >::updateStatus (this=0x7fffd40027c0, gh=..., status_array=...) at /opt/ros/kinetic/include/actionlib/client/comm_state_machine_imp.h:185
#14 0x00007ffff5e243f4 in actionlib::GoalManager<mbf_msgs::ExePathAction_<std::allocator<void> > >::updateStatuses (this=this@entry=0x63b158, status_array=...) at /opt/ros/kinetic/include/actionlib/client/goal_manager_imp.h:118
#15 0x00007ffff5e24739 in actionlib::ActionClient<mbf_msgs::ExePathAction_<std::allocator<void> > >::statusCb (this=0x63b090, status_array_event=...) at /opt/ros/kinetic/include/actionlib/client/action_client.h:291
#16 0x00007ffff5e3def0 in boost::function1<void, ros::MessageEvent<actionlib_msgs::GoalStatusArray_<std::allocator<void> > const> const&>::operator() (a0=..., this=0x634b68) at /usr/include/boost/function/function_template.hpp:773
#17 ros::SubscriptionCallbackHelperT<ros::MessageEvent<actionlib_msgs::GoalStatusArray_<std::allocator<void> > const> const&, void>::call (this=0x634b60, params=...) at /opt/ros/kinetic/include/ros/subscription_callback_helper.h:144
#18 0x00007ffff7677d8d in ros::SubscriptionQueue::call() () from /opt/ros/kinetic/lib/libroscpp.so
#19 0x00007ffff761d838 in ros::CallbackQueue::callOneCB(ros::CallbackQueue::TLS*) () from /opt/ros/kinetic/lib/libroscpp.so
#20 0x00007ffff761f23b in ros::CallbackQueue::callAvailable(ros::WallDuration) () from /opt/ros/kinetic/lib/libroscpp.so
#21 0x00007ffff5dff147 in actionlib::SimpleActionClient<mbf_msgs::ExePathAction_<std::allocator<void> > >::spinThread (this=0x638a98) at /opt/ros/kinetic/include/actionlib/client/simple_action_client.h:297
#22 0x00007ffff39a55d5 in ?? () from /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.58.0
#23 0x00007ffff49d56ba in start_thread (arg=0x7fffe67fc700) at pthread_create.c:333
#24 0x00007ffff667541d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109
```

