### PR TITLE
 Refactor by passing only concurrency slot to run methods

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action.h
@@ -40,7 +40,6 @@
 #define MBF_ABSTRACT_NAV__ABSTRACT_ACTION_H_
 
 #include <actionlib/server/action_server.h>
-#include <boost/bimap/bimap.hpp>
 #include <mbf_abstract_nav/MoveBaseFlexConfig.h>
 #include "mbf_abstract_nav/robot_information.h"
 
@@ -51,12 +50,17 @@ template <typename Action, typename Execution>
 class AbstractAction
 {
  public:
-  typedef boost::bimaps::bimap<uint8_t, std::string> SlotGoalIdMap;
-
   typedef boost::shared_ptr<AbstractAction> Ptr;
 
   typedef typename actionlib::ActionServer<Action>::GoalHandle GoalHandle;
   typedef boost::function<void (GoalHandle &goal_handle, Execution &execution)> RunMethod;
+
+  typedef struct
+  {
+    typename Execution::Ptr execution;
+    boost::thread* thread_ptr;
+    GoalHandle goal_handle;
+  } ConcurrencySlot;
 
   AbstractAction(
       const std::string& name,
@@ -64,93 +68,91 @@ class AbstractAction
       const RunMethod run_method
   ) : name_(name), robot_info_(robot_info), run_(run_method){}
 
-  void start(
-      GoalHandle goal_handle,
+  virtual void start(
+      GoalHandle &goal_handle,
       typename Execution::Ptr execution_ptr
   )
   {
-    boost::lock_guard<boost::mutex> guard(map_mtx_);
-    typename SlotGoalIdMap::left_const_iterator slot
-        = concurrency_slots_.left.find(goal_handle.getGoal()->concurrency_slot);
-    if(slot != concurrency_slots_.left.end()) // if there is a plugin running on the same slot, cancel it // TODO make thread safe
+    uint8_t slot = goal_handle.getGoal()->concurrency_slot;
+
+    boost::lock_guard<boost::mutex> guard(slots_mtx_);
+    typename std::map<uint8_t, ConcurrencySlot>::iterator slot_it = concurrency_slots_.find(slot);
+    if(slot_it != concurrency_slots_.end())
     {
-      typename std::map<const std::string, const typename Execution::Ptr>::const_iterator elem
-          = executions_.find(slot->second);
-      if(elem != executions_.end())
-      {
-        elem->second->cancel();
-      }
-      concurrency_slots_.left.erase(slot->first);
+      // if there is a plugin running on the same slot, cancel it
+      slot_it->second.execution->cancel(); // TODO make thread safe
     }
-    concurrency_slots_.insert(SlotGoalIdMap::value_type(goal_handle.getGoal()->concurrency_slot, goal_handle.getGoalID().id));
-    executions_.insert(std::pair<const std::string, const typename Execution::Ptr>(goal_handle.getGoalID().id, execution_ptr));
-    threads_ptrs_.insert(std::pair<const std::string, boost::thread*>(goal_handle.getGoalID().id,
-                         threads_.create_thread(boost::bind(&AbstractAction::runAndCleanUp, this, goal_handle, execution_ptr))));
+    // fill concurrency slot with the new goal handle, execution, and working thread
+    concurrency_slots_[slot].goal_handle = goal_handle;
+    concurrency_slots_[slot].execution = execution_ptr;
+    concurrency_slots_[slot].thread_ptr = threads_.create_thread(boost::bind(&AbstractAction::runAndCleanUp,
+                                                                             this, goal_handle, execution_ptr));
   }
 
-  void cancel(GoalHandle &goal_handle){
-    typename std::map<const std::string, const typename Execution::Ptr>::const_iterator
-        elem = executions_.find(goal_handle.getGoalID().id);
-    if(elem != executions_.end())
+  virtual void cancel(GoalHandle &goal_handle){
+    uint8_t slot = goal_handle.getGoal()->concurrency_slot;
+
+    boost::lock_guard<boost::mutex> guard(slots_mtx_);
+    typename std::map<uint8_t, ConcurrencySlot>::iterator slot_it = concurrency_slots_.find(slot);
+    if(slot_it != concurrency_slots_.end())
     {
-      boost::lock_guard<boost::mutex> guard(map_mtx_);
-      elem->second->cancel();
+      concurrency_slots_[slot].execution->cancel();
     }
   }
 
-  void runAndCleanUp(GoalHandle goal_handle, typename Execution::Ptr execution_ptr){
+  virtual void runAndCleanUp(GoalHandle &goal_handle, typename Execution::Ptr execution_ptr){
+    uint8_t slot = goal_handle.getGoal()->concurrency_slot;
+
     if (execution_ptr->setup_fn_)
       execution_ptr->setup_fn_();
-    run_(goal_handle, *execution_ptr);
-    ROS_DEBUG_STREAM("Finished action run method, waiting for execution thread to finish.");
+    run_(concurrency_slots_[slot].goal_handle, *execution_ptr);
+    ROS_DEBUG_STREAM_NAMED(name_, "Finished action \"" << name_ << "\" run method, waiting for execution thread to finish.");
     execution_ptr->join();
-    ROS_DEBUG_STREAM("Execution thread stopped, cleaning up the execution object map and the slot map");
-    boost::lock_guard<boost::mutex> guard(map_mtx_);
-    executions_.erase(goal_handle.getGoalID().id);
-    concurrency_slots_.right.erase(goal_handle.getGoalID().id);
-    ROS_DEBUG_STREAM("Exiting run method with goal status: " << goal_handle.getGoalStatus().text << " and code: "
-        << static_cast<int>(goal_handle.getGoalStatus().status));
-    threads_.remove_thread(threads_ptrs_[goal_handle.getGoalID().id]);
-    delete threads_ptrs_[goal_handle.getGoalID().id];
-    threads_ptrs_.erase(goal_handle.getGoalID().id);
+    ROS_DEBUG_STREAM_NAMED(name_, "Execution thread for action \"" << name_ << "\" stopped, cleaning up execution leftovers.");
+    boost::lock_guard<boost::mutex> guard(slots_mtx_);
+    ROS_DEBUG_STREAM_NAMED(name_, "Exiting run method with goal status: "
+                           << concurrency_slots_[slot].goal_handle.getGoalStatus().text
+                           << " and code: " << concurrency_slots_[slot].goal_handle.getGoalStatus().status);
+    threads_.remove_thread(concurrency_slots_[slot].thread_ptr);
+    delete concurrency_slots_[slot].thread_ptr;
+    concurrency_slots_.erase(slot);
     if (execution_ptr->cleanup_fn_)
       execution_ptr->cleanup_fn_();
   }
 
-  void reconfigureAll(
+  virtual void reconfigureAll(
       mbf_abstract_nav::MoveBaseFlexConfig &config, uint32_t level)
   {
-    boost::lock_guard<boost::mutex> guard(map_mtx_);
+    boost::lock_guard<boost::mutex> guard(slots_mtx_);
 
-    typename std::map<const std::string, const typename Execution::Ptr>::iterator iter;
-    for(iter = executions_.begin(); iter != executions_.end(); ++iter)
+    typename std::map<uint8_t, ConcurrencySlot>::iterator iter;
+    for(iter = concurrency_slots_.begin(); iter != concurrency_slots_.end(); ++iter)
     {
-      iter->second->reconfigure(config);
+      iter->second.execution->reconfigure(config);
     }
   }
 
-  void cancelAll()
+  virtual void cancelAll()
   {
     ROS_INFO_STREAM_NAMED(name_, "Cancel all goals for \"" << name_ << "\".");
-    boost::lock_guard<boost::mutex> guard(map_mtx_);
-    typename std::map<const std::string, const typename Execution::Ptr>::iterator iter;
-    for(iter = executions_.begin(); iter != executions_.end(); ++iter)
+    boost::lock_guard<boost::mutex> guard(slots_mtx_);
+    typename std::map<uint8_t, ConcurrencySlot>::iterator iter;
+    for(iter = concurrency_slots_.begin(); iter != concurrency_slots_.end(); ++iter)
     {
-      iter->second->cancel();
+      iter->second.execution->cancel();
     }
     threads_.join_all();
   }
 
+protected:
   const std::string &name_;
   const RobotInformation &robot_info_;
 
   RunMethod run_;
   boost::thread_group threads_;
-  std::map<const std::string, const typename Execution::Ptr> executions_;
-  std::map<const std::string, boost::thread*> threads_ptrs_;
-  SlotGoalIdMap concurrency_slots_;
+  std::map<uint8_t, ConcurrencySlot> concurrency_slots_;
 
-  boost::mutex map_mtx_;
+  boost::mutex slots_mtx_;
 
 };
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -75,24 +75,21 @@ class ControllerAction :
 protected:
   void publishExePathFeedback(
           GoalHandle goal_handle,
-          const geometry_msgs::PoseStamped& robot_pose,
-          const geometry_msgs::PoseStamped& goal_pose,
           uint32_t outcome, const std::string &message,
           const geometry_msgs::TwistStamped& current_twist);
 
   /**
    * @brief Utility method to fill the ExePath action result in a single line
-   * @param robot_pose Current pose of the robot
-   * @param goal_pose Robot's goal pose
    * @param outcome ExePath action outcome
    * @param message ExePath action message
    * @param result The action result to fill
    */
   void fillExePathResult(
-        const geometry_msgs::PoseStamped& robot_pose,
-        const geometry_msgs::PoseStamped& goal_pose,
         uint32_t outcome, const std::string &message,
         mbf_msgs::ExePathResult &result);
+
+  geometry_msgs::PoseStamped robot_pose_; ///< Current robot pose
+  geometry_msgs::PoseStamped goal_pose_;  ///< Current goal pose
 
 };
 }

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -74,7 +74,7 @@ class ControllerAction :
 
 protected:
   void publishExePathFeedback(
-          uint8_t concurrency_slot,
+          GoalHandle goal_handle,
           const geometry_msgs::PoseStamped& robot_pose,
           const geometry_msgs::PoseStamped& goal_pose,
           uint32_t outcome, const std::string &message,

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -70,11 +70,11 @@ class ControllerAction :
       typename AbstractControllerExecution::Ptr execution_ptr
   );
 
-  void run(GoalHandle &goal_handle, AbstractControllerExecution &execution);
+  void run(uint8_t concurrency_slot);
 
 protected:
   void publishExePathFeedback(
-          GoalHandle& goal_handle,
+          uint8_t concurrency_slot,
           const geometry_msgs::PoseStamped& robot_pose,
           const geometry_msgs::PoseStamped& goal_pose,
           uint32_t outcome, const std::string &message,

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -59,8 +59,14 @@ class ControllerAction :
   ControllerAction(const std::string &name,
                    const RobotInformation &robot_info);
 
+  /**
+   * @brief Start controller action.
+   * Override abstract action version to allow updating current plan without stopping execution.
+   * @param goal_handle Reference to the goal handle received on action execution callback.
+   * @param execution_ptr Pointer to the execution descriptor.
+   */
   void start(
-      GoalHandle goal_handle,
+      GoalHandle &goal_handle,
       typename AbstractControllerExecution::Ptr execution_ptr
   );
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
@@ -61,7 +61,7 @@ class PlannerAction : public AbstractAction<mbf_msgs::GetPathAction, AbstractPla
       const RobotInformation &robot_info
   );
 
-  void run(GoalHandle &goal_handle, AbstractPlannerExecution &execution);
+  void run(uint8_t concurrency_slot);
 
  protected:
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/recovery_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/recovery_action.h
@@ -58,7 +58,7 @@ class RecoveryAction : public AbstractAction<mbf_msgs::RecoveryAction, AbstractR
 
   RecoveryAction(const std::string& name, const RobotInformation &robot_info);
 
-  void run(GoalHandle &goal_handle, AbstractRecoveryExecution &execution);
+  void run(uint8_t concurrency_slot);
 
 };
 

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -162,7 +162,6 @@ void AbstractNavigationServer::callActionGetPath(ActionServerGetPath::GoalHandle
   ROS_INFO_STREAM_NAMED("get_path", "Using the planner \"" << planner_name << "\" of type \""
                                          << planner_plugin_manager_.getType(planner_name) << "\"");
 
-  goal_handle.setAccepted();
 
   if(planner_plugin)
   {
@@ -178,7 +177,7 @@ void AbstractNavigationServer::callActionGetPath(ActionServerGetPath::GoalHandle
     result.outcome = mbf_msgs::GetPathResult::INTERNAL_ERROR;
     result.message = "Internal Error: \"planner_plugin\" pointer should not be a null pointer!";
     ROS_FATAL_STREAM_NAMED("get_path", result.message);
-    goal_handle.setAborted(result, result.message);
+    goal_handle.setRejected(result, result.message);
   }
 }
 
@@ -223,7 +222,6 @@ void AbstractNavigationServer::callActionExePath(ActionServerExePath::GoalHandle
   ROS_INFO_STREAM("Using the controller \"" << controller_name
                                             << "\" of type \"" << controller_plugin_manager_.getType(controller_name) << "\"");
 
-  goal_handle.setAccepted();
 
   if(controller_plugin)
   {
@@ -239,7 +237,7 @@ void AbstractNavigationServer::callActionExePath(ActionServerExePath::GoalHandle
     result.outcome = mbf_msgs::ExePathResult::INTERNAL_ERROR;
     result.message = "Internal Error: \"controller_plugin\" pointer should not be a null pointer!";
     ROS_FATAL_STREAM_NAMED("exe_path", result.message);
-    goal_handle.setAborted(result, result.message);
+    goal_handle.setRejected(result, result.message);
   }
 }
 
@@ -284,7 +282,6 @@ void AbstractNavigationServer::callActionRecovery(ActionServerRecovery::GoalHand
   ROS_INFO_STREAM("Using the recovery \"" << recovery_name
                                             << "\" of type \"" << recovery_plugin_manager_.getType(recovery_name) << "\"");
 
-  goal_handle.setAccepted();
 
   if(recovery_plugin)
   {
@@ -299,7 +296,7 @@ void AbstractNavigationServer::callActionRecovery(ActionServerRecovery::GoalHand
     result.outcome = mbf_msgs::RecoveryResult::INTERNAL_ERROR;
     result.message = "Internal Error: \"recovery_plugin\" pointer should not be a null pointer!";
     ROS_FATAL_STREAM_NAMED("recovery", result.message);
-    goal_handle.setAborted(result, result.message);
+    goal_handle.setRejected(result, result.message);
   }
 }
 

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -55,6 +55,12 @@ void ControllerAction::start(
     typename AbstractControllerExecution::Ptr execution_ptr
 )
 {
+  if(goal_handle.getGoalStatus().status == actionlib_msgs::GoalStatus::RECALLING)
+  {
+    goal_handle.setCanceled();
+    return;
+  }
+
   uint8_t concurrency_slot = goal_handle.getGoal()->concurrency_slot;
   lockSlot(concurrency_slot);
   try
@@ -71,6 +77,7 @@ void ControllerAction::start(
       fillExePathResult(mbf_msgs::ExePathResult::CANCELED, "Goal preempted by a new plan", result);
       getGoalHandle(concurrency_slot).setCanceled(result, result.message);
       setGoalHandle(concurrency_slot, goal_handle);
+      goal_handle.setAccepted();
       return;
     }
   }


### PR DESCRIPTION
The concurrency slots map is now private and accesed by get/set methods
that lock the slots mutex.