### PR TITLE
Prevent LOST goals when replanning

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action.h
@@ -40,7 +40,6 @@
 #define MBF_ABSTRACT_NAV__ABSTRACT_ACTION_H_
 
 #include <actionlib/server/action_server.h>
-#include <boost/bimap/bimap.hpp>
 #include <mbf_abstract_nav/MoveBaseFlexConfig.h>
 #include "mbf_abstract_nav/robot_information.h"
 
@@ -51,12 +50,17 @@ template <typename Action, typename Execution>
 class AbstractAction
 {
  public:
-  typedef boost::bimaps::bimap<uint8_t, std::string> SlotGoalIdMap;
-
   typedef boost::shared_ptr<AbstractAction> Ptr;
 
   typedef typename actionlib::ActionServer<Action>::GoalHandle GoalHandle;
   typedef boost::function<void (GoalHandle &goal_handle, Execution &execution)> RunMethod;
+
+  typedef struct
+  {
+    typename Execution::Ptr execution;
+    boost::thread* thread_ptr;
+    GoalHandle goal_handle;
+  } ConcurrencySlot;
 
   AbstractAction(
       const std::string& name,
@@ -64,93 +68,91 @@ class AbstractAction
       const RunMethod run_method
   ) : name_(name), robot_info_(robot_info), run_(run_method){}
 
-  void start(
-      GoalHandle goal_handle,
+  virtual void start(
+      GoalHandle &goal_handle,
       typename Execution::Ptr execution_ptr
   )
   {
-    boost::lock_guard<boost::mutex> guard(map_mtx_);
-    typename SlotGoalIdMap::left_const_iterator slot
-        = concurrency_slots_.left.find(goal_handle.getGoal()->concurrency_slot);
-    if(slot != concurrency_slots_.left.end()) // if there is a plugin running on the same slot, cancel it // TODO make thread safe
+    uint8_t slot = goal_handle.getGoal()->concurrency_slot;
+
+    boost::lock_guard<boost::mutex> guard(slots_mtx_);
+    typename std::map<uint8_t, ConcurrencySlot>::iterator slot_it = concurrency_slots_.find(slot);
+    if(slot_it != concurrency_slots_.end())
     {
-      typename std::map<const std::string, const typename Execution::Ptr>::const_iterator elem
-          = executions_.find(slot->second);
-      if(elem != executions_.end())
-      {
-        elem->second->cancel();
-      }
-      concurrency_slots_.left.erase(slot->first);
+      // if there is a plugin running on the same slot, cancel it
+      slot_it->second.execution->cancel(); // TODO make thread safe
     }
-    concurrency_slots_.insert(SlotGoalIdMap::value_type(goal_handle.getGoal()->concurrency_slot, goal_handle.getGoalID().id));
-    executions_.insert(std::pair<const std::string, const typename Execution::Ptr>(goal_handle.getGoalID().id, execution_ptr));
-    threads_ptrs_.insert(std::pair<const std::string, boost::thread*>(goal_handle.getGoalID().id,
-                         threads_.create_thread(boost::bind(&AbstractAction::runAndCleanUp, this, goal_handle, execution_ptr))));
+    // fill concurrency slot with the new goal handle, execution, and working thread
+    concurrency_slots_[slot].goal_handle = goal_handle;
+    concurrency_slots_[slot].execution = execution_ptr;
+    concurrency_slots_[slot].thread_ptr = threads_.create_thread(boost::bind(&AbstractAction::runAndCleanUp,
+                                                                             this, goal_handle, execution_ptr));
   }
 
-  void cancel(GoalHandle &goal_handle){
-    typename std::map<const std::string, const typename Execution::Ptr>::const_iterator
-        elem = executions_.find(goal_handle.getGoalID().id);
-    if(elem != executions_.end())
+  virtual void cancel(GoalHandle &goal_handle){
+    uint8_t slot = goal_handle.getGoal()->concurrency_slot;
+
+    boost::lock_guard<boost::mutex> guard(slots_mtx_);
+    typename std::map<uint8_t, ConcurrencySlot>::iterator slot_it = concurrency_slots_.find(slot);
+    if(slot_it != concurrency_slots_.end())
     {
-      boost::lock_guard<boost::mutex> guard(map_mtx_);
-      elem->second->cancel();
+      concurrency_slots_[slot].execution->cancel();
     }
   }
 
-  void runAndCleanUp(GoalHandle goal_handle, typename Execution::Ptr execution_ptr){
+  virtual void runAndCleanUp(GoalHandle &goal_handle, typename Execution::Ptr execution_ptr){
+    uint8_t slot = goal_handle.getGoal()->concurrency_slot;
+
     if (execution_ptr->setup_fn_)
       execution_ptr->setup_fn_();
-    run_(goal_handle, *execution_ptr);
-    ROS_DEBUG_STREAM("Finished action run method, waiting for execution thread to finish.");
+    run_(concurrency_slots_[slot].goal_handle, *execution_ptr);
+    ROS_DEBUG_STREAM_NAMED(name_, "Finished action \"" << name_ << "\" run method, waiting for execution thread to finish.");
     execution_ptr->join();
-    ROS_DEBUG_STREAM("Execution thread stopped, cleaning up the execution object map and the slot map");
-    boost::lock_guard<boost::mutex> guard(map_mtx_);
-    executions_.erase(goal_handle.getGoalID().id);
-    concurrency_slots_.right.erase(goal_handle.getGoalID().id);
-    ROS_DEBUG_STREAM("Exiting run method with goal status: " << goal_handle.getGoalStatus().text << " and code: "
-        << static_cast<int>(goal_handle.getGoalStatus().status));
-    threads_.remove_thread(threads_ptrs_[goal_handle.getGoalID().id]);
-    delete threads_ptrs_[goal_handle.getGoalID().id];
-    threads_ptrs_.erase(goal_handle.getGoalID().id);
+    ROS_DEBUG_STREAM_NAMED(name_, "Execution thread for action \"" << name_ << "\" stopped, cleaning up execution leftovers.");
+    boost::lock_guard<boost::mutex> guard(slots_mtx_);
+    ROS_DEBUG_STREAM_NAMED(name_, "Exiting run method with goal status: "
+                           << concurrency_slots_[slot].goal_handle.getGoalStatus().text
+                           << " and code: " << concurrency_slots_[slot].goal_handle.getGoalStatus().status);
+    threads_.remove_thread(concurrency_slots_[slot].thread_ptr);
+    delete concurrency_slots_[slot].thread_ptr;
+    concurrency_slots_.erase(slot);
     if (execution_ptr->cleanup_fn_)
       execution_ptr->cleanup_fn_();
   }
 
-  void reconfigureAll(
+  virtual void reconfigureAll(
       mbf_abstract_nav::MoveBaseFlexConfig &config, uint32_t level)
   {
-    boost::lock_guard<boost::mutex> guard(map_mtx_);
+    boost::lock_guard<boost::mutex> guard(slots_mtx_);
 
-    typename std::map<const std::string, const typename Execution::Ptr>::iterator iter;
-    for(iter = executions_.begin(); iter != executions_.end(); ++iter)
+    typename std::map<uint8_t, ConcurrencySlot>::iterator iter;
+    for(iter = concurrency_slots_.begin(); iter != concurrency_slots_.end(); ++iter)
     {
-      iter->second->reconfigure(config);
+      iter->second.execution->reconfigure(config);
     }
   }
 
-  void cancelAll()
+  virtual void cancelAll()
   {
     ROS_INFO_STREAM_NAMED(name_, "Cancel all goals for \"" << name_ << "\".");
-    boost::lock_guard<boost::mutex> guard(map_mtx_);
-    typename std::map<const std::string, const typename Execution::Ptr>::iterator iter;
-    for(iter = executions_.begin(); iter != executions_.end(); ++iter)
+    boost::lock_guard<boost::mutex> guard(slots_mtx_);
+    typename std::map<uint8_t, ConcurrencySlot>::iterator iter;
+    for(iter = concurrency_slots_.begin(); iter != concurrency_slots_.end(); ++iter)
     {
-      iter->second->cancel();
+      iter->second.execution->cancel();
     }
     threads_.join_all();
   }
 
+protected:
   const std::string &name_;
   const RobotInformation &robot_info_;
 
   RunMethod run_;
   boost::thread_group threads_;
-  std::map<const std::string, const typename Execution::Ptr> executions_;
-  std::map<const std::string, boost::thread*> threads_ptrs_;
-  SlotGoalIdMap concurrency_slots_;
+  std::map<uint8_t, ConcurrencySlot> concurrency_slots_;
 
-  boost::mutex map_mtx_;
+  boost::mutex slots_mtx_;
 
 };
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -59,8 +59,14 @@ class ControllerAction :
   ControllerAction(const std::string &name,
                    const RobotInformation &robot_info);
 
+  /**
+   * @brief Start controller action.
+   * Override abstract action version to allow updating current plan without stopping execution.
+   * @param goal_handle Reference to the goal handle received on action execution callback.
+   * @param execution_ptr Pointer to the execution descriptor.
+   */
   void start(
-      GoalHandle goal_handle,
+      GoalHandle &goal_handle,
       typename AbstractControllerExecution::Ptr execution_ptr
   );
 


### PR DESCRIPTION
This fixes (hopefully) #121 and #107 by properly overriding AbstractAction::start method to allow updating current plan without stopping controller execution.

The problem was that we accepted a new goal but kept using the initial goal handle, and so the last goal received before stopping got LOST (all previous ones get PREEMPTED, so no problem). With this PR, we always use the last received goal handle. Also I tried to simplify the code by storing in a single map (concurrency slots map) goal handle, execution, and working thread.