### PR TITLE
Add clear_on_shutdown functionality

### DIFF
--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_wrapper.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_wrapper.h
@@ -108,6 +108,7 @@ private:
   ros::NodeHandle private_nh_;
 
   bool shutdown_costmap_;                //!< don't update costmap when not using it
+  bool clear_on_shutdown_;               //!< clear the costmap, when shutting down
   int16_t costmap_users_;                //!< keep track of plugins using costmap
   ros::Timer shutdown_costmap_timer_;    //!< costmap delayed shutdown timer
   ros::Duration shutdown_costmap_delay_; //!< costmap delayed shutdown delay

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_wrapper.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_wrapper.cpp
@@ -52,6 +52,7 @@ CostmapWrapper::CostmapWrapper(const std::string &name, const TFPtr &tf_listener
   // even if shutdown_costmaps is a dynamically reconfigurable parameter, we
   // need it here to decide whether to start or not the costmap on starting up
   private_nh_.param("shutdown_costmaps", shutdown_costmap_, false);
+  private_nh_.param("clear_on_shutdown", clear_on_shutdown_, false);
 
   if (shutdown_costmap_)
     // initialize costmap stopped if shutdown_costmaps parameter is true
@@ -130,6 +131,8 @@ void CostmapWrapper::deactivate(const ros::TimerEvent &event)
   ROS_ASSERT_MSG(!costmap_users_, "Deactivating costmap with %d active users!", costmap_users_);
   stop();
   ROS_DEBUG_STREAM("" << name_ << " deactivated");
+  if(clear_on_shutdown_)
+    clear();
 }
 
 } /* namespace mbf_costmap_nav */


### PR DESCRIPTION

Pull request implements an optional functionality to clear the costmaps once they have been shutdown. The functionality will not change the current behaviour if not explicitly enabled 