### PR TITLE
use shared_from_this to avoid crash on shutdown

### DIFF
--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_wrapper.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_wrapper.cpp
@@ -64,6 +64,7 @@ CostmapWrapper::CostmapWrapper(const std::string &name, const TFPtr &tf_listener
 
 CostmapWrapper::~CostmapWrapper()
 {
+  shutdown_costmap_timer_.stop();
 }
 
 

--- a/mbf_costmap_nav/src/move_base_server_node.cpp
+++ b/mbf_costmap_nav/src/move_base_server_node.cpp
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
   costmap_nav_srv_ptr = boost::make_shared<mbf_costmap_nav::CostmapNavigationServer>(tf_listener_ptr);
   ros::spin();
 
-  // explicitly call desctructor here, otherwise costmap_nav_srv_ptr will be
+  // explicitly call destructor here, otherwise costmap_nav_srv_ptr will be
   // destructed after tearing down internally allocated static variables
   costmap_nav_srv_ptr.reset();
   return EXIT_SUCCESS;

--- a/mbf_costmap_nav/src/move_base_server_node.cpp
+++ b/mbf_costmap_nav/src/move_base_server_node.cpp
@@ -75,5 +75,9 @@ int main(int argc, char **argv)
 #endif
   costmap_nav_srv_ptr = boost::make_shared<mbf_costmap_nav::CostmapNavigationServer>(tf_listener_ptr);
   ros::spin();
+
+  // explicitly desctructor here, otherwise this class will be destructed
+  // after tearing down internally allocaled static variables
+  costmap_nav_srv_ptr.reset();
   return EXIT_SUCCESS;
 }

--- a/mbf_costmap_nav/src/move_base_server_node.cpp
+++ b/mbf_costmap_nav/src/move_base_server_node.cpp
@@ -76,8 +76,8 @@ int main(int argc, char **argv)
   costmap_nav_srv_ptr = boost::make_shared<mbf_costmap_nav::CostmapNavigationServer>(tf_listener_ptr);
   ros::spin();
 
-  // call explicitly desctructor here, otherwise costmap_nav_srv_ptr will be
-  // destructed after tearing down internally allocaled static variables
+  // explicitly call desctructor here, otherwise costmap_nav_srv_ptr will be
+  // destructed after tearing down internally allocated static variables
   costmap_nav_srv_ptr.reset();
   return EXIT_SUCCESS;
 }

--- a/mbf_costmap_nav/src/move_base_server_node.cpp
+++ b/mbf_costmap_nav/src/move_base_server_node.cpp
@@ -76,8 +76,8 @@ int main(int argc, char **argv)
   costmap_nav_srv_ptr = boost::make_shared<mbf_costmap_nav::CostmapNavigationServer>(tf_listener_ptr);
   ros::spin();
 
-  // explicitly desctructor here, otherwise this class will be destructed
-  // after tearing down internally allocaled static variables
+  // call explicitly desctructor here, otherwise costmap_nav_srv_ptr will be
+  // destructed after tearing down internally allocaled static variables
   costmap_nav_srv_ptr.reset();
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Hi guys, 

we had a crash on shutdown with following stack trace

> Stack trace of thread 3423:
> #0  0x00007f2f89d7ee97 __GI_raise (libc.so.6)
> #1  0x00007f2f89d80801 __GI_abort (libc.so.6)
> #2  0x00007f2f8a3d5957 n/a (libstdc++.so.6)
> #3  0x00007f2f8a3dbae6 n/a (libstdc++.so.6)
> #4  0x00007f2f8a3dab49 n/a (libstdc++.so.6)
> #5  0x00007f2f8a3db4b8 __gxx_personality_v0 (libstdc++.so.6)
> #6  0x00007f2f8a141573 n/a (libgcc_s.so.1)
> #7  0x00007f2f8a141df5 _Unwind_Resume (libgcc_s.so.1)
> #8  0x00007f2f8b12d4c9 _ZN5boost11unique_lockINS_5mutexEE4lockEv (libtf2_ros.so)
> #9  0x00007f2f8adf2e5b _ZN3ros12TimerManagerINS_4TimeENS_8DurationENS_10TimerEventEE6removeEi (libroscpp.so)
> #10 0x00007f2f8adf1c3b _ZN3ros5Timer4Impl4stopEv (libroscpp.so)
> #11 0x00007f2f8adf1cfb _ZN3ros5Timer4ImplD2Ev (libroscpp.so)
> #12 0x00007f2f8adf3e82 _ZN5boost6detail17sp_counted_impl_pIN3ros5Timer4ImplEE7disposeEv (libroscpp.so)
> #13 0x00007f2f8adf1bd1 _ZN3ros5TimerD2Ev (libroscpp.so)
> #14 0x00007f2f8b426999 _ZN15mbf_costmap_nav14CostmapWrapperD1Ev (libmbf_costmap_server.so)
> #15 0x00007f2f8b4269c9 _ZN15mbf_costmap_nav14CostmapWrapperD0Ev (libmbf_costmap_server.so)
> #16 0x00005560e651c28a _ZN5boost6detail15sp_counted_base7releaseEv (mbf_costmap_nav)
> #17 0x00007f2f8b3cbe47 _ZN15mbf_costmap_nav23CostmapNavigationServerD1Ev (libmbf_costmap_server.so)
> #18 0x00005560e651b4ce _ZN5boost6detail18sp_counted_impl_pdIPN15mbf_costmap_nav23CostmapNavigationServerENS0_13sp_ms_deleterIS3_EEE7disposeEv (mbf_costmap_nav)
> #19 0x00005560e651bf71 _ZN5boost10shared_ptrIN15mbf_costmap_nav23CostmapNavigationServerEED2Ev (mbf_costmap_nav)
> #20 0x00007f2f89d83041 __run_exit_handlers (libc.so.6)
> #21 0x00007f2f89d8313a __GI_exit (libc.so.6)
> #22 0x00007f2f89d61b9e __libc_start_main (libc.so.6)
> #23 0x00005560e651ac5a _start (mbf_costmap_nav)

I think that the reason might be a race condition such that the ros::Timer callback is still called, after the costmap_wrapper instance is destructed. ros::Timer offers for that the track_object API, which might   solve the problem.