### PR TITLE
 Do not pass boost functions to abstract server to (de)activate costmaps

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action.h
@@ -113,8 +113,7 @@ class AbstractAction
   virtual void runAndCleanUp(GoalHandle &goal_handle, typename Execution::Ptr execution_ptr){
     uint8_t slot = goal_handle.getGoal()->concurrency_slot;
 
-    if (execution_ptr->setup_fn_)
-      execution_ptr->setup_fn_();
+    execution_ptr->preRun();
     run_(goal_handle, *execution_ptr);
     ROS_DEBUG_STREAM_NAMED(name_, "Finished action \"" << name_ << "\" run method, waiting for execution thread to finish.");
     execution_ptr->join();
@@ -126,8 +125,7 @@ class AbstractAction
     threads_.remove_thread(concurrency_slots_[slot].thread_ptr);
     delete concurrency_slots_[slot].thread_ptr;
     concurrency_slots_.erase(slot);
-    if (execution_ptr->cleanup_fn_)
-      execution_ptr->cleanup_fn_();
+    execution_ptr->postRun();
   }
 
   virtual void reconfigureAll(

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -236,11 +236,20 @@ namespace mbf_abstract_nav
      */
     virtual void run();
 
+    /**
+     * @brief Check if its safe to drive.
+     * This method gets called at every controller cycle, stopping the robot if its not. When overridden by
+     * child class, gives a chance to the specific execution implementation to stop the robot if it detects
+     * something wrong on the underlying map.
+     * @return Always true, unless overridden by child class.
+     */
+    virtual bool isSafeToDrive() { return true; };
+
   private:
 
 
     /**
-     * publishes a velocity command with zero values to stop the robot.
+     * @brief Publishes a velocity command with zero values to stop the robot.
      */
     void publishZeroVelocity();
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -93,9 +93,7 @@ namespace mbf_abstract_nav
         const ros::Publisher& vel_pub,
         const ros::Publisher& goal_pub,
         const TFPtr &tf_listener_ptr,
-        const MoveBaseFlexConfig &config,
-        boost::function<void()> setup_fn,
-        boost::function<void()> cleanup_fn);
+        const MoveBaseFlexConfig &config);
 
     /**
      * @brief Destructor
@@ -243,7 +241,7 @@ namespace mbf_abstract_nav
      * something wrong on the underlying map.
      * @return Always true, unless overridden by child class.
      */
-    virtual bool isSafeToDrive() { return true; };
+    virtual bool safetyCheck() { return true; };
 
   private:
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
@@ -51,9 +51,7 @@ class AbstractExecutionBase
 {
  public:
 
-  AbstractExecutionBase(std::string name,
-                        boost::function<void()> setup_fn,
-                        boost::function<void()> cleanup_fn);
+  AbstractExecutionBase(std::string name);
 
   virtual bool start();
 
@@ -70,16 +68,6 @@ class AbstractExecutionBase
   void waitForStateUpdate(boost::chrono::microseconds const &duration);
 
   /**
-   * @brief Implementation-specific setup function called right before execution; empty on abstract server
-   */
-  boost::function<void()> setup_fn_;
-
-  /**
-   * @brief Implementation-specific cleanup function called right after execution; empty on abstract server
-   */
-  boost::function<void()> cleanup_fn_;
-
-  /**
    * @brief Gets the current plugin execution outcome
    */
   uint32_t getOutcome();
@@ -94,8 +82,17 @@ class AbstractExecutionBase
    */
   std::string getName();
 
- protected:
+  /**
+   * @brief Optional implementation-specific setup function, called right before execution.
+   */
+  virtual void preRun() { ROS_ERROR("PARENT pre run"); };
 
+  /**
+   * @brief Optional implementation-specific cleanup function, called right after execution.
+   */
+  virtual void postRun() { ROS_ERROR("PARENT post run"); };
+
+protected:
   virtual void run() = 0;
 
   //! condition variable to wake up control thread

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
@@ -85,12 +85,12 @@ class AbstractExecutionBase
   /**
    * @brief Optional implementation-specific setup function, called right before execution.
    */
-  virtual void preRun() { ROS_ERROR("PARENT pre run"); };
+  virtual void preRun() { };
 
   /**
    * @brief Optional implementation-specific cleanup function, called right after execution.
    */
-  virtual void postRun() { ROS_ERROR("PARENT post run"); };
+  virtual void postRun() { };
 
 protected:
   virtual void run() = 0;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
@@ -124,11 +124,9 @@ typedef boost::shared_ptr<dynamic_reconfigure::Server<mbf_abstract_nav::MoveBase
      * @brief Constructor, reads all parameters and initializes all action servers and creates the plugin instances.
      *        Parameters are the concrete implementations of the abstract classes.
      * @param tf_listener_ptr shared pointer to the common TransformListener buffering transformations
-     * @param planning_ptr shared pointer to an object of the concrete derived implementation of the AbstractPlannerExecution
-     * @param moving_ptr shared pointer to an object of the concrete derived implementation of the AbstractControllerExecution
-     * @param recovery_ptr shared pointer to an object of the concrete derived implementation of the AbstractRecoveryExecution
      */
     AbstractNavigationServer(const TFPtr &tf_listener_ptr);
+
     /**
      * @brief Destructor
      */
@@ -136,19 +134,34 @@ typedef boost::shared_ptr<dynamic_reconfigure::Server<mbf_abstract_nav::MoveBase
 
     virtual void stop();
 
-    //! shared pointer to a new @ref planner_execution "PlannerExecution"
+    /**
+     * @brief Create a new abstract planner execution.
+     * @param plugin_name Name of the planner to use.
+     * @param plugin_ptr Shared pointer to the plugin to use.
+     * @return Shared pointer to a new @ref planner_execution "PlannerExecution".
+     */
     virtual mbf_abstract_nav::AbstractPlannerExecution::Ptr newPlannerExecution(
-        const std::string plugin_name,
+        const std::string &plugin_name,
         const mbf_abstract_core::AbstractPlanner::Ptr plugin_ptr);
 
-    //! shared pointer to a new @ref controller_execution "ControllerExecution"
+    /**
+     * @brief Create a new abstract controller execution.
+     * @param plugin_name Name of the controller to use.
+     * @param plugin_ptr Shared pointer to the plugin to use.
+     * @return Shared pointer to a new @ref controller_execution "ControllerExecution".
+     */
     virtual mbf_abstract_nav::AbstractControllerExecution::Ptr newControllerExecution(
-        const std::string plugin_name,
+        const std::string &plugin_name,
         const mbf_abstract_core::AbstractController::Ptr plugin_ptr);
 
-    //! shared pointer to a new @ref recovery_execution "RecoveryExecution"
+    /**
+     * @brief Create a new abstract recovery behavior execution.
+     * @param plugin_name Name of the recovery behavior to run.
+     * @param plugin_ptr Shared pointer to the plugin to use
+     * @return Shared pointer to a new @ref recovery_execution "RecoveryExecution".
+     */
     virtual mbf_abstract_nav::AbstractRecoveryExecution::Ptr newRecoveryExecution(
-        const std::string plugin_name,
+        const std::string &plugin_name,
         const mbf_abstract_core::AbstractRecovery::Ptr plugin_ptr);
 
     /**

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -86,9 +86,7 @@ namespace mbf_abstract_nav
      */
     AbstractPlannerExecution(const std::string name,
                              const mbf_abstract_core::AbstractPlanner::Ptr planner_ptr,
-                             const MoveBaseFlexConfig &config,
-                             boost::function<void()> setup_fn,
-                             boost::function<void()> cleanup_fn);
+                             const MoveBaseFlexConfig &config);
 
     /**
      * @brief Destructor

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
@@ -87,9 +87,7 @@ namespace mbf_abstract_nav
     AbstractRecoveryExecution(const std::string name,
                               const mbf_abstract_core::AbstractRecovery::Ptr recovery_ptr,
                               const TFPtr &tf_listener_ptr,
-                              const MoveBaseFlexConfig &config,
-                              boost::function<void()> setup_fn,
-                              boost::function<void()> cleanup_fn);
+                              const MoveBaseFlexConfig &config);
 
     /**
      * @brief Destructor

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -52,10 +52,8 @@ namespace mbf_abstract_nav
       const ros::Publisher& vel_pub,
       const ros::Publisher& goal_pub,
       const TFPtr &tf_listener_ptr,
-      const MoveBaseFlexConfig &config,
-      boost::function<void()> setup_fn,
-      boost::function<void()> cleanup_fn) :
-    AbstractExecutionBase(name, setup_fn, cleanup_fn),
+      const MoveBaseFlexConfig &config) :
+    AbstractExecutionBase(name),
       controller_(controller_ptr), tf_listener_ptr(tf_listener_ptr), state_(INITIALIZED),
       moving_(false), max_retries_(0), patience_(0), vel_pub_(vel_pub), current_goal_pub_(goal_pub),
       calling_duration_(boost::chrono::microseconds(static_cast<int>(1e6 / DEFAULT_CONTROLLER_FREQUENCY)))
@@ -277,7 +275,7 @@ namespace mbf_abstract_nav
           return;
         }
 
-        if (!isSafeToDrive())
+        if (!safetyCheck())
         {
           // the specific implementation must have detected a risk situation; at this abstract level, we
           // cannot tell what the problem is, but anyway we command the robot to stop to avoid crashes

--- a/mbf_abstract_nav/src/abstract_execution_base.cpp
+++ b/mbf_abstract_nav/src/abstract_execution_base.cpp
@@ -40,10 +40,8 @@
 
 namespace mbf_abstract_nav{
 
-  AbstractExecutionBase::AbstractExecutionBase(std::string name,
-                                               boost::function<void()> setup_fn,
-                                               boost::function<void()> cleanup_fn)
-    : outcome_(255), cancel_(false), name_(name), setup_fn_(setup_fn), cleanup_fn_(cleanup_fn)
+  AbstractExecutionBase::AbstractExecutionBase(std::string name)
+    : outcome_(255), cancel_(false), name_(name)
   {
   }
 

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -315,29 +315,26 @@ void AbstractNavigationServer::cancelActionMoveBase(ActionServerMoveBase::GoalHa
 }
 
 mbf_abstract_nav::AbstractPlannerExecution::Ptr AbstractNavigationServer::newPlannerExecution(
-    const std::string name,
+    const std::string &plugin_name,
     const mbf_abstract_core::AbstractPlanner::Ptr plugin_ptr)
 {
-  return boost::make_shared<mbf_abstract_nav::AbstractPlannerExecution>(name, plugin_ptr, last_config_,
-                                                                        boost::function<void()>(),
-                                                                        boost::function<void()>());
+  return boost::make_shared<mbf_abstract_nav::AbstractPlannerExecution>(plugin_name, plugin_ptr, last_config_);
 }
 
 mbf_abstract_nav::AbstractControllerExecution::Ptr AbstractNavigationServer::newControllerExecution(
-    const std::string name,
+    const std::string &plugin_name,
     const mbf_abstract_core::AbstractController::Ptr plugin_ptr)
 {
-  return boost::make_shared<mbf_abstract_nav::AbstractControllerExecution>(name, plugin_ptr, vel_pub_, goal_pub_,
-      tf_listener_ptr_, last_config_, boost::function<void()>(), boost::function<void()>());
+  return boost::make_shared<mbf_abstract_nav::AbstractControllerExecution>(plugin_name, plugin_ptr, vel_pub_, goal_pub_,
+                                                                           tf_listener_ptr_, last_config_);
 }
 
 mbf_abstract_nav::AbstractRecoveryExecution::Ptr AbstractNavigationServer::newRecoveryExecution(
-    const std::string name,
+    const std::string &plugin_name,
     const mbf_abstract_core::AbstractRecovery::Ptr plugin_ptr)
 {
-  return boost::make_shared<mbf_abstract_nav::AbstractRecoveryExecution>(name, plugin_ptr, tf_listener_ptr_, last_config_,
-                                                                         boost::function<void()>(),
-                                                                         boost::function<void()>());
+  return boost::make_shared<mbf_abstract_nav::AbstractRecoveryExecution>(plugin_name, plugin_ptr,
+                                                                         tf_listener_ptr_, last_config_);
 }
 
 void AbstractNavigationServer::startActionServers()

--- a/mbf_abstract_nav/src/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_planner_execution.cpp
@@ -44,12 +44,11 @@ namespace mbf_abstract_nav
 {
 
 
-  AbstractPlannerExecution::AbstractPlannerExecution(const std::string name,
-                                                     const mbf_abstract_core::AbstractPlanner::Ptr planner_ptr,
-                                                     const MoveBaseFlexConfig &config,
-                                                     boost::function<void()> setup_fn,
-                                                     boost::function<void()> cleanup_fn) :
-    AbstractExecutionBase(name, setup_fn, cleanup_fn),
+  AbstractPlannerExecution::AbstractPlannerExecution(
+      const std::string name,
+      const mbf_abstract_core::AbstractPlanner::Ptr planner_ptr,
+      const MoveBaseFlexConfig &config) :
+    AbstractExecutionBase(name),
       planner_(planner_ptr), state_(INITIALIZED), planning_(false),
       has_new_start_(false), has_new_goal_(false)
   {

--- a/mbf_abstract_nav/src/abstract_recovery_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_recovery_execution.cpp
@@ -51,10 +51,8 @@ namespace mbf_abstract_nav
       const std::string name,
       mbf_abstract_core::AbstractRecovery::Ptr recovery_ptr,
       const TFPtr &tf_listener_ptr,
-      const MoveBaseFlexConfig &config,
-      boost::function<void()> setup_fn,
-      boost::function<void()> cleanup_fn) :
-    AbstractExecutionBase(name, setup_fn, cleanup_fn),
+      const MoveBaseFlexConfig &config) :
+    AbstractExecutionBase(name),
       behavior_(recovery_ptr), tf_listener_ptr_(tf_listener_ptr), state_(INITIALIZED)
   {
     // dynamically reconfigurable parameters

--- a/mbf_costmap_nav/CMakeLists.txt
+++ b/mbf_costmap_nav/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(${MBF_COSTMAP_2D_SERVER_LIB}
   src/mbf_costmap_nav/costmap_planner_execution.cpp
   src/mbf_costmap_nav/costmap_controller_execution.cpp
   src/mbf_costmap_nav/costmap_recovery_execution.cpp
+  src/mbf_costmap_nav/costmap_wrapper.cpp
 )
 add_dependencies(${MBF_COSTMAP_2D_SERVER_LIB} ${catkin_EXPORTED_TARGETS})
 add_dependencies(${MBF_COSTMAP_2D_SERVER_LIB} ${MBF_NAV_CORE_WRAPPER_LIB})

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
@@ -85,7 +85,7 @@ public:
    */
   virtual ~CostmapControllerExecution();
 
-protected:
+private:
 
   /**
    * @brief Implementation-specific setup function, called right before execution.
@@ -93,7 +93,6 @@ protected:
    */
   void preRun()
   {
-    ROS_WARN("OK  pre run  %s", name_.c_str());
     costmap_ptr_->checkActivate();
   };
 
@@ -103,7 +102,6 @@ protected:
    */
   void postRun()
   {
-    ROS_WARN("OK  post run  %s", name_.c_str());
     costmap_ptr_->checkDeactivate();
   };
 
@@ -129,8 +127,6 @@ protected:
       const geometry_msgs::TwistStamped& robot_velocity,
       geometry_msgs::TwistStamped& vel_cmd,
       std::string& message);
-
-private:
 
   mbf_abstract_nav::MoveBaseFlexConfig toAbstract(const MoveBaseFlexConfig &config);
 

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
@@ -41,17 +41,19 @@
 #ifndef MBF_COSTMAP_NAV__COSTMAP_CONTROLLER_EXECUTION_H_
 #define MBF_COSTMAP_NAV__COSTMAP_CONTROLLER_EXECUTION_H_
 
-#include <costmap_2d/costmap_2d_ros.h>
-#include <mbf_costmap_nav/MoveBaseFlexConfig.h>
-#include <mbf_costmap_core/costmap_controller.h>
 #include <mbf_abstract_nav/abstract_controller_execution.h>
+#include <mbf_costmap_core/costmap_controller.h>
+
+#include "mbf_costmap_nav/MoveBaseFlexConfig.h"
+#include "mbf_costmap_nav/costmap_wrapper.h"
+
 
 namespace mbf_costmap_nav
 {
 /**
  * @brief The CostmapControllerExecution binds a local costmap to the AbstractControllerExecution and uses the
- *        nav_core/BaseLocalPlanner class as base plugin interface. This class makes move_base_flex compatible to
- *        the old move_base.
+ *        nav_core/BaseLocalPlanner class as base plugin interface.
+ * This class makes move_base_flex compatible to the old move_base.
  *
  * @ingroup controller_execution move_base_server
  */
@@ -59,24 +61,24 @@ class CostmapControllerExecution : public mbf_abstract_nav::AbstractControllerEx
 {
 public:
 
-  typedef boost::shared_ptr<costmap_2d::Costmap2DROS> CostmapPtr;
-
   /**
-   * @brief Constructor
-   * @param condition Thread sleep condition variable, to wake up connected threads
-   * @param tf_listener_ptr Shared pointer to a common tf listener
-   * @param costmap_ptr Shared pointer to the costmap.
+   * @brief Constructor.
+   * @param controller_name Name of the controller to use.
+   * @param controller_ptr Shared pointer to the plugin to use.
+   * @param vel_pub Velocity commands publisher.
+   * @param goal_pub Goal pose publisher (just vor visualization).
+   * @param tf_listener_ptr Shared pointer to a common tf listener.
+   * @param costmap_ptr Shared pointer to the local costmap.
+   * @param config Current server configuration (dynamic).
    */
   CostmapControllerExecution(
-      const std::string name,
+      const std::string &controller_name,
       const mbf_costmap_core::CostmapController::Ptr &controller_ptr,
-      const ros::Publisher& vel_pub,
-      const ros::Publisher& goal_pub,
+      const ros::Publisher &vel_pub,
+      const ros::Publisher &goal_pub,
       const TFPtr &tf_listener_ptr,
-      CostmapPtr &costmap_ptr,
-      const MoveBaseFlexConfig &config,
-      boost::function<void()> setup_fn,
-      boost::function<void()> cleanup_fn);
+      const CostmapWrapper::Ptr &costmap_ptr,
+      const MoveBaseFlexConfig &config);
 
   /**
    * @brief Destructor
@@ -86,12 +88,32 @@ public:
 protected:
 
   /**
-   * @brief Check if its safe to drive.
-   * This method overrides abstract execution empty implementation with underlying map specific check,
+   * @brief Implementation-specific setup function, called right before execution.
+   * This method overrides abstract execution empty implementation with underlying map-specific setup code.
+   */
+  void preRun()
+  {
+    ROS_WARN("OK  pre run  %s", name_.c_str());
+    costmap_ptr_->checkActivate();
+  };
+
+  /**
+   * @brief Implementation-specific cleanup function, called right after execution.
+   * This method overrides abstract execution empty implementation with underlying map-specific cleanup code.
+   */
+  void postRun()
+  {
+    ROS_WARN("OK  post run  %s", name_.c_str());
+    costmap_ptr_->checkDeactivate();
+  };
+
+  /**
+   * @brief Implementation-specific safety check, called during execution to ensure it's safe to drive.
+   * This method overrides abstract execution empty implementation with underlying map-specific checks,
    * more precisely if controller costmap is current.
    * @return True if costmap is current, false otherwise.
    */
-  bool isSafeToDrive();
+  bool safetyCheck();
 
   /**
    * @brief Request plugin for a new velocity command. We override this method so we can lock the local costmap
@@ -112,8 +134,8 @@ private:
 
   mbf_abstract_nav::MoveBaseFlexConfig toAbstract(const MoveBaseFlexConfig &config);
 
-  //! costmap for 2d navigation planning
-  CostmapPtr &costmap_ptr_;
+  //! Shared pointer to thr local costmap
+  const CostmapWrapper::Ptr &costmap_ptr_;
 
   //! Whether to lock costmap before calling the controller (see issue #4 for details)
   bool lock_costmap_;

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
@@ -86,6 +86,14 @@ public:
 protected:
 
   /**
+   * @brief Check if its safe to drive.
+   * This method overrides abstract execution empty implementation with underlying map specific check,
+   * more precisely if controller costmap is current.
+   * @return True if costmap is current, false otherwise.
+   */
+  bool isSafeToDrive();
+
+  /**
    * @brief Request plugin for a new velocity command. We override this method so we can lock the local costmap
    *        before calling the planner.
    * @param pose the current pose of the robot.

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
@@ -43,11 +43,6 @@
 
 #include <mbf_abstract_nav/abstract_navigation_server.h>
 
-#include "costmap_planner_execution.h"
-#include "costmap_controller_execution.h"
-#include "costmap_recovery_execution.h"
-
-#include <mbf_costmap_nav/MoveBaseFlexConfig.h>
 #include <std_srvs/Empty.h>
 #include <mbf_msgs/CheckPath.h>
 #include <mbf_msgs/CheckPose.h>
@@ -56,6 +51,13 @@
 #include <nav_core/base_global_planner.h>
 #include <nav_core/base_local_planner.h>
 #include <nav_core/recovery_behavior.h>
+
+#include "mbf_costmap_nav/MoveBaseFlexConfig.h"
+#include "mbf_costmap_nav/costmap_planner_execution.h"
+#include "mbf_costmap_nav/costmap_controller_execution.h"
+#include "mbf_costmap_nav/costmap_recovery_execution.h"
+#include "mbf_costmap_nav/costmap_wrapper.h"
+
 
 namespace mbf_costmap_nav
 {
@@ -79,8 +81,6 @@ class CostmapNavigationServer : public mbf_abstract_nav::AbstractNavigationServe
 {
 public:
 
-  typedef boost::shared_ptr<costmap_2d::Costmap2DROS> CostmapPtr;
-
   typedef boost::shared_ptr<CostmapNavigationServer> Ptr;
 
   /**
@@ -98,19 +98,34 @@ public:
 
 private:
 
-  //! shared pointer to a new @ref planner_execution "PlannerExecution"
+  /**
+   * @brief Create a new planner execution.
+   * @param plugin_name Name of the planner to use.
+   * @param plugin_ptr Shared pointer to the plugin to use.
+   * @return Shared pointer to a new @ref planner_execution "PlannerExecution".
+   */
   virtual mbf_abstract_nav::AbstractPlannerExecution::Ptr newPlannerExecution(
-      const std::string name,
+      const std::string &plugin_name,
       const mbf_abstract_core::AbstractPlanner::Ptr plugin_ptr);
 
-  //! shared pointer to a new @ref controller_execution "ControllerExecution"
+  /**
+   * @brief Create a new controller execution.
+   * @param plugin_name Name of the controller to use.
+   * @param plugin_ptr Shared pointer to the plugin to use.
+   * @return Shared pointer to a new @ref controller_execution "ControllerExecution".
+   */
   virtual mbf_abstract_nav::AbstractControllerExecution::Ptr newControllerExecution(
-      const std::string name,
+      const std::string &plugin_name,
       const mbf_abstract_core::AbstractController::Ptr plugin_ptr);
 
-  //! shared pointer to a new @ref recovery_execution "RecoveryExecution"
+  /**
+   * @brief Create a new recovery behavior execution.
+   * @param plugin_name Name of the recovery behavior to run.
+   * @param plugin_ptr Shared pointer to the plugin to use
+   * @return Shared pointer to a new @ref recovery_execution "RecoveryExecution".
+   */
   virtual mbf_abstract_nav::AbstractRecoveryExecution::Ptr newRecoveryExecution(
-      const std::string name,
+      const std::string &plugin_name,
       const mbf_abstract_core::AbstractRecovery::Ptr plugin_ptr);
 
   /**
@@ -167,22 +182,6 @@ private:
   virtual bool initializeRecoveryPlugin(
       const std::string& name,
       const mbf_abstract_core::AbstractRecovery::Ptr& behavior_ptr);
-
-
-  /**
-   * @brief Check whether the costmaps should be activated.
-   */
-  void checkActivateCostmaps();
-
-  /**
-   * @brief Check whether the costmaps should and could be deactivated
-   */
-  void checkDeactivateCostmaps();
-
-  /**
-   * @brief Timer-triggered deactivation of both costmaps.
-   */
-  void deactivateCostmaps(const ros::TimerEvent &event);
 
   /**
    * @brief Callback method for the check_point_cost service
@@ -246,10 +245,10 @@ private:
   bool setup_reconfigure_;
 
   //! Shared pointer to the common local costmap
-  CostmapPtr local_costmap_ptr_;
+  const CostmapWrapper::Ptr local_costmap_ptr_;
 
   //! Shared pointer to the common global costmap
-  CostmapPtr global_costmap_ptr_;
+  const CostmapWrapper::Ptr global_costmap_ptr_;
 
   //! Service Server for the check_point_cost service
   ros::ServiceServer check_point_cost_srv_;
@@ -262,15 +261,6 @@ private:
 
   //! Service Server for the clear_costmap service
   ros::ServiceServer clear_costmaps_srv_;
-
-  //! Stop updating costmaps when not planning or controlling, if true
-  bool shutdown_costmaps_;
-  uint16_t costmaps_users_;               //!< keep track of plugins using costmaps
-  ros::Timer shutdown_costmaps_timer_;    //!< costmpas delayed shutdown timer
-  ros::Duration shutdown_costmaps_delay_; //!< costmpas delayed shutdown delay
-
-  //! Start/stop costmaps mutex; concurrent calls to start can lead to segfault
-  boost::mutex check_costmaps_mutex_;
 };
 
 } /* namespace mbf_costmap_nav */

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_planner_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_planner_execution.h
@@ -87,7 +87,6 @@ private:
    */
   void preRun()
   {
-    ROS_WARN("OK  pre run  %s", name_.c_str());
     costmap_ptr_->checkActivate();
   };
 
@@ -97,7 +96,6 @@ private:
    */
   void postRun()
   {
-    ROS_WARN("OK  post run  %s", name_.c_str());
     costmap_ptr_->checkDeactivate();
   };
 

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_recovery_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_recovery_execution.h
@@ -92,7 +92,6 @@ private:
    */
   void preRun()
   {
-    ROS_WARN("OK  pre run  %s", name_.c_str());
     local_costmap_->checkActivate();
     global_costmap_->checkActivate();
   };
@@ -103,18 +102,17 @@ private:
    */
   void postRun()
   {
-    ROS_WARN("OK  post run  %s", name_.c_str());
     local_costmap_->checkDeactivate();
     global_costmap_->checkDeactivate();
   };
+
+  mbf_abstract_nav::MoveBaseFlexConfig toAbstract(const MoveBaseFlexConfig &config);
 
   //! Shared pointer to the global costmap
   const CostmapWrapper::Ptr &global_costmap_;
 
   //! Shared pointer to thr local costmap
   const CostmapWrapper::Ptr &local_costmap_;
-
-  mbf_abstract_nav::MoveBaseFlexConfig toAbstract(const MoveBaseFlexConfig &config);
 };
 
 } /* namespace mbf_costmap_nav */

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_wrapper.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_wrapper.h
@@ -1,0 +1,119 @@
+/*
+ *  Copyright 2019, Magazino GmbH, Sebastian Pütz, Jorge Santos Simón
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  costmap_wrapper.h
+ *
+ *  authors:
+ *    Sebastian Pütz <spuetz@uni-osnabrueck.de>
+ *    Jorge Santos Simón <santos@magazino.eu>
+ *
+ */
+
+#ifndef MBF_COSTMAP_NAV__COSTMAP_WRAPPER_H_
+#define MBF_COSTMAP_NAV__COSTMAP_WRAPPER_H_
+
+#include <costmap_2d/costmap_2d_ros.h>
+
+#include <mbf_utility/types.h>
+
+
+namespace mbf_costmap_nav
+{
+/**
+ * @defgroup move_base_server Move Base Server
+ * @brief Classes belonging to the Move Base Server level.
+ */
+
+
+/**
+ * @brief The CostmapWrapper class manages access to a costmap by locking/unlocking its mutex and handles
+ * (de)activation.
+ *
+ * @ingroup navigation_server move_base_server
+ */
+class CostmapWrapper : public costmap_2d::Costmap2DROS
+{
+public:
+  typedef boost::shared_ptr<CostmapWrapper> Ptr;
+
+  /**
+   * @brief Constructor
+   * @param tf_listener_ptr Shared pointer to a common TransformListener
+   */
+  CostmapWrapper(const std::string &name, const TFPtr &tf_listener_ptr);
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~CostmapWrapper();
+
+  /**
+   * @brief Reconfiguration method called by dynamic reconfigure.
+   * @param shutdown_costmap Determines whether or not to shutdown the costmap when move_base_flex is inactive.
+   * @param shutdown_costmap_delay How long in seconds to wait after last action before shutting down the costmap.
+   */
+  void reconfigure(double shutdown_costmap, double shutdown_costmap_delay);
+
+  /**
+   * @brief Clear costmap.
+   */
+  void clear();
+
+  /**
+   * @brief Check whether the costmap should be activated.
+   */
+  void checkActivate();
+
+  /**
+   * @brief Check whether the costmap should and could be deactivated.
+   */
+  void checkDeactivate();
+
+private:
+  /**
+   * @brief Timer-triggered deactivation of the costmap.
+   */
+  void deactivate(const ros::TimerEvent &event);
+
+  //! Private node handle
+  ros::NodeHandle private_nh_;
+
+  bool shutdown_costmap_;                //!< don't update costmap when not using it
+  int16_t costmap_users_;                //!< keep track of plugins using costmap
+  ros::Timer shutdown_costmap_timer_;    //!< costmap delayed shutdown timer
+  ros::Duration shutdown_costmap_delay_; //!< costmap delayed shutdown delay
+  boost::mutex check_costmap_mutex_;     //!< Start/stop costmap mutex; concurrent calls to start can lead to segfault
+};
+
+} /* namespace mbf_costmap_nav */
+
+#endif /* MBF_COSTMAP_NAV__COSTMAP_WRAPPER_H_ */

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
@@ -91,4 +91,15 @@ uint32_t CostmapControllerExecution::computeVelocityCmd(
   return controller_->computeVelocityCommands(robot_pose, robot_velocity, vel_cmd, message);
 }
 
+bool CostmapControllerExecution::isSafeToDrive()
+{
+  // Check that the observation buffers for the costmap are current, we don't want to drive blind
+  if (!costmap_ptr_->isCurrent())
+  {
+    ROS_WARN("Sensor data is out of date, we're not going to allow commanding of the base for safety");
+    return false;
+  }
+  return true;
+}
+
 } /* namespace mbf_costmap_nav */

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
@@ -43,17 +43,15 @@ namespace mbf_costmap_nav
 {
 
 CostmapControllerExecution::CostmapControllerExecution(
-    const std::string name,
+    const std::string &controller_name,
     const mbf_costmap_core::CostmapController::Ptr &controller_ptr,
-    const ros::Publisher& vel_pub,
-    const ros::Publisher& goal_pub,
+    const ros::Publisher &vel_pub,
+    const ros::Publisher &goal_pub,
     const TFPtr &tf_listener_ptr,
-    CostmapPtr &costmap_ptr,
-    const MoveBaseFlexConfig &config,
-    boost::function<void()> setup_fn,
-    boost::function<void()> cleanup_fn)
-      : AbstractControllerExecution(name, controller_ptr, vel_pub, goal_pub, tf_listener_ptr,
-          toAbstract(config), setup_fn, cleanup_fn),
+    const CostmapWrapper::Ptr &costmap_ptr,
+    const MoveBaseFlexConfig &config)
+      : AbstractControllerExecution(controller_name, controller_ptr, vel_pub, goal_pub,
+                                    tf_listener_ptr, toAbstract(config)),
         costmap_ptr_(costmap_ptr)
 {
   ros::NodeHandle private_nh("~");
@@ -91,7 +89,7 @@ uint32_t CostmapControllerExecution::computeVelocityCmd(
   return controller_->computeVelocityCommands(robot_pose, robot_velocity, vel_cmd, message);
 }
 
-bool CostmapControllerExecution::isSafeToDrive()
+bool CostmapControllerExecution::safetyCheck()
 {
   // Check that the observation buffers for the costmap are current, we don't want to drive blind
   if (!costmap_ptr_->isCurrent())

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_planner_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_planner_execution.cpp
@@ -45,13 +45,11 @@ namespace mbf_costmap_nav
 {
 
 CostmapPlannerExecution::CostmapPlannerExecution(
-    const std::string name,
+    const std::string &planner_name,
     const mbf_costmap_core::CostmapPlanner::Ptr &planner_ptr,
-    CostmapPtr &costmap_ptr,
-    const MoveBaseFlexConfig &config,
-    boost::function<void()> setup_fn,
-    boost::function<void()> cleanup_fn)
-      : AbstractPlannerExecution(name, planner_ptr, toAbstract(config), setup_fn, cleanup_fn),
+    const CostmapWrapper::Ptr &costmap_ptr,
+    const MoveBaseFlexConfig &config)
+      : AbstractPlannerExecution(planner_name, planner_ptr, toAbstract(config)),
         costmap_ptr_(costmap_ptr)
 {
   ros::NodeHandle private_nh("~");

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_recovery_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_recovery_execution.cpp
@@ -45,14 +45,13 @@ namespace mbf_costmap_nav
 {
 
 CostmapRecoveryExecution::CostmapRecoveryExecution(
-    const std::string name,
+    const std::string &recovery_name,
     const mbf_costmap_core::CostmapRecovery::Ptr &recovery_ptr,
     const TFPtr &tf_listener_ptr,
-    CostmapPtr &global_costmap, CostmapPtr &local_costmap,
-    const MoveBaseFlexConfig &config,
-    boost::function<void()> setup_fn,
-    boost::function<void()> cleanup_fn)
-      : AbstractRecoveryExecution(name, recovery_ptr, tf_listener_ptr, toAbstract(config), setup_fn, cleanup_fn),
+    const CostmapWrapper::Ptr &global_costmap,
+    const CostmapWrapper::Ptr &local_costmap,
+    const MoveBaseFlexConfig &config)
+      : AbstractRecoveryExecution(recovery_name, recovery_ptr, tf_listener_ptr, toAbstract(config)),
         global_costmap_(global_costmap), local_costmap_(local_costmap)
 {
 }

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_wrapper.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_wrapper.cpp
@@ -102,7 +102,7 @@ void CostmapWrapper::checkActivate()
   if (shutdown_costmap_ && !costmap_users_)
   {
     start();
-    ROS_INFO_STREAM("" << name_ << " activated");
+    ROS_DEBUG_STREAM("" << name_ << " activated");
   }
   ++costmap_users_;
 }
@@ -129,7 +129,7 @@ void CostmapWrapper::deactivate(const ros::TimerEvent &event)
 
   ROS_ASSERT_MSG(!costmap_users_, "Deactivating costmap with %d active users!", costmap_users_);
   stop();
-  ROS_INFO_STREAM("" << name_ << " deactivated");
+  ROS_DEBUG_STREAM("" << name_ << " deactivated");
 }
 
 } /* namespace mbf_costmap_nav */

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_wrapper.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_wrapper.cpp
@@ -1,0 +1,135 @@
+/*
+ *  Copyright 2019, Magazino GmbH, Sebastian Pütz, Jorge Santos Simón
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  costmap_wrapper.cpp
+ *
+ *  authors:
+ *    Sebastian Pütz <spuetz@uni-osnabrueck.de>
+ *    Jorge Santos Simón <santos@magazino.eu>
+ *
+ */
+
+#include "mbf_costmap_nav/costmap_wrapper.h"
+
+
+namespace mbf_costmap_nav
+{
+
+
+CostmapWrapper::CostmapWrapper(const std::string &name, const TFPtr &tf_listener_ptr) :
+  costmap_2d::Costmap2DROS(name, *tf_listener_ptr),
+  shutdown_costmap_(false), costmap_users_(0), private_nh_("~")
+{
+  // even if shutdown_costmaps is a dynamically reconfigurable parameter, we
+  // need it here to decide whether to start or not the costmap on starting up
+  private_nh_.param("shutdown_costmaps", shutdown_costmap_, false);
+
+  if (shutdown_costmap_)
+    // initialize costmap stopped if shutdown_costmaps parameter is true
+    stop();
+  else
+    // otherwise costmap_users_ is at least 1, as costmap is always active
+    ++costmap_users_;
+}
+
+CostmapWrapper::~CostmapWrapper()
+{
+}
+
+
+void CostmapWrapper::reconfigure(double shutdown_costmap, double shutdown_costmap_delay)
+{
+  shutdown_costmap_delay_ = ros::Duration(shutdown_costmap_delay);
+  if (shutdown_costmap_delay_.isZero())
+    ROS_WARN("Zero shutdown costmaps delay is not recommended, as it forces us to enable costmaps on each action");
+
+  if (shutdown_costmap_ && !shutdown_costmap)
+  {
+    checkActivate();
+    shutdown_costmap_ = shutdown_costmap;
+  }
+  if (!shutdown_costmap_ && shutdown_costmap)
+  {
+    shutdown_costmap_ = shutdown_costmap;
+    checkDeactivate();
+  }
+}
+
+void CostmapWrapper::clear()
+{
+  // lock and clear costmap
+  boost::unique_lock<costmap_2d::Costmap2D::mutex_t> lock(*getCostmap()->getMutex());
+  resetLayers();
+}
+
+void CostmapWrapper::checkActivate()
+{
+  boost::mutex::scoped_lock sl(check_costmap_mutex_);
+
+  shutdown_costmap_timer_.stop();
+
+  // Activate costmap if we shutdown them when not moving and they are not already active. This method must be
+  // synchronized because start costmap can take up to 1/update freq., and concurrent calls to it can lead to segfaults
+  if (shutdown_costmap_ && !costmap_users_)
+  {
+    start();
+    ROS_INFO_STREAM("" << name_ << " activated");
+  }
+  ++costmap_users_;
+}
+
+void CostmapWrapper::checkDeactivate()
+{
+  boost::mutex::scoped_lock sl(check_costmap_mutex_);
+
+  --costmap_users_;
+  ROS_ASSERT_MSG(costmap_users_ >= 0, "Negative number (%d) of active users count!", costmap_users_);
+  if (shutdown_costmap_ && !costmap_users_)
+  {
+    // Delay costmap shutdown by shutdown_costmap_delay so we don't need to enable at each step of a normal
+    // navigation sequence, what is terribly inefficient; the timer is stopped on costmap re-activation and
+    // reset after every new call to deactivate
+    shutdown_costmap_timer_ =
+      private_nh_.createTimer(shutdown_costmap_delay_, &CostmapWrapper::deactivate, this, true);
+  }
+}
+
+void CostmapWrapper::deactivate(const ros::TimerEvent &event)
+{
+  boost::mutex::scoped_lock sl(check_costmap_mutex_);
+
+  ROS_ASSERT_MSG(!costmap_users_, "Deactivating costmap with %d active users!", costmap_users_);
+  stop();
+  ROS_INFO_STREAM("" << name_ << " deactivated");
+}
+
+} /* namespace mbf_costmap_nav */


### PR DESCRIPTION
Run instead abstract methods (possibly) overridden in the costmap server
To do this I have refactored all costmap-related handling to a new CostmapWrapper class
In the process, I have also added/fixed many missing/wrong comments

This PR is an evolution of #141, so if merged, #141 can be discarded.

This is mostly to gain code clarity an simplicity. The only improvement on code behavior is that now we only enable/disable the local (for controllers) OR global (for planners) costmap, what can save time in some cases

**NOTE:** I still enable/disable both costmaps for recovery behaviors, because they receive a pointer to both. But I wonder if it makes sense to configure the recovery behaviors signaling which costmap(s) they use, and only enable/disable them

**TODO:** I let the debug prints intentionally; remove them before merging!