### PR TITLE
Replace recursive mutexes with normal ones when not needed

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action.h
@@ -69,7 +69,7 @@ class AbstractAction
       typename Execution::Ptr execution_ptr
   )
   {
-    boost::lock_guard<boost::mutex> lock_guard(map_mtx_);
+    boost::lock_guard<boost::mutex> guard(map_mtx_);
     typename SlotGoalIdMap::left_const_iterator slot
         = concurrency_slots_.left.find(goal_handle.getGoal()->concurrency_slot);
     if(slot != concurrency_slots_.left.end()) // if there is a plugin running on the same slot, cancel it // TODO make thread safe
@@ -93,7 +93,7 @@ class AbstractAction
         elem = executions_.find(goal_handle.getGoalID().id);
     if(elem != executions_.end())
     {
-      boost::lock_guard<boost::mutex> lock_guard(map_mtx_);
+      boost::lock_guard<boost::mutex> guard(map_mtx_);
       elem->second->cancel();
     }
   }
@@ -105,7 +105,7 @@ class AbstractAction
     ROS_DEBUG_STREAM("Finished action run method, waiting for execution thread to finish.");
     execution_ptr->join();
     ROS_DEBUG_STREAM("Execution thread stopped, cleaning up the execution object map and the slot map");
-    boost::lock_guard<boost::mutex> lock_guard(map_mtx_);
+    boost::lock_guard<boost::mutex> guard(map_mtx_);
     executions_.erase(goal_handle.getGoalID().id);
     concurrency_slots_.right.erase(goal_handle.getGoalID().id);
     ROS_DEBUG_STREAM("Exiting run method with goal status: " << goal_handle.getGoalStatus().text << " and code: "
@@ -120,7 +120,7 @@ class AbstractAction
   void reconfigureAll(
       mbf_abstract_nav::MoveBaseFlexConfig &config, uint32_t level)
   {
-    boost::lock_guard<boost::mutex> lock_guard(map_mtx_);
+    boost::lock_guard<boost::mutex> guard(map_mtx_);
 
     typename std::map<const std::string, const typename Execution::Ptr>::iterator iter;
     for(iter = executions_.begin(); iter != executions_.end(); ++iter)
@@ -132,7 +132,7 @@ class AbstractAction
   void cancelAll()
   {
     ROS_INFO_STREAM_NAMED(name_, "Cancel all goals for \"" << name_ << "\".");
-    boost::lock_guard<boost::mutex> lock_guard(map_mtx_);
+    boost::lock_guard<boost::mutex> guard(map_mtx_);
     typename std::map<const std::string, const typename Execution::Ptr>::iterator iter;
     for(iter = executions_.begin(); iter != executions_.end(); ++iter)
     {

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
@@ -319,7 +319,7 @@ typedef boost::shared_ptr<dynamic_reconfigure::Server<mbf_abstract_nav::MoveBase
     DynamicReconfigureServer dsrv_;
 
     //! configuration mutex for derived classes and other threads.
-    boost::recursive_mutex configuration_mutex_;
+    boost::mutex configuration_mutex_;
 
     //! last configuration save
     mbf_abstract_nav::MoveBaseFlexConfig last_config_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -298,7 +298,7 @@ namespace mbf_abstract_nav
     PlanningState state_;
 
     //! dynamic reconfigure mutex for a thread safe communication
-    boost::recursive_mutex configuration_mutex_;
+    boost::mutex configuration_mutex_;
 
   };
 

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -93,7 +93,7 @@ namespace mbf_abstract_nav
 
   void AbstractControllerExecution::reconfigure(const MoveBaseFlexConfig &config)
   {
-    boost::lock_guard<boost::mutex> lock_guard(configuration_mutex_);
+    boost::lock_guard<boost::mutex> guard(configuration_mutex_);
     // Timeout granted to the local planner. We keep calling it up to this time or up to max_retries times
     // If it doesn't return within time, the navigator will cancel it and abort the corresponding action
     patience_ = ros::Duration(config.controller_patience);
@@ -343,7 +343,7 @@ namespace mbf_abstract_nav
           }
           else
           {
-            boost::lock_guard<boost::mutex> lock_guard(configuration_mutex_);
+            boost::lock_guard<boost::mutex> guard(configuration_mutex_);
             if (max_retries_ >= 0 && ++retries > max_retries_)
             {
               setState(MAX_RETRIES);

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -365,7 +365,7 @@ void AbstractNavigationServer::startDynamicReconfigureServer()
 void AbstractNavigationServer::reconfigure(
   mbf_abstract_nav::MoveBaseFlexConfig &config, uint32_t level)
 {
-  boost::recursive_mutex::scoped_lock sl(configuration_mutex_);
+  boost::lock_guard<boost::mutex> guard(configuration_mutex_);
 
   // Make sure we have the original configuration the first time we're called, so we can restore it if needed
   if (!setup_reconfigure_)

--- a/mbf_abstract_nav/src/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_planner_execution.cpp
@@ -91,7 +91,7 @@ namespace mbf_abstract_nav
 
   void AbstractPlannerExecution::reconfigure(const MoveBaseFlexConfig &config)
   {
-    boost::recursive_mutex::scoped_lock sl(configuration_mutex_);
+    boost::lock_guard<boost::mutex> guard(configuration_mutex_);
 
     max_retries_ = config.planner_max_retries;
     frequency_ = config.planner_frequency;
@@ -273,7 +273,7 @@ namespace mbf_abstract_nav
           outcome_ = makePlan(current_start, current_goal, current_tolerance, plan, cost, message_);
           success = outcome_ < 10;
 
-          boost::recursive_mutex::scoped_lock sl(configuration_mutex_);
+          boost::lock_guard<boost::mutex> guard(configuration_mutex_);
 
           if (cancel_ && !isPatienceExceeded())
           {

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -56,7 +56,7 @@ void ControllerAction::start(
 )
 {
   bool new_plan = false;
-  boost::lock_guard<boost::mutex> lock_guard(map_mtx_);
+  boost::lock_guard<boost::mutex> guard(map_mtx_);
   typename SlotGoalIdMap::left_const_iterator slot
       = concurrency_slots_.left.find(goal_handle.getGoal()->concurrency_slot);
   if(slot != concurrency_slots_.left.end())

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -73,7 +73,7 @@ void MoveBaseAction::reconfigure(
 {
   if (config.planner_frequency > 0.0)
   {
-    boost::lock_guard<boost::mutex> lock_guard(replanning_mtx_);
+    boost::lock_guard<boost::mutex> guard(replanning_mtx_);
     if (!replanning_)
     {
       replanning_ = true;
@@ -338,7 +338,7 @@ void MoveBaseAction::actionGetPathDone(
 
   // we reset the replan clock (we can have been stopped for a while) and make a fist sleep, so we don't replan
   // just after start moving
-  boost::lock_guard<boost::mutex> lock_guard(replanning_mtx_);
+  boost::lock_guard<boost::mutex> guard(replanning_mtx_);
   replanning_rate_.reset();
   replanning_rate_.sleep();
   if (!replanning_ || action_state_ != EXE_PATH ||

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -341,8 +341,6 @@ CostmapNavigationServer::~CostmapNavigationServer()
 
 void CostmapNavigationServer::reconfigure(mbf_costmap_nav::MoveBaseFlexConfig &config, uint32_t level)
 {
-  boost::recursive_mutex::scoped_lock sl(configuration_mutex_);
-
   // Make sure we have the original configuration the first time we're called, so we can restore it if needed
   if (!setup_reconfigure_)
   {


### PR DESCRIPTION
as they introduce an unnecessary overhead

For code regularity sake, I also unified all _lock_guard_, _guard_ and _lg_ variable names as _guard_