### PR TITLE
Remove explicit boost-exception dependency

### DIFF
--- a/mbf_abstract_nav/CMakeLists.txt
+++ b/mbf_abstract_nav/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(catkin REQUIRED
   xmlrpcpp
   )
 
-find_package(Boost COMPONENTS thread chrono exception REQUIRED)
+find_package(Boost COMPONENTS thread chrono REQUIRED)
 
 # dynamic reconfigure: we provide the abstract configuration common to all MBF-based navigation
 # frameworks in a python module, so it can easily be included in particular navigation flavours


### PR DESCRIPTION
As per subject.
Otherwise building `mbf_abstract_nav` with Boost >= 1.69 leads to the following:

```
==> Processing catkin package: 'mbf_abstract_nav'
==> Building with env: '/tmp/test_ws/devel_isolated/mbf_utility/env.sh'
Makefile exists, skipping explicit cmake invocation...
==> make cmake_check_build_system in '/tmp/test_ws/build_isolated/mbf_abstract_nav'
-- Using CATKIN_DEVEL_PREFIX: /tmp/test_ws/devel_isolated/mbf_abstract_nav
-- Using CMAKE_PREFIX_PATH: /tmp/test_ws/devel_isolated/mbf_utility;/tmp/test_ws/devel_isolated/mbf_msgs;/tmp/test_ws/devel_isolated/mbf_abstract_core;/tmp/test_ws/devel_isolated/amcl;/tmp/test_ws/devel_isolated/map_server;/tmp/test_ws/devel_isolated/fake_localization;/usr/lib64/ros
-- This workspace overlays: /tmp/test_ws/devel_isolated/mbf_utility;/tmp/test_ws/devel_isolated/mbf_msgs;/tmp/test_ws/devel_isolated/mbf_abstract_core;/tmp/test_ws/devel_isolated/amcl;/tmp/test_ws/devel_isolated/map_server;/tmp/test_ws/devel_isolated/fake_localization;/usr/lib64/ros
-- Found PythonInterp: /usr/bin/python2 (found suitable version "2.7.17", minimum required is "2")
-- Using PYTHON_EXECUTABLE: /usr/bin/python2
-- Using default Python package layout
-- Using empy: /usr/lib/python2.7/site-packages/em.pyc
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /tmp/test_ws/build_isolated/mbf_abstract_nav/test_results
-- Found gtest: gtests will be built
-- Using Python nosetests: /usr/bin/nosetests
-- catkin 0.7.20
-- BUILD_SHARED_LIBS is on
-- Using these message generators: gencpp;geneus;genlisp;gennodejs;genpy
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:146 (message):
  Could NOT find Boost (missing: exception) (found version "1.69.0")
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:393 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake/Modules/FindBoost.cmake:2179 (find_package_handle_standard_args)
  CMakeLists.txt:21 (find_package)
```