### PR TITLE
Rename abstract_action.h as abstract_action_base.hpp

### DIFF
--- a/mbf_abstract_nav/CMakeLists.txt
+++ b/mbf_abstract_nav/CMakeLists.txt
@@ -58,7 +58,7 @@ include_directories(
 )
 
 add_library(${MBF_ABSTRACT_SERVER_LIB}
-  src/robot_Information.cpp
+  src/robot_information.cpp
   src/controller_action.cpp
   src/planner_action.cpp
   src/recovery_action.cpp

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -36,8 +36,8 @@
  *
  */
 
-#ifndef MBF_ABSTRACT_NAV__ABSTRACT_ACTION_H_
-#define MBF_ABSTRACT_NAV__ABSTRACT_ACTION_H_
+#ifndef MBF_ABSTRACT_NAV__ABSTRACT_ACTION_BASE_H_
+#define MBF_ABSTRACT_NAV__ABSTRACT_ACTION_BASE_H_
 
 #include <actionlib/server/action_server.h>
 #include <mbf_abstract_nav/MoveBaseFlexConfig.h>
@@ -46,10 +46,10 @@
 namespace mbf_abstract_nav{
 
 template <typename Action, typename Execution>
-class AbstractAction
+class AbstractActionBase
 {
  public:
-  typedef boost::shared_ptr<AbstractAction> Ptr;
+  typedef boost::shared_ptr<AbstractActionBase> Ptr;
   typedef typename actionlib::ActionServer<Action>::GoalHandle GoalHandle;
   typedef boost::function<void (GoalHandle &goal_handle, Execution &execution)> RunMethod;
   typedef struct{
@@ -59,7 +59,7 @@ class AbstractAction
   } ConcurrencySlot;
 
 
-  AbstractAction(
+  AbstractActionBase(
       const std::string& name,
       const RobotInformation &robot_info,
       const RunMethod run_method
@@ -94,7 +94,7 @@ class AbstractAction
       concurrency_slots_[slot].goal_handle.setAccepted();
       concurrency_slots_[slot].execution = execution_ptr;
       concurrency_slots_[slot].thread_ptr = threads_.create_thread(boost::bind(
-          &AbstractAction::runAndCleanUp, this,
+          &AbstractActionBase::runAndCleanUp, this,
           boost::ref(concurrency_slots_[slot].goal_handle), execution_ptr));
     }
   }
@@ -166,4 +166,4 @@ protected:
 
 }
 
-#endif //MBF_ABSTRACT_NAV__ABSTRACT_ACTION_H_
+#endif /* MBF_ABSTRACT_NAV__ABSTRACT_ACTION_BASE_H_ */

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -59,6 +59,7 @@
 
 namespace mbf_abstract_nav
 {
+
 /**
  * @defgroup controller_execution Controller Execution Classes
  * @brief The controller execution classes are derived from the AbstractControllerExecution and extends the

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
@@ -113,6 +113,7 @@ protected:
   //! the plugin name; not the plugin type!
   std::string name_;
 };
+
 } /* namespace mbf_abstract_nav */
 
 #endif  /* MBF_ABSTRACT_NAV__ABSTRACT_EXECUTION_BASE_H_ */

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
@@ -68,6 +68,7 @@
 
 namespace mbf_abstract_nav
 {
+
 /**
  * @defgroup abstract_server Abstract Server
  * @brief Classes belonging to the Abstract Server level.
@@ -381,4 +382,4 @@ typedef boost::shared_ptr<dynamic_reconfigure::Server<mbf_abstract_nav::MoveBase
 
 } /* namespace mbf_abstract_nav */
 
-#endif /* navigation_controller.h */
+#endif /* MBF_ABSTRACT_NAV__ABSTRACT_NAVIGATION_SERVER_H_ */

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_plugin_manager.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_plugin_manager.h
@@ -41,7 +41,8 @@
 
 #include <boost/function.hpp>
 
-namespace mbf_abstract_nav{
+namespace mbf_abstract_nav
+{
 
 template <typename PluginType>
 class AbstractPluginManager
@@ -75,7 +76,8 @@ class AbstractPluginManager
   const loadPluginFunction loadPlugin_;
   const initPluginFunction initPlugin_;
 };
+
 } /* namespace mbf_abstract_nav */
 
 #include "impl/abstract_plugin_manager.tcc"
-#endif //MBF_ABSTRACT_NAV__ABSTRACT_PLUGIN_MANAGER_H_
+#endif /* MBF_ABSTRACT_NAV__ABSTRACT_PLUGIN_MANAGER_H_ */

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
@@ -59,6 +59,7 @@
 
 namespace mbf_abstract_nav
 {
+
 /**
  * @defgroup recovery_execution Recovery Execution Classes
  * @brief The recovery execution classes are derived from the RecoveryPlannerExecution and extends the functionality.

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -41,16 +41,17 @@
 #ifndef MBF_ABSTRACT_NAV__CONTROLLER_ACTION_H_
 #define MBF_ABSTRACT_NAV__CONTROLLER_ACTION_H_
 
-#include "mbf_abstract_nav/abstract_action.h"
+#include "mbf_abstract_nav/abstract_action_base.hpp"
 #include "mbf_abstract_nav/abstract_controller_execution.h"
 #include "mbf_abstract_nav/robot_information.h"
 #include <actionlib/server/action_server.h>
 #include <mbf_msgs/ExePathAction.h>
 
-namespace mbf_abstract_nav{
+namespace mbf_abstract_nav
+{
 
 class ControllerAction :
-    public AbstractAction<mbf_msgs::ExePathAction, AbstractControllerExecution>
+    public AbstractActionBase<mbf_msgs::ExePathAction, AbstractControllerExecution>
 {
  public:
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
@@ -41,7 +41,7 @@
 #ifndef MBF_ABSTRACT_NAV__PLANNER_ACTION_H_
 #define MBF_ABSTRACT_NAV__PLANNER_ACTION_H_
 
-#include "mbf_abstract_nav/abstract_action.h"
+#include "mbf_abstract_nav/abstract_action_base.hpp"
 #include "mbf_abstract_nav/abstract_planner_execution.h"
 #include "mbf_abstract_nav/robot_information.h"
 #include <actionlib/server/action_server.h>
@@ -50,7 +50,7 @@
 namespace mbf_abstract_nav{
 
 
-class PlannerAction : public AbstractAction<mbf_msgs::GetPathAction, AbstractPlannerExecution>
+class PlannerAction : public AbstractActionBase<mbf_msgs::GetPathAction, AbstractPlannerExecution>
 {
  public:
 
@@ -84,8 +84,6 @@ class PlannerAction : public AbstractAction<mbf_msgs::GetPathAction, AbstractPla
   unsigned int path_seq_count_;
 };
 
+} /* mbf_abstract_nav */
 
-}
-
-
-#endif //MBF_ABSTRACT_NAV__PLANNER_ACTION_H_
+#endif /* MBF_ABSTRACT_NAV__PLANNER_ACTION_H_ */

--- a/mbf_abstract_nav/include/mbf_abstract_nav/recovery_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/recovery_action.h
@@ -41,7 +41,7 @@
 #ifndef MBF_ABSTRACT_NAV__RECOVERY_ACTION_H_
 #define MBF_ABSTRACT_NAV__RECOVERY_ACTION_H_
 
-#include "mbf_abstract_nav/abstract_action.h"
+#include "mbf_abstract_nav/abstract_action_base.hpp"
 #include "mbf_abstract_nav/abstract_recovery_execution.h"
 #include "mbf_abstract_nav/robot_information.h"
 #include <actionlib/server/action_server.h>
@@ -50,7 +50,7 @@
 
 namespace mbf_abstract_nav{
 
-class RecoveryAction : public AbstractAction<mbf_msgs::RecoveryAction, AbstractRecoveryExecution>
+class RecoveryAction : public AbstractActionBase<mbf_msgs::RecoveryAction, AbstractRecoveryExecution>
 {
  public:
 
@@ -62,7 +62,6 @@ class RecoveryAction : public AbstractAction<mbf_msgs::RecoveryAction, AbstractR
 
 };
 
-}
+} /* mbf_abstract_nav */
 
-
-#endif //MBF_ABSTRACT_NAV__RECOVERY_ACTION_H_
+#endif /* MBF_ABSTRACT_NAV__RECOVERY_ACTION_H_ */

--- a/mbf_abstract_nav/include/mbf_abstract_nav/robot_information.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/robot_information.h
@@ -85,5 +85,6 @@ class RobotInformation{
 
 };
 
-}
-#endif //MBF_ABSTRACT_NAV__ROBOT_INFORMATION_H_
+} /* mbf_abstract_nav */
+
+#endif /* MBF_ABSTRACT_NAV__ROBOT_INFORMATION_H_ */

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -44,390 +44,390 @@
 namespace mbf_abstract_nav
 {
 
-  const double AbstractControllerExecution::DEFAULT_CONTROLLER_FREQUENCY = 100.0; // 100 Hz
+const double AbstractControllerExecution::DEFAULT_CONTROLLER_FREQUENCY = 100.0; // 100 Hz
 
-  AbstractControllerExecution::AbstractControllerExecution(
-      const std::string name,
-      const mbf_abstract_core::AbstractController::Ptr& controller_ptr,
-      const ros::Publisher& vel_pub,
-      const ros::Publisher& goal_pub,
-      const TFPtr &tf_listener_ptr,
-      const MoveBaseFlexConfig &config) :
-    AbstractExecutionBase(name),
-      controller_(controller_ptr), tf_listener_ptr(tf_listener_ptr), state_(INITIALIZED),
-      moving_(false), max_retries_(0), patience_(0), vel_pub_(vel_pub), current_goal_pub_(goal_pub),
-      calling_duration_(boost::chrono::microseconds(static_cast<int>(1e6 / DEFAULT_CONTROLLER_FREQUENCY)))
+AbstractControllerExecution::AbstractControllerExecution(
+    const std::string name,
+    const mbf_abstract_core::AbstractController::Ptr& controller_ptr,
+    const ros::Publisher& vel_pub,
+    const ros::Publisher& goal_pub,
+    const TFPtr &tf_listener_ptr,
+    const MoveBaseFlexConfig &config) :
+  AbstractExecutionBase(name),
+    controller_(controller_ptr), tf_listener_ptr(tf_listener_ptr), state_(INITIALIZED),
+    moving_(false), max_retries_(0), patience_(0), vel_pub_(vel_pub), current_goal_pub_(goal_pub),
+    calling_duration_(boost::chrono::microseconds(static_cast<int>(1e6 / DEFAULT_CONTROLLER_FREQUENCY)))
+{
+  ros::NodeHandle nh;
+  ros::NodeHandle private_nh("~");
+
+  // non-dynamically reconfigurable parameters
+  private_nh.param("robot_frame", robot_frame_, std::string("base_link"));
+  private_nh.param("map_frame", global_frame_, std::string("map"));
+  private_nh.param("mbf_tolerance_check", mbf_tolerance_check_, false);
+  private_nh.param("force_stop_at_goal", force_stop_at_goal_, false);
+  private_nh.param("dist_tolerance", dist_tolerance_, 0.1);
+  private_nh.param("angle_tolerance", angle_tolerance_, M_PI / 18.0);
+  private_nh.param("tf_timeout", tf_timeout_, 1.0);
+
+  // dynamically reconfigurable parameters
+  reconfigure(config);
+}
+
+AbstractControllerExecution::~AbstractControllerExecution()
+{
+}
+
+bool AbstractControllerExecution::setControllerFrequency(double frequency)
+{
+  // set the calling duration by the moving frequency
+  if (frequency <= 0.0)
   {
-    ros::NodeHandle nh;
-    ros::NodeHandle private_nh("~");
+    ROS_ERROR("Controller frequency must be greater than 0.0! No change of the frequency!");
+    return false;
+  }
+  calling_duration_ = boost::chrono::microseconds(static_cast<int>(1e6 / frequency));
+  return true;
+}
 
-    // non-dynamically reconfigurable parameters
-    private_nh.param("robot_frame", robot_frame_, std::string("base_link"));
-    private_nh.param("map_frame", global_frame_, std::string("map"));
-    private_nh.param("mbf_tolerance_check", mbf_tolerance_check_, false);
-    private_nh.param("force_stop_at_goal", force_stop_at_goal_, false);
-    private_nh.param("dist_tolerance", dist_tolerance_, 0.1);
-    private_nh.param("angle_tolerance", angle_tolerance_, M_PI / 18.0);
-    private_nh.param("tf_timeout", tf_timeout_, 1.0);
+void AbstractControllerExecution::reconfigure(const MoveBaseFlexConfig &config)
+{
+  boost::lock_guard<boost::mutex> guard(configuration_mutex_);
+  // Timeout granted to the controller. We keep calling it up to this time or up to max_retries times
+  // If it doesn't return within time, the navigator will cancel it and abort the corresponding action
+  patience_ = ros::Duration(config.controller_patience);
 
-    // dynamically reconfigurable parameters
-    reconfigure(config);
+  setControllerFrequency(config.controller_frequency);
+
+  max_retries_ = config.controller_max_retries;
+}
+
+
+bool AbstractControllerExecution::start()
+{
+  setState(STARTED);
+  if (moving_)
+  {
+    return false; // thread is already running.
+  }
+  moving_ = true;
+  return AbstractExecutionBase::start();
+}
+
+
+void AbstractControllerExecution::setState(ControllerState state)
+{
+  boost::lock_guard<boost::mutex> guard(state_mtx_);
+  state_ = state;
+}
+
+
+typename AbstractControllerExecution::ControllerState
+AbstractControllerExecution::getState()
+{
+  boost::lock_guard<boost::mutex> guard(state_mtx_);
+  return state_;
+}
+
+void AbstractControllerExecution::setNewPlan(const std::vector<geometry_msgs::PoseStamped> &plan)
+{
+  if (moving_)
+  {
+    // This is fine on continuous replanning
+    ROS_DEBUG("Setting new plan while moving");
+  }
+  boost::lock_guard<boost::mutex> guard(plan_mtx_);
+  new_plan_ = true;
+
+  plan_ = plan;
+}
+
+
+bool AbstractControllerExecution::hasNewPlan()
+{
+  boost::lock_guard<boost::mutex> guard(plan_mtx_);
+  return new_plan_;
+}
+
+
+std::vector<geometry_msgs::PoseStamped> AbstractControllerExecution::getNewPlan()
+{
+  boost::lock_guard<boost::mutex> guard(plan_mtx_);
+  new_plan_ = false;
+  return plan_;
+}
+
+
+bool AbstractControllerExecution::computeRobotPose()
+{
+  bool tf_success = mbf_utility::getRobotPose(*tf_listener_ptr, robot_frame_, global_frame_,
+                                              ros::Duration(tf_timeout_), robot_pose_);
+  // would be 0 if not, as we ask tf listener for the last pose available
+  robot_pose_.header.stamp = ros::Time::now();
+  if (!tf_success)
+  {
+    ROS_ERROR_STREAM("Could not get the robot pose in the global frame. - robot frame: \""
+                         << robot_frame_ << "\"   global frame: \"" << global_frame_ << std::endl);
+    message_ = "Could not get the robot pose";
+    outcome_ = mbf_msgs::ExePathResult::TF_ERROR;
+    return false;
+  }
+  return true;
+}
+
+
+uint32_t AbstractControllerExecution::computeVelocityCmd(const geometry_msgs::PoseStamped& robot_pose,
+                                                         const geometry_msgs::TwistStamped& robot_velocity,
+                                                         geometry_msgs::TwistStamped& vel_cmd,
+                                                         std::string& message)
+{
+  return controller_->computeVelocityCommands(robot_pose, robot_velocity, vel_cmd, message);
+}
+
+
+void AbstractControllerExecution::setVelocityCmd(const geometry_msgs::TwistStamped &vel_cmd)
+{
+  boost::lock_guard<boost::mutex> guard(vel_cmd_mtx_);
+  vel_cmd_stamped_ = vel_cmd;
+  if (vel_cmd_stamped_.header.stamp.isZero())
+    vel_cmd_stamped_.header.stamp = ros::Time::now();
+  // TODO what happen with frame id?
+  // TODO Add a queue here for handling the outcome, message and cmd_vel values bundled,
+  // TODO so there should be no loss of information in the feedback stream
+}
+
+
+geometry_msgs::TwistStamped AbstractControllerExecution::getVelocityCmd()
+{
+  boost::lock_guard<boost::mutex> guard(vel_cmd_mtx_);
+  return vel_cmd_stamped_;
+}
+
+
+ros::Time AbstractControllerExecution::getLastPluginCallTime()
+{
+  boost::lock_guard<boost::mutex> guard(lct_mtx_);
+  return last_call_time_;
+}
+
+
+bool AbstractControllerExecution::isPatienceExceeded()
+{
+  boost::lock_guard<boost::mutex> guard(lct_mtx_);
+  return !patience_.isZero() && (ros::Time::now() - last_call_time_ > patience_);
+}
+
+
+bool AbstractControllerExecution::isMoving()
+{
+  return moving_;
+}
+
+bool AbstractControllerExecution::reachedGoalCheck()
+{
+  // check whether the controller plugin returns goal reached or if mbf should check for goal reached.
+  return controller_->isGoalReached(dist_tolerance_, angle_tolerance_) || (mbf_tolerance_check_
+      && mbf_utility::distance(robot_pose_, plan_.back()) < dist_tolerance_
+      && mbf_utility::angle(robot_pose_, plan_.back()) < angle_tolerance_);
+}
+
+bool AbstractControllerExecution::cancel()
+{
+  cancel_ = true;
+  // returns false if cancel is not implemented or rejected by the recovery behavior (will run until completion)
+  if(!controller_->cancel())
+  {
+    ROS_WARN_STREAM("Cancel controlling failed or is not supported by the plugin. "
+                        << "Wait until the current control cycle finished!");
+    return false;
+  }
+  return true;
+}
+
+
+void AbstractControllerExecution::run()
+{
+  start_time_ = ros::Time::now();
+
+  // init plan
+  std::vector<geometry_msgs::PoseStamped> plan;
+  if (!hasNewPlan())
+  {
+    setState(NO_PLAN);
+    moving_ = false;
+    ROS_ERROR("robot navigation moving has no plan!");
   }
 
-  AbstractControllerExecution::~AbstractControllerExecution()
-  {
-  }
+  ros::Time last_valid_cmd_time = ros::Time();
+  int retries = 0;
+  int seq = 0;
 
-  bool AbstractControllerExecution::setControllerFrequency(double frequency)
+  try
   {
-    // set the calling duration by the moving frequency
-    if (frequency <= 0.0)
+    while (moving_ && ros::ok())
     {
-      ROS_ERROR("Controller frequency must be greater than 0.0! No change of the frequency!");
-      return false;
-    }
-    calling_duration_ = boost::chrono::microseconds(static_cast<int>(1e6 / frequency));
-    return true;
-  }
+      boost::chrono::thread_clock::time_point loop_start_time = boost::chrono::thread_clock::now();
 
-  void AbstractControllerExecution::reconfigure(const MoveBaseFlexConfig &config)
-  {
-    boost::lock_guard<boost::mutex> guard(configuration_mutex_);
-    // Timeout granted to the controller. We keep calling it up to this time or up to max_retries times
-    // If it doesn't return within time, the navigator will cancel it and abort the corresponding action
-    patience_ = ros::Duration(config.controller_patience);
-
-    setControllerFrequency(config.controller_frequency);
-
-    max_retries_ = config.controller_max_retries;
-  }
-
-
-  bool AbstractControllerExecution::start()
-  {
-    setState(STARTED);
-    if (moving_)
-    {
-      return false; // thread is already running.
-    }
-    moving_ = true;
-    return AbstractExecutionBase::start();
-  }
-
-
-  void AbstractControllerExecution::setState(ControllerState state)
-  {
-    boost::lock_guard<boost::mutex> guard(state_mtx_);
-    state_ = state;
-  }
-
-
-  typename AbstractControllerExecution::ControllerState
-  AbstractControllerExecution::getState()
-  {
-    boost::lock_guard<boost::mutex> guard(state_mtx_);
-    return state_;
-  }
-
-  void AbstractControllerExecution::setNewPlan(const std::vector<geometry_msgs::PoseStamped> &plan)
-  {
-    if (moving_)
-    {
-      // This is fine on continuous replanning
-      ROS_DEBUG("Setting new plan while moving");
-    }
-    boost::lock_guard<boost::mutex> guard(plan_mtx_);
-    new_plan_ = true;
-
-    plan_ = plan;
-  }
-
-
-  bool AbstractControllerExecution::hasNewPlan()
-  {
-    boost::lock_guard<boost::mutex> guard(plan_mtx_);
-    return new_plan_;
-  }
-
-
-  std::vector<geometry_msgs::PoseStamped> AbstractControllerExecution::getNewPlan()
-  {
-    boost::lock_guard<boost::mutex> guard(plan_mtx_);
-    new_plan_ = false;
-    return plan_;
-  }
-
-
-  bool AbstractControllerExecution::computeRobotPose()
-  {
-    bool tf_success = mbf_utility::getRobotPose(*tf_listener_ptr, robot_frame_, global_frame_,
-                                                ros::Duration(tf_timeout_), robot_pose_);
-    // would be 0 if not, as we ask tf listener for the last pose available
-    robot_pose_.header.stamp = ros::Time::now();
-    if (!tf_success)
-    {
-      ROS_ERROR_STREAM("Could not get the robot pose in the global frame. - robot frame: \""
-                           << robot_frame_ << "\"   global frame: \"" << global_frame_ << std::endl);
-      message_ = "Could not get the robot pose";
-      outcome_ = mbf_msgs::ExePathResult::TF_ERROR;
-      return false;
-    }
-    return true;
-  }
-
-
-  uint32_t AbstractControllerExecution::computeVelocityCmd(const geometry_msgs::PoseStamped& robot_pose,
-                                                           const geometry_msgs::TwistStamped& robot_velocity,
-                                                           geometry_msgs::TwistStamped& vel_cmd,
-                                                           std::string& message)
-  {
-    return controller_->computeVelocityCommands(robot_pose, robot_velocity, vel_cmd, message);
-  }
-
-
-  void AbstractControllerExecution::setVelocityCmd(const geometry_msgs::TwistStamped &vel_cmd)
-  {
-    boost::lock_guard<boost::mutex> guard(vel_cmd_mtx_);
-    vel_cmd_stamped_ = vel_cmd;
-    if (vel_cmd_stamped_.header.stamp.isZero())
-      vel_cmd_stamped_.header.stamp = ros::Time::now();
-    // TODO what happen with frame id?
-    // TODO Add a queue here for handling the outcome, message and cmd_vel values bundled,
-    // TODO so there should be no loss of information in the feedback stream
-  }
-
-
-  geometry_msgs::TwistStamped AbstractControllerExecution::getVelocityCmd()
-  {
-    boost::lock_guard<boost::mutex> guard(vel_cmd_mtx_);
-    return vel_cmd_stamped_;
-  }
-
-
-  ros::Time AbstractControllerExecution::getLastPluginCallTime()
-  {
-    boost::lock_guard<boost::mutex> guard(lct_mtx_);
-    return last_call_time_;
-  }
-
-
-  bool AbstractControllerExecution::isPatienceExceeded()
-  {
-    boost::lock_guard<boost::mutex> guard(lct_mtx_);
-    return !patience_.isZero() && (ros::Time::now() - last_call_time_ > patience_);
-  }
-
-
-  bool AbstractControllerExecution::isMoving()
-  {
-    return moving_;
-  }
-
-  bool AbstractControllerExecution::reachedGoalCheck()
-  {
-    // check whether the controller plugin returns goal reached or if mbf should check for goal reached.
-    return controller_->isGoalReached(dist_tolerance_, angle_tolerance_) || (mbf_tolerance_check_
-        && mbf_utility::distance(robot_pose_, plan_.back()) < dist_tolerance_
-        && mbf_utility::angle(robot_pose_, plan_.back()) < angle_tolerance_);
-  }
-
-  bool AbstractControllerExecution::cancel()
-  {
-    cancel_ = true;
-    // returns false if cancel is not implemented or rejected by the recovery behavior (will run until completion)
-    if(!controller_->cancel())
-    {
-      ROS_WARN_STREAM("Cancel controlling failed or is not supported by the plugin. "
-                          << "Wait until the current control cycle finished!");
-      return false;
-    }
-    return true;
-  }
-
-
-  void AbstractControllerExecution::run()
-  {
-    start_time_ = ros::Time::now();
-
-    // init plan
-    std::vector<geometry_msgs::PoseStamped> plan;
-    if (!hasNewPlan())
-    {
-      setState(NO_PLAN);
-      moving_ = false;
-      ROS_ERROR("robot navigation moving has no plan!");
-    }
-
-    ros::Time last_valid_cmd_time = ros::Time();
-    int retries = 0;
-    int seq = 0;
-
-    try
-    {
-      while (moving_ && ros::ok())
+      if (cancel_)
       {
-        boost::chrono::thread_clock::time_point loop_start_time = boost::chrono::thread_clock::now();
+        publishZeroVelocity(); // command the robot to stop on canceling navigation
+        setState(CANCELED);
+        condition_.notify_all();
+        moving_ = false;
+        return;
+      }
 
-        if (cancel_)
+      if (!safetyCheck())
+      {
+        // the specific implementation must have detected a risk situation; at this abstract level, we
+        // cannot tell what the problem is, but anyway we command the robot to stop to avoid crashes
+        publishZeroVelocity();   // note that we still feedback command calculated by the plugin
+        boost::this_thread::sleep_for(calling_duration_);
+      }
+
+      // update plan dynamically
+      if (hasNewPlan())
+      {
+        plan = getNewPlan();
+
+        // check if plan is empty
+        if (plan.empty())
         {
-          publishZeroVelocity(); // command the robot to stop on canceling navigation
-          setState(CANCELED);
+          setState(EMPTY_PLAN);
           condition_.notify_all();
           moving_ = false;
           return;
         }
 
-        if (!safetyCheck())
+        // check if plan could be set
+        if (!controller_->setPlan(plan))
         {
-          // the specific implementation must have detected a risk situation; at this abstract level, we
-          // cannot tell what the problem is, but anyway we command the robot to stop to avoid crashes
-          publishZeroVelocity();   // note that we still feedback command calculated by the plugin
-          boost::this_thread::sleep_for(calling_duration_);
-        }
-
-        // update plan dynamically
-        if (hasNewPlan())
-        {
-          plan = getNewPlan();
-
-          // check if plan is empty
-          if (plan.empty())
-          {
-            setState(EMPTY_PLAN);
-            condition_.notify_all();
-            moving_ = false;
-            return;
-          }
-
-          // check if plan could be set
-          if (!controller_->setPlan(plan))
-          {
-            setState(INVALID_PLAN);
-            condition_.notify_all();
-            moving_ = false;
-            return;
-          }
-          current_goal_pub_.publish(plan.back());
-        }
-
-        // compute robot pose and store it in robot_pose_
-        computeRobotPose();
-
-        // ask planner if the goal is reached
-        if (reachedGoalCheck())
-        {
-          ROS_DEBUG_STREAM_NAMED("abstract_controller_execution", "Reached the goal!");
-          if (force_stop_at_goal_) {
-            publishZeroVelocity();
-          }
-          setState(ARRIVED_GOAL);
-          // goal reached, tell it the controller
+          setState(INVALID_PLAN);
           condition_.notify_all();
           moving_ = false;
-          // if not, keep moving
+          return;
+        }
+        current_goal_pub_.publish(plan.back());
+      }
+
+      // compute robot pose and store it in robot_pose_
+      computeRobotPose();
+
+      // ask planner if the goal is reached
+      if (reachedGoalCheck())
+      {
+        ROS_DEBUG_STREAM_NAMED("abstract_controller_execution", "Reached the goal!");
+        if (force_stop_at_goal_) {
+          publishZeroVelocity();
+        }
+        setState(ARRIVED_GOAL);
+        // goal reached, tell it the controller
+        condition_.notify_all();
+        moving_ = false;
+        // if not, keep moving
+      }
+      else
+      {
+        setState(PLANNING);
+
+        // save time and call the plugin
+        lct_mtx_.lock();
+        last_call_time_ = ros::Time::now();
+        lct_mtx_.unlock();
+
+        // call plugin to compute the next velocity command
+        geometry_msgs::TwistStamped cmd_vel_stamped;
+        geometry_msgs::TwistStamped robot_velocity;   // TODO pass current velocity to the plugin!
+        outcome_ = computeVelocityCmd(robot_pose_, robot_velocity, cmd_vel_stamped, message_ = "");
+
+        if (outcome_ < 10)
+        {
+          setState(GOT_LOCAL_CMD);
+          vel_pub_.publish(cmd_vel_stamped.twist);
+          last_valid_cmd_time = ros::Time::now();
+          retries = 0;
         }
         else
         {
-          setState(PLANNING);
-
-          // save time and call the plugin
-          lct_mtx_.lock();
-          last_call_time_ = ros::Time::now();
-          lct_mtx_.unlock();
-
-          // call plugin to compute the next velocity command
-          geometry_msgs::TwistStamped cmd_vel_stamped;
-          geometry_msgs::TwistStamped robot_velocity;   // TODO pass current velocity to the plugin!
-          outcome_ = computeVelocityCmd(robot_pose_, robot_velocity, cmd_vel_stamped, message_ = "");
-
-          if (outcome_ < 10)
+          boost::lock_guard<boost::mutex> guard(configuration_mutex_);
+          if (max_retries_ >= 0 && ++retries > max_retries_)
           {
-            setState(GOT_LOCAL_CMD);
-            vel_pub_.publish(cmd_vel_stamped.twist);
-            last_valid_cmd_time = ros::Time::now();
-            retries = 0;
+            setState(MAX_RETRIES);
+            moving_ = false;
+          }
+          else if (!patience_.isZero() && ros::Time::now() - last_valid_cmd_time > patience_
+                   && ros::Time::now() - start_time_ > patience_)
+          {
+            // patience limit enabled and running controller for more than patience without valid commands
+            setState(PAT_EXCEEDED);
+            moving_ = false;
           }
           else
           {
-            boost::lock_guard<boost::mutex> guard(configuration_mutex_);
-            if (max_retries_ >= 0 && ++retries > max_retries_)
-            {
-              setState(MAX_RETRIES);
-              moving_ = false;
-            }
-            else if (!patience_.isZero() && ros::Time::now() - last_valid_cmd_time > patience_
-                     && ros::Time::now() - start_time_ > patience_)
-            {
-              // patience limit enabled and running controller for more than patience without valid commands
-              setState(PAT_EXCEEDED);
-              moving_ = false;
-            }
-            else
-            {
-              setState(NO_LOCAL_CMD); // useful for server feedback
-            }
-            // could not compute a valid velocity command -> stop moving the robot
-            publishZeroVelocity(); // command the robot to stop; we still feedback command calculated by the plugin
+            setState(NO_LOCAL_CMD); // useful for server feedback
           }
-
-          // set stamped values; timestamp and frame_id should be set by the plugin; otherwise setVelocityCmd will do
-          cmd_vel_stamped.header.seq = seq++; // sequence number
-          setVelocityCmd(cmd_vel_stamped);
-          condition_.notify_all();
+          // could not compute a valid velocity command -> stop moving the robot
+          publishZeroVelocity(); // command the robot to stop; we still feedback command calculated by the plugin
         }
 
-        boost::chrono::thread_clock::time_point end_time = boost::chrono::thread_clock::now();
-        boost::chrono::microseconds execution_duration =
-            boost::chrono::duration_cast<boost::chrono::microseconds>(end_time - loop_start_time);
-        configuration_mutex_.lock();
-        boost::chrono::microseconds sleep_time = calling_duration_ - execution_duration;
-        configuration_mutex_.unlock();
-        if (moving_ && ros::ok())
+        // set stamped values; timestamp and frame_id should be set by the plugin; otherwise setVelocityCmd will do
+        cmd_vel_stamped.header.seq = seq++; // sequence number
+        setVelocityCmd(cmd_vel_stamped);
+        condition_.notify_all();
+      }
+
+      boost::chrono::thread_clock::time_point end_time = boost::chrono::thread_clock::now();
+      boost::chrono::microseconds execution_duration =
+          boost::chrono::duration_cast<boost::chrono::microseconds>(end_time - loop_start_time);
+      configuration_mutex_.lock();
+      boost::chrono::microseconds sleep_time = calling_duration_ - execution_duration;
+      configuration_mutex_.unlock();
+      if (moving_ && ros::ok())
+      {
+        if (sleep_time > boost::chrono::microseconds(0))
         {
-          if (sleep_time > boost::chrono::microseconds(0))
-          {
-            // interruption point
-            boost::this_thread::sleep_for(sleep_time);
-          }
-          else
-          {
-            // provide an interruption point also with 0 or negative sleep_time
-            boost::this_thread::interruption_point();
-            ROS_WARN_THROTTLE(1.0, "Calculation needs too much time to stay in the moving frequency! (%f > %f)",
-                              execution_duration.count()/1000000.0, calling_duration_.count()/1000000.0);
-          }
+          // interruption point
+          boost::this_thread::sleep_for(sleep_time);
+        }
+        else
+        {
+          // provide an interruption point also with 0 or negative sleep_time
+          boost::this_thread::interruption_point();
+          ROS_WARN_THROTTLE(1.0, "Calculation needs too much time to stay in the moving frequency! (%f > %f)",
+                            execution_duration.count()/1000000.0, calling_duration_.count()/1000000.0);
         }
       }
     }
-    catch (const boost::thread_interrupted &ex)
-    {
-      // Controller thread interrupted; in most cases we have started a new plan
-      // Can also be that robot is oscillating or we have exceeded planner patience
-      ROS_DEBUG_STREAM("Controller thread interrupted!");
-      publishZeroVelocity();
-      setState(STOPPED);
-      condition_.notify_all();
-      moving_ = false;
-    }
-    catch (...)
-    {
-      message_ = "Unknown error occurred: " + boost::current_exception_diagnostic_information();
-      ROS_FATAL_STREAM(message_);
-      setState(INTERNAL_ERROR);
-    }
   }
-
-
-  void AbstractControllerExecution::publishZeroVelocity()
+  catch (const boost::thread_interrupted &ex)
   {
-    geometry_msgs::Twist cmd_vel;
-    cmd_vel.linear.x = 0;
-    cmd_vel.linear.y = 0;
-    cmd_vel.linear.z = 0;
-    cmd_vel.angular.x = 0;
-    cmd_vel.angular.y = 0;
-    cmd_vel.angular.z = 0;
-    vel_pub_.publish(cmd_vel);
+    // Controller thread interrupted; in most cases we have started a new plan
+    // Can also be that robot is oscillating or we have exceeded planner patience
+    ROS_DEBUG_STREAM("Controller thread interrupted!");
+    publishZeroVelocity();
+    setState(STOPPED);
+    condition_.notify_all();
+    moving_ = false;
   }
+  catch (...)
+  {
+    message_ = "Unknown error occurred: " + boost::current_exception_diagnostic_information();
+    ROS_FATAL_STREAM(message_);
+    setState(INTERNAL_ERROR);
+  }
+}
+
+
+void AbstractControllerExecution::publishZeroVelocity()
+{
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0;
+  cmd_vel.linear.y = 0;
+  cmd_vel.linear.z = 0;
+  cmd_vel.angular.x = 0;
+  cmd_vel.angular.y = 0;
+  cmd_vel.angular.z = 0;
+  vel_pub_.publish(cmd_vel);
+}
 
 } /* namespace mbf_abstract_nav */

--- a/mbf_abstract_nav/src/abstract_execution_base.cpp
+++ b/mbf_abstract_nav/src/abstract_execution_base.cpp
@@ -38,52 +38,52 @@
 
 #include "mbf_abstract_nav/abstract_execution_base.h"
 
-namespace mbf_abstract_nav{
+namespace mbf_abstract_nav
+{
 
-  AbstractExecutionBase::AbstractExecutionBase(std::string name)
-    : outcome_(255), cancel_(false), name_(name)
-  {
-  }
+AbstractExecutionBase::AbstractExecutionBase(std::string name)
+  : outcome_(255), cancel_(false), name_(name)
+{
+}
 
-  bool AbstractExecutionBase::start()
-  {
-    //setState(STARTED); // TODO
-    thread_ = boost::thread(&AbstractExecutionBase::run, this);
-    return true;
-  }
+bool AbstractExecutionBase::start()
+{
+  //setState(STARTED); // TODO
+  thread_ = boost::thread(&AbstractExecutionBase::run, this);
+  return true;
+}
 
-  void AbstractExecutionBase::stop()
-  {
-    ROS_WARN_STREAM("Trying to stop the planning rigorously by interrupting the thread!");
-    thread_.interrupt();
-    //setState(STOPPED); // TODO
-  }
+void AbstractExecutionBase::stop()
+{
+  ROS_WARN_STREAM("Trying to stop the planning rigorously by interrupting the thread!");
+  thread_.interrupt();
+  //setState(STOPPED); // TODO
+}
 
-  void AbstractExecutionBase::join(){
-    thread_.join();
-  }
+void AbstractExecutionBase::join(){
+  thread_.join();
+}
 
-  void AbstractExecutionBase::waitForStateUpdate(boost::chrono::microseconds const &duration)
-  {
-    boost::mutex mutex;
-    boost::unique_lock<boost::mutex> lock(mutex);
-    condition_.wait_for(lock, duration);
-  }
+void AbstractExecutionBase::waitForStateUpdate(boost::chrono::microseconds const &duration)
+{
+  boost::mutex mutex;
+  boost::unique_lock<boost::mutex> lock(mutex);
+  condition_.wait_for(lock, duration);
+}
 
-  uint32_t AbstractExecutionBase::getOutcome()
-  {
-    return outcome_;
-  }
+uint32_t AbstractExecutionBase::getOutcome()
+{
+  return outcome_;
+}
 
-  std::string AbstractExecutionBase::getMessage()
-  {
-    return message_;
-  }
+std::string AbstractExecutionBase::getMessage()
+{
+  return message_;
+}
 
-  std::string AbstractExecutionBase::getName()
-  {
-    return name_;
-  }
-
+std::string AbstractExecutionBase::getName()
+{
+  return name_;
+}
 
 } /* namespace mbf_abstract_nav */

--- a/mbf_abstract_nav/src/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_planner_execution.cpp
@@ -43,317 +43,316 @@
 namespace mbf_abstract_nav
 {
 
+AbstractPlannerExecution::AbstractPlannerExecution(
+    const std::string name,
+    const mbf_abstract_core::AbstractPlanner::Ptr planner_ptr,
+    const MoveBaseFlexConfig &config) :
+  AbstractExecutionBase(name),
+    planner_(planner_ptr), state_(INITIALIZED), planning_(false),
+    has_new_start_(false), has_new_goal_(false)
+{
+  ros::NodeHandle private_nh("~");
 
-  AbstractPlannerExecution::AbstractPlannerExecution(
-      const std::string name,
-      const mbf_abstract_core::AbstractPlanner::Ptr planner_ptr,
-      const MoveBaseFlexConfig &config) :
-    AbstractExecutionBase(name),
-      planner_(planner_ptr), state_(INITIALIZED), planning_(false),
-      has_new_start_(false), has_new_goal_(false)
+  // non-dynamically reconfigurable parameters
+  private_nh.param("robot_frame", robot_frame_, std::string("base_footprint"));
+  private_nh.param("map_frame", global_frame_, std::string("map"));
+
+  // dynamically reconfigurable parameters
+  reconfigure(config);
+}
+
+AbstractPlannerExecution::~AbstractPlannerExecution()
+{
+}
+
+
+double AbstractPlannerExecution::getCost()
+{
+  boost::lock_guard<boost::mutex> guard(plan_mtx_);
+  // copy plan and costs to output
+  // if the planner plugin do not compute costs compute costs by discrete path length
+  if(cost_ == 0 && !plan_.empty())
   {
-    ros::NodeHandle private_nh("~");
+    ROS_DEBUG_STREAM("Compute costs by discrete path length!");
+    double cost = 0;
 
-    // non-dynamically reconfigurable parameters
-    private_nh.param("robot_frame", robot_frame_, std::string("base_footprint"));
-    private_nh.param("map_frame", global_frame_, std::string("map"));
-
-    // dynamically reconfigurable parameters
-    reconfigure(config);
-  }
-
-  AbstractPlannerExecution::~AbstractPlannerExecution()
-  {
-  }
-
-
-  double AbstractPlannerExecution::getCost()
-  {
-    boost::lock_guard<boost::mutex> guard(plan_mtx_);
-    // copy plan and costs to output
-    // if the planner plugin do not compute costs compute costs by discrete path length
-    if(cost_ == 0 && !plan_.empty())
+    geometry_msgs::PoseStamped prev_pose = plan_.front();
+    for(std::vector<geometry_msgs::PoseStamped>::iterator iter = plan_.begin() + 1; iter != plan_.end(); ++iter)
     {
-      ROS_DEBUG_STREAM("Compute costs by discrete path length!");
-      double cost = 0;
+      cost += mbf_utility::distance(prev_pose, *iter);
+      prev_pose = *iter;
+    }
+    return cost;
+  }
+  return cost_;
+}
 
-      geometry_msgs::PoseStamped prev_pose = plan_.front();
-      for(std::vector<geometry_msgs::PoseStamped>::iterator iter = plan_.begin() + 1; iter != plan_.end(); ++iter)
+void AbstractPlannerExecution::reconfigure(const MoveBaseFlexConfig &config)
+{
+  boost::lock_guard<boost::mutex> guard(configuration_mutex_);
+
+  max_retries_ = config.planner_max_retries;
+  frequency_ = config.planner_frequency;
+
+  // Timeout granted to the global planner. We keep calling it up to this time or up to max_retries times
+  // If it doesn't return within time, the navigator will cancel it and abort the corresponding action
+  patience_ = ros::Duration(config.planner_patience);
+}
+
+
+typename AbstractPlannerExecution::PlanningState AbstractPlannerExecution::getState()
+{
+  boost::lock_guard<boost::mutex> guard(state_mtx_);
+  return state_;
+}
+
+void AbstractPlannerExecution::setState(PlanningState state)
+{
+  boost::lock_guard<boost::mutex> guard(state_mtx_);
+  state_ = state;
+}
+
+
+ros::Time AbstractPlannerExecution::getLastValidPlanTime()
+{
+  boost::lock_guard<boost::mutex> guard(plan_mtx_);
+  return last_valid_plan_time_;
+}
+
+
+bool AbstractPlannerExecution::isPatienceExceeded()
+{
+  return !patience_.isZero() && (ros::Time::now() - last_call_start_time_ > patience_);
+}
+
+
+std::vector<geometry_msgs::PoseStamped> AbstractPlannerExecution::getPlan()
+{
+  boost::lock_guard<boost::mutex> guard(plan_mtx_);
+  // copy plan and costs to output
+  return plan_;
+}
+
+
+void AbstractPlannerExecution::setNewGoal(const geometry_msgs::PoseStamped &goal, double tolerance)
+{
+  boost::lock_guard<boost::mutex> guard(goal_start_mtx_);
+  goal_ = goal;
+  tolerance_ = tolerance;
+  has_new_goal_ = true;
+}
+
+
+void AbstractPlannerExecution::setNewStart(const geometry_msgs::PoseStamped &start)
+{
+  boost::lock_guard<boost::mutex> guard(goal_start_mtx_);
+  start_ = start;
+  has_new_start_ = true;
+}
+
+
+void AbstractPlannerExecution::setNewStartAndGoal(const geometry_msgs::PoseStamped &start,
+                                                  const geometry_msgs::PoseStamped &goal,
+                                                  double tolerance)
+{
+  boost::lock_guard<boost::mutex> guard(goal_start_mtx_);
+  start_ = start;
+  goal_ = goal;
+  tolerance_ = tolerance;
+  has_new_start_ = true;
+  has_new_goal_ = true;
+}
+
+
+bool AbstractPlannerExecution::start(const geometry_msgs::PoseStamped &start,
+                                     const geometry_msgs::PoseStamped &goal,
+                                     double tolerance)
+{
+  if (planning_)
+  {
+    return false;
+  }
+  boost::lock_guard<boost::mutex> guard(planning_mtx_);
+  planning_ = true;
+  start_ = start;
+  goal_ = goal;
+  tolerance_ = tolerance;
+
+  geometry_msgs::Point s = start.pose.position;
+  geometry_msgs::Point g = goal.pose.position;
+
+  ROS_DEBUG_STREAM("Start planning from the start pose: (" << s.x << ", " << s.y << ", " << s.z << ")"
+                                 << " to the goal pose: ("<< g.x << ", " << g.y << ", " << g.z << ")");
+
+  return AbstractExecutionBase::start();
+}
+
+
+bool AbstractPlannerExecution::cancel()
+{
+  cancel_ = true; // force cancel immediately, as the call to cancel in the planner can take a while
+
+  // returns false if cancel is not implemented or rejected by the planner (will run until completion)
+  if(!planner_->cancel())
+  {
+    ROS_WARN_STREAM("Cancel planning failed or is not supported by the plugin. "
+        << "Wait until the current planning finished!");
+
+    return false;
+  }
+  return true;
+}
+
+uint32_t AbstractPlannerExecution::makePlan(const geometry_msgs::PoseStamped &start,
+                                            const geometry_msgs::PoseStamped &goal,
+                                            double tolerance,
+                                            std::vector<geometry_msgs::PoseStamped> &plan,
+                                            double &cost,
+                                            std::string &message)
+{
+  return planner_->makePlan(start, goal, tolerance, plan, cost, message);
+}
+
+void AbstractPlannerExecution::run()
+{
+  boost::lock_guard<boost::mutex> guard(planning_mtx_);
+  int retries = 0;
+  geometry_msgs::PoseStamped current_start = start_;
+  geometry_msgs::PoseStamped current_goal = goal_;
+  double current_tolerance = tolerance_;
+
+  bool success = false;
+  bool make_plan = false;
+  bool exceeded = false;
+
+  last_call_start_time_ = ros::Time::now();
+  last_valid_plan_time_ = ros::Time::now();
+
+  try
+  {
+    while (planning_ && ros::ok())
+    {
+      boost::chrono::thread_clock::time_point start_time = boost::chrono::thread_clock::now();
+
+      // call the planner
+      std::vector<geometry_msgs::PoseStamped> plan;
+      double cost;
+
+      // lock goal start mutex
+      goal_start_mtx_.lock();
+      if (has_new_start_)
       {
-        cost += mbf_utility::distance(prev_pose, *iter);
-        prev_pose = *iter;
+        has_new_start_ = false;
+        current_start = start_;
+        ROS_INFO_STREAM("A new start pose is available. Planning with the new start pose!");
+        exceeded = false;
+        geometry_msgs::Point s = start_.pose.position;
+        ROS_INFO_STREAM("New planning start pose: (" << s.x << ", " << s.y << ", " << s.z << ")");
       }
-      return cost;
-    }
-    return cost_;
-  }
-
-  void AbstractPlannerExecution::reconfigure(const MoveBaseFlexConfig &config)
-  {
-    boost::lock_guard<boost::mutex> guard(configuration_mutex_);
-
-    max_retries_ = config.planner_max_retries;
-    frequency_ = config.planner_frequency;
-
-    // Timeout granted to the global planner. We keep calling it up to this time or up to max_retries times
-    // If it doesn't return within time, the navigator will cancel it and abort the corresponding action
-    patience_ = ros::Duration(config.planner_patience);
-  }
-
-
-  typename AbstractPlannerExecution::PlanningState AbstractPlannerExecution::getState()
-  {
-    boost::lock_guard<boost::mutex> guard(state_mtx_);
-    return state_;
-  }
-
-  void AbstractPlannerExecution::setState(PlanningState state)
-  {
-    boost::lock_guard<boost::mutex> guard(state_mtx_);
-    state_ = state;
-  }
-
-
-  ros::Time AbstractPlannerExecution::getLastValidPlanTime()
-  {
-    boost::lock_guard<boost::mutex> guard(plan_mtx_);
-    return last_valid_plan_time_;
-  }
-
-
-  bool AbstractPlannerExecution::isPatienceExceeded()
-  {
-    return !patience_.isZero() && (ros::Time::now() - last_call_start_time_ > patience_);
-  }
-
-
-  std::vector<geometry_msgs::PoseStamped> AbstractPlannerExecution::getPlan()
-  {
-    boost::lock_guard<boost::mutex> guard(plan_mtx_);
-    // copy plan and costs to output
-    return plan_;
-  }
-
-
-  void AbstractPlannerExecution::setNewGoal(const geometry_msgs::PoseStamped &goal, double tolerance)
-  {
-    boost::lock_guard<boost::mutex> guard(goal_start_mtx_);
-    goal_ = goal;
-    tolerance_ = tolerance;
-    has_new_goal_ = true;
-  }
-
-
-  void AbstractPlannerExecution::setNewStart(const geometry_msgs::PoseStamped &start)
-  {
-    boost::lock_guard<boost::mutex> guard(goal_start_mtx_);
-    start_ = start;
-    has_new_start_ = true;
-  }
-
-
-  void AbstractPlannerExecution::setNewStartAndGoal(const geometry_msgs::PoseStamped &start,
-                                                    const geometry_msgs::PoseStamped &goal,
-                                                    double tolerance)
-  {
-    boost::lock_guard<boost::mutex> guard(goal_start_mtx_);
-    start_ = start;
-    goal_ = goal;
-    tolerance_ = tolerance;
-    has_new_start_ = true;
-    has_new_goal_ = true;
-  }
-
-
-  bool AbstractPlannerExecution::start(const geometry_msgs::PoseStamped &start,
-                                       const geometry_msgs::PoseStamped &goal,
-                                       double tolerance)
-  {
-    if (planning_)
-    {
-      return false;
-    }
-    boost::lock_guard<boost::mutex> guard(planning_mtx_);
-    planning_ = true;
-    start_ = start;
-    goal_ = goal;
-    tolerance_ = tolerance;
-
-    geometry_msgs::Point s = start.pose.position;
-    geometry_msgs::Point g = goal.pose.position;
-
-    ROS_DEBUG_STREAM("Start planning from the start pose: (" << s.x << ", " << s.y << ", " << s.z << ")"
-                                   << " to the goal pose: ("<< g.x << ", " << g.y << ", " << g.z << ")");
-
-    return AbstractExecutionBase::start();
-  }
-
-
-  bool AbstractPlannerExecution::cancel()
-  {
-    cancel_ = true; // force cancel immediately, as the call to cancel in the planner can take a while
-
-    // returns false if cancel is not implemented or rejected by the planner (will run until completion)
-    if(!planner_->cancel())
-    {
-      ROS_WARN_STREAM("Cancel planning failed or is not supported by the plugin. "
-          << "Wait until the current planning finished!");
-
-      return false;
-    }
-    return true;
-  }
-
-  uint32_t AbstractPlannerExecution::makePlan(const geometry_msgs::PoseStamped &start,
-                                              const geometry_msgs::PoseStamped &goal,
-                                              double tolerance,
-                                              std::vector<geometry_msgs::PoseStamped> &plan,
-                                              double &cost,
-                                              std::string &message)
-  {
-    return planner_->makePlan(start, goal, tolerance, plan, cost, message);
-  }
-
-  void AbstractPlannerExecution::run()
-  {
-    boost::lock_guard<boost::mutex> guard(planning_mtx_);
-    int retries = 0;
-    geometry_msgs::PoseStamped current_start = start_;
-    geometry_msgs::PoseStamped current_goal = goal_;
-    double current_tolerance = tolerance_;
-
-    bool success = false;
-    bool make_plan = false;
-    bool exceeded = false;
-
-    last_call_start_time_ = ros::Time::now();
-    last_valid_plan_time_ = ros::Time::now();
-
-    try
-    {
-      while (planning_ && ros::ok())
+      if (has_new_goal_)
       {
-        boost::chrono::thread_clock::time_point start_time = boost::chrono::thread_clock::now();
+        has_new_goal_ = false;
+        current_goal = goal_;
+        current_tolerance = tolerance_;
+        ROS_INFO_STREAM("A new goal pose is available. Planning with the new goal pose and the tolerance: "
+                        << current_tolerance);
+        exceeded = false;
+        geometry_msgs::Point g = goal_.pose.position;
+        ROS_INFO_STREAM("New goal pose: (" << g.x << ", " << g.y << ", " << g.z << ")");
+      }
 
-        // call the planner
-        std::vector<geometry_msgs::PoseStamped> plan;
-        double cost;
+      make_plan = !(success || exceeded) || has_new_start_ || has_new_goal_;
 
-        // lock goal start mutex
-        goal_start_mtx_.lock();
-        if (has_new_start_)
+      // unlock goal
+      goal_start_mtx_.unlock();
+      setState(PLANNING);
+      if (make_plan)
+      {
+        outcome_ = makePlan(current_start, current_goal, current_tolerance, plan, cost, message_);
+        success = outcome_ < 10;
+
+        boost::lock_guard<boost::mutex> guard(configuration_mutex_);
+
+        if (cancel_ && !isPatienceExceeded())
         {
-          has_new_start_ = false;
-          current_start = start_;
-          ROS_INFO_STREAM("A new start pose is available. Planning with the new start pose!");
-          exceeded = false;
-          geometry_msgs::Point s = start_.pose.position;
-          ROS_INFO_STREAM("New planning start pose: (" << s.x << ", " << s.y << ", " << s.z << ")");
-        }
-        if (has_new_goal_)
-        {
-          has_new_goal_ = false;
-          current_goal = goal_;
-          current_tolerance = tolerance_;
-          ROS_INFO_STREAM("A new goal pose is available. Planning with the new goal pose and the tolerance: "
-                          << current_tolerance);
-          exceeded = false;
-          geometry_msgs::Point g = goal_.pose.position;
-          ROS_INFO_STREAM("New goal pose: (" << g.x << ", " << g.y << ", " << g.z << ")");
-        }
-
-        make_plan = !(success || exceeded) || has_new_start_ || has_new_goal_;
-
-        // unlock goal
-        goal_start_mtx_.unlock();
-        setState(PLANNING);
-        if (make_plan)
-        {
-          outcome_ = makePlan(current_start, current_goal, current_tolerance, plan, cost, message_);
-          success = outcome_ < 10;
-
-          boost::lock_guard<boost::mutex> guard(configuration_mutex_);
-
-          if (cancel_ && !isPatienceExceeded())
-          {
-            setState(CANCELED);
-            ROS_INFO_STREAM("The global planner has been canceled!"); // but not due to patience exceeded
-            planning_ = false;
-            condition_.notify_all();
-          }
-          else if (success)
-          {
-            ROS_DEBUG_STREAM("Successfully found a plan.");
-            exceeded = false;
-            planning_ = false;
-
-            plan_mtx_.lock();
-            plan_ = plan;
-            cost_ = cost;
-            last_valid_plan_time_ = ros::Time::now();
-            plan_mtx_.unlock();
-            setState(FOUND_PLAN);
-
-            condition_.notify_all(); // notify observer
-          }
-          else if (max_retries_ >= 0 && ++retries > max_retries_)
-          {
-            ROS_INFO_STREAM("Planning reached max retries! (" << max_retries_ << ")");
-            setState(MAX_RETRIES);
-            exceeded = true;
-            planning_ = false;
-            condition_.notify_all(); // notify observer
-          }
-          else if (isPatienceExceeded())
-          {
-            // Patience exceeded is handled at two levels: here to stop retrying planning when max_retries is
-            // disabled, and on the navigation server when the planner doesn't return for more that patience seconds.
-            // In the second case, the navigation server has tried to cancel planning (possibly without success, as
-            // old nav_core-based planners do not support canceling), and we add here the fact to the log for info
-            ROS_INFO_STREAM("Planning patience (" << patience_.toSec() << "s) has been exceeded"
-                                                  << (cancel_ ? "; planner canceled!" : ""));
-            setState(PAT_EXCEEDED);
-            exceeded = true;
-            planning_ = false;
-            condition_.notify_all(); // notify observer
-          }
-          else if (max_retries_ == 0 && patience_.isZero())
-          {
-            ROS_INFO_STREAM("Planning could not find a plan!");
-            exceeded = true;
-            setState(NO_PLAN_FOUND);
-            condition_.notify_all(); // notify observer
-            planning_ = false;
-          }
-          else
-          {
-            exceeded = false;
-            ROS_DEBUG_STREAM("Planning could not find a plan! Trying again...");
-          }
-        }
-        else if (cancel_)
-        {
-          ROS_INFO_STREAM("The global planner has been canceled!");
           setState(CANCELED);
+          ROS_INFO_STREAM("The global planner has been canceled!"); // but not due to patience exceeded
           planning_ = false;
           condition_.notify_all();
         }
-      } // while (planning_ && ros::ok())
-    }
-    catch (const boost::thread_interrupted &ex)
-    {
-      // Planner thread interrupted; probably we have exceeded planner patience
-      ROS_WARN_STREAM("Planner thread interrupted!");
-      setState(STOPPED);
-      condition_.notify_all(); // notify observer
-      planning_ = false;
-    }
-    catch (...)
-    {
-      ROS_FATAL_STREAM("Unknown error occurred: " << boost::current_exception_diagnostic_information());
-      setState(INTERNAL_ERROR);
-    }
+        else if (success)
+        {
+          ROS_DEBUG_STREAM("Successfully found a plan.");
+          exceeded = false;
+          planning_ = false;
+
+          plan_mtx_.lock();
+          plan_ = plan;
+          cost_ = cost;
+          last_valid_plan_time_ = ros::Time::now();
+          plan_mtx_.unlock();
+          setState(FOUND_PLAN);
+
+          condition_.notify_all(); // notify observer
+        }
+        else if (max_retries_ >= 0 && ++retries > max_retries_)
+        {
+          ROS_INFO_STREAM("Planning reached max retries! (" << max_retries_ << ")");
+          setState(MAX_RETRIES);
+          exceeded = true;
+          planning_ = false;
+          condition_.notify_all(); // notify observer
+        }
+        else if (isPatienceExceeded())
+        {
+          // Patience exceeded is handled at two levels: here to stop retrying planning when max_retries is
+          // disabled, and on the navigation server when the planner doesn't return for more that patience seconds.
+          // In the second case, the navigation server has tried to cancel planning (possibly without success, as
+          // old nav_core-based planners do not support canceling), and we add here the fact to the log for info
+          ROS_INFO_STREAM("Planning patience (" << patience_.toSec() << "s) has been exceeded"
+                                                << (cancel_ ? "; planner canceled!" : ""));
+          setState(PAT_EXCEEDED);
+          exceeded = true;
+          planning_ = false;
+          condition_.notify_all(); // notify observer
+        }
+        else if (max_retries_ == 0 && patience_.isZero())
+        {
+          ROS_INFO_STREAM("Planning could not find a plan!");
+          exceeded = true;
+          setState(NO_PLAN_FOUND);
+          condition_.notify_all(); // notify observer
+          planning_ = false;
+        }
+        else
+        {
+          exceeded = false;
+          ROS_DEBUG_STREAM("Planning could not find a plan! Trying again...");
+        }
+      }
+      else if (cancel_)
+      {
+        ROS_INFO_STREAM("The global planner has been canceled!");
+        setState(CANCELED);
+        planning_ = false;
+        condition_.notify_all();
+      }
+    } // while (planning_ && ros::ok())
   }
+  catch (const boost::thread_interrupted &ex)
+  {
+    // Planner thread interrupted; probably we have exceeded planner patience
+    ROS_WARN_STREAM("Planner thread interrupted!");
+    setState(STOPPED);
+    condition_.notify_all(); // notify observer
+    planning_ = false;
+  }
+  catch (...)
+  {
+    ROS_FATAL_STREAM("Unknown error occurred: " << boost::current_exception_diagnostic_information());
+    setState(INTERNAL_ERROR);
+  }
+}
 
 } /* namespace mbf_abstract_nav */
 

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -40,13 +40,13 @@
 
 #include "mbf_abstract_nav/controller_action.h"
 
-namespace mbf_abstract_nav{
-
+namespace mbf_abstract_nav
+{
 
 ControllerAction::ControllerAction(
     const std::string &action_name,
     const RobotInformation &robot_info)
-    : AbstractAction(action_name, robot_info, boost::bind(&mbf_abstract_nav::ControllerAction::run, this, _1, _2))
+    : AbstractActionBase(action_name, robot_info, boost::bind(&mbf_abstract_nav::ControllerAction::run, this, _1, _2))
 {
 }
 
@@ -89,8 +89,8 @@ void ControllerAction::start(
   slot_map_mtx_.unlock();
   if(!update_plan)
   {
-      // Otherwise run parent version of this method
-      AbstractAction::start(goal_handle, execution_ptr);
+    // Otherwise run parent version of this method
+    AbstractActionBase::start(goal_handle, execution_ptr);
   }
 }
 
@@ -355,5 +355,4 @@ void ControllerAction::fillExePathResult(
   result.angle_to_goal = static_cast<float>(mbf_utility::angle(robot_pose_, goal_pose_));
 }
 
-}
-
+} /* mbf_abstract_nav */

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -605,6 +605,4 @@ void MoveBaseAction::actionGetPathReplanningDone(
       boost::bind(&MoveBaseAction::actionGetPathReplanningDone, this, _1, _2)); // replanning
 }
 
-
 } /* namespace mbf_abstract_nav */
-

--- a/mbf_abstract_nav/src/planner_action.cpp
+++ b/mbf_abstract_nav/src/planner_action.cpp
@@ -42,12 +42,13 @@
 
 #include "mbf_abstract_nav/planner_action.h"
 
-namespace mbf_abstract_nav{
+namespace mbf_abstract_nav
+{
 
 PlannerAction::PlannerAction(
     const std::string &name,
     const RobotInformation &robot_info)
-  : AbstractAction(name, robot_info, boost::bind(&mbf_abstract_nav::PlannerAction::run, this, _1, _2)), path_seq_count_(0)
+  : AbstractActionBase(name, robot_info, boost::bind(&mbf_abstract_nav::PlannerAction::run, this, _1, _2)), path_seq_count_(0)
 {
   ros::NodeHandle private_nh("~");
   // informative topics: current navigation goal
@@ -287,4 +288,3 @@ bool PlannerAction::transformPlanToGlobalFrame(
 }
 
 } /* namespace mbf_abstract_nav */
-

--- a/mbf_abstract_nav/src/recovery_action.cpp
+++ b/mbf_abstract_nav/src/recovery_action.cpp
@@ -40,10 +40,11 @@
 
 #include "mbf_abstract_nav/recovery_action.h"
 
-namespace mbf_abstract_nav{
+namespace mbf_abstract_nav
+{
 
 RecoveryAction::RecoveryAction(const std::string &name, const RobotInformation &robot_info)
-  : AbstractAction(name, robot_info, boost::bind(&mbf_abstract_nav::RecoveryAction::run, this, _1, _2)){}
+  : AbstractActionBase(name, robot_info, boost::bind(&mbf_abstract_nav::RecoveryAction::run, this, _1, _2)){}
 
 void RecoveryAction::run(GoalHandle &goal_handle, AbstractRecoveryExecution &execution)
 {
@@ -155,4 +156,3 @@ void RecoveryAction::run(GoalHandle &goal_handle, AbstractRecoveryExecution &exe
 }
 
 } /* namespace mbf_abstract_nav */
-

--- a/mbf_abstract_nav/src/robot_information.cpp
+++ b/mbf_abstract_nav/src/robot_information.cpp
@@ -39,7 +39,8 @@
 #include "mbf_abstract_nav/robot_information.h"
 #include "mbf_utility/navigation_utility.h"
 
-namespace mbf_abstract_nav{
+namespace mbf_abstract_nav
+{
 
 RobotInformation::RobotInformation(TF &tf_listener,
                                    const std::string &global_frame,
@@ -80,4 +81,4 @@ const TF& RobotInformation::getTransformListener() const {return tf_listener_;};
 
 const ros::Duration& RobotInformation::getTfTimeout() const {return tf_timeout_;}
 
-}
+} /* namespace mbf_abstract_nav */


### PR DESCRIPTION
(to mimic abstract_execution_base.h)
Also unify headers definitions and namespace indentation