### PR TITLE
add parameter to actively stop once the goal is reached

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -332,6 +332,9 @@ namespace mbf_abstract_nav
     //! whether move base flex should check for the goal tolerance or not.
     bool mbf_tolerance_check_;
 
+    //! whether move base flex should stop the robot once the goal is reached.
+    bool stop_at_goal_;
+
     //! distance tolerance to the given goal pose
     double dist_tolerance_;
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -332,8 +332,8 @@ namespace mbf_abstract_nav
     //! whether move base flex should check for the goal tolerance or not.
     bool mbf_tolerance_check_;
 
-    //! whether move base flex should stop the robot once the goal is reached.
-    bool stop_at_goal_;
+    //! whether move base flex should force the robot to stop once the goal is reached.
+    bool force_stop_at_goal_;
 
     //! distance tolerance to the given goal pose
     double dist_tolerance_;

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -65,7 +65,7 @@ namespace mbf_abstract_nav
     private_nh.param("robot_frame", robot_frame_, std::string("base_link"));
     private_nh.param("map_frame", global_frame_, std::string("map"));
     private_nh.param("mbf_tolerance_check", mbf_tolerance_check_, false);
-    private_nh.param("stop_at_goal", stop_at_goal_, true);
+    private_nh.param("force_stop_at_goal", force_stop_at_goal_, true);
     private_nh.param("dist_tolerance", dist_tolerance_, 0.1);
     private_nh.param("angle_tolerance", angle_tolerance_, M_PI / 18.0);
     private_nh.param("tf_timeout", tf_timeout_, 1.0);
@@ -317,7 +317,7 @@ namespace mbf_abstract_nav
         if (reachedGoalCheck())
         {
           ROS_DEBUG_STREAM_NAMED("abstract_controller_execution", "Reached the goal!");
-          if (stop_at_goal_) {
+          if (force_stop_at_goal_) {
             publishZeroVelocity();
           }
           setState(ARRIVED_GOAL);

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -65,6 +65,7 @@ namespace mbf_abstract_nav
     private_nh.param("robot_frame", robot_frame_, std::string("base_link"));
     private_nh.param("map_frame", global_frame_, std::string("map"));
     private_nh.param("mbf_tolerance_check", mbf_tolerance_check_, false);
+    private_nh.param("stop_at_goal", stop_at_goal_, true);
     private_nh.param("dist_tolerance", dist_tolerance_, 0.1);
     private_nh.param("angle_tolerance", angle_tolerance_, M_PI / 18.0);
     private_nh.param("tf_timeout", tf_timeout_, 1.0);
@@ -316,6 +317,9 @@ namespace mbf_abstract_nav
         if (reachedGoalCheck())
         {
           ROS_DEBUG_STREAM_NAMED("abstract_controller_execution", "Reached the goal!");
+          if (stop_at_goal_) {
+            publishZeroVelocity();
+          }
           setState(ARRIVED_GOAL);
           // goal reached, tell it the controller
           condition_.notify_all();

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -65,7 +65,7 @@ namespace mbf_abstract_nav
     private_nh.param("robot_frame", robot_frame_, std::string("base_link"));
     private_nh.param("map_frame", global_frame_, std::string("map"));
     private_nh.param("mbf_tolerance_check", mbf_tolerance_check_, false);
-    private_nh.param("force_stop_at_goal", force_stop_at_goal_, true);
+    private_nh.param("force_stop_at_goal", force_stop_at_goal_, false);
     private_nh.param("dist_tolerance", dist_tolerance_, 0.1);
     private_nh.param("angle_tolerance", angle_tolerance_, M_PI / 18.0);
     private_nh.param("tf_timeout", tf_timeout_, 1.0);


### PR DESCRIPTION
Related to Issue #109, the current implementation (correct me if I'm wrong) requires one to delegate the responsibility to stop the robot to the local planner. If someone wanted to ensure that the robot stopped at a goal, one would have to do the following:
- The local planner has to return false for `isGoalReached()` if the robot isn't stopped yet (i.e. if last call to `computeVelocityCmd()` did not set `cmd_vel` to zero)
- `mbf_tolerance_check_` needs to be false (otherwise above doesn't work)
- You can probably not use multiple local planners, because this method relies on the planner's last internally calculated velocity command being the last one that was published by move_base_flex

This is not very nice; as the thread in the issue suggests, this should be handled by a configurable parameter.

I verified on my system that adding these changes stops the robot at the goal (by modifying the local planner to return non-zero commands in all cases)