### PR TITLE
Issue #102: Change current_twist for last_cmd_vel on exe_path/feedback

### DIFF
--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -192,6 +192,7 @@ namespace mbf_abstract_nav
     vel_cmd_stamped_ = vel_cmd;
     if (vel_cmd_stamped_.header.stamp.isZero())
       vel_cmd_stamped_.header.stamp = ros::Time::now();
+    // TODO what happen with frame id?
   }
 
 
@@ -333,9 +334,6 @@ namespace mbf_abstract_nav
 
           if (outcome_ < 10)
           {
-            // set stamped values: frame id, time stamp and sequence number
-            cmd_vel_stamped.header.seq = seq++;
-            setVelocityCmd(cmd_vel_stamped);
             setState(GOT_LOCAL_CMD);
             vel_pub_.publish(cmd_vel_stamped.twist);
             condition_.notify_all();
@@ -363,8 +361,12 @@ namespace mbf_abstract_nav
               condition_.notify_all();
             }
             // could not compute a valid velocity command -> stop moving the robot
-            publishZeroVelocity(); // command the robot to stop
+            publishZeroVelocity(); // command the robot to stop; we still feedback command calculated by the plugin
           }
+
+          // set stamped values; timestamp and frame_id should be set by the plugin; otherwise setVelocityCmd will do
+          cmd_vel_stamped.header.seq = seq++; // sequence number
+          setVelocityCmd(cmd_vel_stamped);
         }
 
         boost::chrono::thread_clock::time_point end_time = boost::chrono::thread_clock::now();

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -340,9 +340,9 @@ void ControllerAction::publishExePathFeedback(
   feedback.outcome = outcome;
   feedback.message = message;
 
-  feedback.current_twist = current_twist;
-  if (feedback.current_twist.header.stamp.isZero())
-    feedback.current_twist.header.stamp = ros::Time::now();
+  feedback.last_cmd_vel = current_twist;
+  if (feedback.last_cmd_vel.header.stamp.isZero())
+    feedback.last_cmd_vel.header.stamp = ros::Time::now();
 
   feedback.current_pose = robot_pose;
   feedback.dist_to_goal = static_cast<float>(mbf_utility::distance(robot_pose, goal_pose));

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -191,7 +191,7 @@ void MoveBaseAction::actionExePathFeedback(
   move_base_feedback_.angle_to_goal = feedback->angle_to_goal;
   move_base_feedback_.dist_to_goal = feedback->dist_to_goal;
   move_base_feedback_.current_pose = feedback->current_pose;
-  move_base_feedback_.current_twist = feedback->current_twist;
+  move_base_feedback_.last_cmd_vel = feedback->last_cmd_vel;
   robot_pose_ = feedback->current_pose;
   goal_handle_.publishFeedback(move_base_feedback_);
 

--- a/mbf_msgs/action/ExePath.action
+++ b/mbf_msgs/action/ExePath.action
@@ -48,5 +48,4 @@ string message
 float32 dist_to_goal
 float32 angle_to_goal
 geometry_msgs/PoseStamped  current_pose
-geometry_msgs/TwistStamped current_twist
-uint8 concurrency_slot
+geometry_msgs/TwistStamped last_cmd_vel  # last command calculated by the controller

--- a/mbf_msgs/action/MoveBase.action
+++ b/mbf_msgs/action/MoveBase.action
@@ -45,12 +45,11 @@ geometry_msgs/PoseStamped final_pose
 
 ---
 
-# Outcome of most recent controller cycle.
-# Same values as in MoveBase or ExePath result.
+# Outcome of most recent controller cycle. Same values as in MoveBase or ExePath result.
 uint32 outcome
 string message
 
 float32 dist_to_goal
 float32 angle_to_goal
 geometry_msgs/PoseStamped current_pose
-geometry_msgs/TwistStamped current_twist
+geometry_msgs/TwistStamped last_cmd_vel  # last command calculated by the controller


### PR DESCRIPTION
Is a clearer name, as current_twist can be interpreted as the actual velocity of the robot.
Also ensure that we report a zero velocity when we send it to the robot