### PR TITLE
Ensure that check_costmap_mutex_ is destroyed after timer.

### DIFF
--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_wrapper.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_wrapper.h
@@ -107,12 +107,12 @@ private:
   //! Private node handle
   ros::NodeHandle private_nh_;
 
+  boost::mutex check_costmap_mutex_;     //!< Start/stop costmap mutex; concurrent calls to start can lead to segfault
   bool shutdown_costmap_;                //!< don't update costmap when not using it
   bool clear_on_shutdown_;               //!< clear the costmap, when shutting down
   int16_t costmap_users_;                //!< keep track of plugins using costmap
   ros::Timer shutdown_costmap_timer_;    //!< costmap delayed shutdown timer
   ros::Duration shutdown_costmap_delay_; //!< costmap delayed shutdown delay
-  boost::mutex check_costmap_mutex_;     //!< Start/stop costmap mutex; concurrent calls to start can lead to segfault
 };
 
 } /* namespace mbf_costmap_nav */


### PR DESCRIPTION
Reorders the member declaration so that the timer event can't attempt to
lock the destroyed mutex.