### PR TITLE
Allow the user time-consuming cancel implementations

### DIFF
--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -234,14 +234,14 @@ bool AbstractControllerExecution::reachedGoalCheck()
 bool AbstractControllerExecution::cancel()
 {
   // returns false if cancel is not implemented or rejected by the recovery behavior (will run until completion)
-  if(!controller_->cancel())
+  bool ctrl_cancelled = controller_->cancel();
+  if(!ctrl_cancelled)
   {
     ROS_WARN_STREAM("Cancel controlling failed or is not supported by the plugin. "
                         << "Wait until the current control cycle finished!");
-    return false;
   }
   cancel_ = true;
-  return true;
+  return ctrl_cancelled;
 }
 
 

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -233,7 +233,6 @@ bool AbstractControllerExecution::reachedGoalCheck()
 
 bool AbstractControllerExecution::cancel()
 {
-  cancel_ = true;
   // returns false if cancel is not implemented or rejected by the recovery behavior (will run until completion)
   if(!controller_->cancel())
   {
@@ -241,6 +240,7 @@ bool AbstractControllerExecution::cancel()
                         << "Wait until the current control cycle finished!");
     return false;
   }
+  cancel_ = true;
   return true;
 }
 


### PR DESCRIPTION
 by setting the flag after function succeeds

Solves #171 