### PR TITLE
Update goal pose on replanning, so the feedback remains consistent

### DIFF
--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -77,6 +77,8 @@ void ControllerAction::start(
       // we update the goal handle and pass the new plan to the execution without stopping it
       execution_ptr = slot_it->second.execution;
       execution_ptr->setNewPlan(goal_handle.getGoal()->path.poses);
+      // Update also goal pose, so the feedback remains consistent
+      goal_pose_ = goal_handle.getGoal()->path.poses.back();
       mbf_msgs::ExePathResult result;
       fillExePathResult(mbf_msgs::ExePathResult::CANCELED, "Goal preempted by a new plan", result);
       concurrency_slots_[slot].goal_handle.setCanceled(result, result.message);


### PR DESCRIPTION
Thanks to @karan-narula for reporting the bug