### PR TITLE
On controller execution, check that local costmap is current

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -236,11 +236,20 @@ namespace mbf_abstract_nav
      */
     virtual void run();
 
+    /**
+     * @brief Check if its safe to drive.
+     * This method gets called at every controller cycle, stopping the robot if its not. When overridden by
+     * child class, gives a chance to the specific execution implementation to stop the robot if it detects
+     * something wrong on the underlying map.
+     * @return Always true, unless overridden by child class.
+     */
+    virtual bool isSafeToDrive() { return true; };
+
   private:
 
 
     /**
-     * publishes a velocity command with zero values to stop the robot.
+     * @brief Publishes a velocity command with zero values to stop the robot.
      */
     void publishZeroVelocity();
 

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
@@ -86,6 +86,14 @@ public:
 protected:
 
   /**
+   * @brief Check if its safe to drive.
+   * This method overrides abstract execution empty implementation with underlying map specific check,
+   * more precisely if controller costmap is current.
+   * @return True if costmap is current, false otherwise.
+   */
+  bool isSafeToDrive();
+
+  /**
    * @brief Request plugin for a new velocity command. We override this method so we can lock the local costmap
    *        before calling the planner.
    * @param pose the current pose of the robot.

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
@@ -91,4 +91,15 @@ uint32_t CostmapControllerExecution::computeVelocityCmd(
   return controller_->computeVelocityCommands(robot_pose, robot_velocity, vel_cmd, message);
 }
 
+bool CostmapControllerExecution::isSafeToDrive()
+{
+  // Check that the observation buffers for the costmap are current, we don't want to drive blind
+  if (!costmap_ptr_->isCurrent())
+  {
+    ROS_WARN("Sensor data is out of date, we're not going to allow commanding of the base for safety");
+    return false;
+  }
+  return true;
+}
+
 } /* namespace mbf_costmap_nav */


### PR DESCRIPTION
I'm thinking,,, maybe overridding as in this PR is cleaner than [passing setup and cleanup functions](https://github.com/magazino/move_base_flex/blob/master/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp#L111) to the abstract execution :thinking: 
