### PR TITLE
mbf_tolerance check for missions

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -111,7 +111,7 @@ namespace mbf_abstract_nav
      * @brief Sets a new plan to the controller execution
      * @param plan A vector of stamped poses.
      */
-    void setNewPlan(const std::vector<geometry_msgs::PoseStamped> &plan);
+    void setNewPlan(const std::vector<geometry_msgs::PoseStamped> &plan, bool has_tolerance = false, double dist_to_goal_tolerance = 0.0, double angle_to_goal_tolerance = 3.14);
 
     /**
      * @brief Cancel the planner execution. This calls the cancel method of the planner plugin. This could be useful if the

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -358,13 +358,13 @@ namespace mbf_abstract_nav
     //! current robot pose;
     geometry_msgs::PoseStamped robot_pose_;
 
-    //! whether check for action specific has_tolerance
+    //! whether check for action specific tolerance
     bool has_tolerance_;
 
-    //! replaces default distance to goal tolerance for the action
+    //! replaces parameter dist_tolerance_ for the action
     double dist_to_goal_tolerance_;
 
-    //! replaces default angle to goal tolerance for the action
+    //! replaces parameter angle_tolerance_ for the action
     double angle_to_goal_tolerance_;
   };
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -110,15 +110,15 @@ namespace mbf_abstract_nav
     /**
      * @brief Sets a new plan to the controller execution
      * @param plan A vector of stamped poses.
-     * @param has_tolerance flag that will be set to true when the new plan (action) has tolerance, default is false
-     * @param dist_to_goal_tolerance distance to goal tolerance specific for this new plan
-     * @param angle_to_goal_tolerance angle to goal tolerance specific for this new plan
+     * @param tolerance_from_action flag that will be set to true when the new plan (action) has tolerance
+     * @param action_dist_tolerance distance to goal tolerance specific for this new plan (action)
+     * @param action_angle_tolerance angle to goal tolerance specific for this new plan (action)
      */
     void setNewPlan(
       const std::vector<geometry_msgs::PoseStamped> &plan,
-      bool has_tolerance = false,
-      double dist_to_goal_tolerance = 1.0,
-      double angle_to_goal_tolerance = 3.1415);
+      bool tolerance_from_action = false,
+      double action_dist_tolerance = 1.0,
+      double action_angle_tolerance = 3.1415);
 
     /**
      * @brief Cancel the planner execution. This calls the cancel method of the planner plugin. This could be useful if the
@@ -359,13 +359,13 @@ namespace mbf_abstract_nav
     geometry_msgs::PoseStamped robot_pose_;
 
     //! whether check for action specific tolerance
-    bool has_tolerance_;
+    bool tolerance_from_action_;
 
     //! replaces parameter dist_tolerance_ for the action
-    double dist_to_goal_tolerance_;
+    double action_dist_tolerance_;
 
     //! replaces parameter angle_tolerance_ for the action
-    double angle_to_goal_tolerance_;
+    double action_angle_tolerance_;
   };
 
 } /* namespace mbf_abstract_nav */

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -114,7 +114,11 @@ namespace mbf_abstract_nav
      * @param dist_to_goal_tolerance distance goal tolerance specific for this plan
      * @param angle_to_goal_tolerance angle to goal tolerance specific for this plan
      */
-    void setNewPlan(const std::vector<geometry_msgs::PoseStamped> &plan, bool has_tolerance = false, double dist_to_goal_tolerance = 0.0, double angle_to_goal_tolerance = 3.14);
+    void setNewPlan(
+      const std::vector<geometry_msgs::PoseStamped> &plan,
+      bool has_tolerance = false,
+      double dist_to_goal_tolerance = 1.0,
+      double angle_to_goal_tolerance = 3.1415);
 
     /**
      * @brief Cancel the planner execution. This calls the cancel method of the planner plugin. This could be useful if the
@@ -354,6 +358,14 @@ namespace mbf_abstract_nav
     //! current robot pose;
     geometry_msgs::PoseStamped robot_pose_;
 
+    //! whether check for action specific has_tolerance
+    bool has_tolerance_;
+
+    //! replaces default distance to goal tolerance for the action
+    double dist_to_goal_tolerance_;
+
+    //! replaces default angle to goal tolerance for the action
+    double angle_to_goal_tolerance_;
   };
 
 } /* namespace mbf_abstract_nav */

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -110,9 +110,9 @@ namespace mbf_abstract_nav
     /**
      * @brief Sets a new plan to the controller execution
      * @param plan A vector of stamped poses.
-     * @param has_tolerance flag that will be set to true when action has tolerance, default is false
-     * @param dist_to_goal_tolerance distance goal tolerance specific for this plan
-     * @param angle_to_goal_tolerance angle to goal tolerance specific for this plan
+     * @param has_tolerance flag that will be set to true when the new plan (action) has tolerance, default is false
+     * @param dist_to_goal_tolerance distance to goal tolerance specific for this new plan
+     * @param angle_to_goal_tolerance angle to goal tolerance specific for this new plan
      */
     void setNewPlan(
       const std::vector<geometry_msgs::PoseStamped> &plan,

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -110,6 +110,9 @@ namespace mbf_abstract_nav
     /**
      * @brief Sets a new plan to the controller execution
      * @param plan A vector of stamped poses.
+     * @param has_tolerance flag that will be set to true when action has tolerance, default is false
+     * @param dist_to_goal_tolerance distance goal tolerance specific for this plan
+     * @param angle_to_goal_tolerance angle to goal tolerance specific for this plan
      */
     void setNewPlan(const std::vector<geometry_msgs::PoseStamped> &plan, bool has_tolerance = false, double dist_to_goal_tolerance = 0.0, double angle_to_goal_tolerance = 3.14);
 

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -132,9 +132,9 @@ AbstractControllerExecution::getState()
 
 void AbstractControllerExecution::setNewPlan(
   const std::vector<geometry_msgs::PoseStamped> &plan,
-  bool has_tolerance,
-  double dist_to_goal_tolerance,
-  double angle_to_goal_tolerance)
+  bool tolerance_from_action,
+  double action_dist_tolerance,
+  double action_angle_tolerance)
 {
   if (moving_)
   {
@@ -145,9 +145,9 @@ void AbstractControllerExecution::setNewPlan(
   new_plan_ = true;
 
   plan_ = plan;
-  has_tolerance_ = has_tolerance;
-  dist_to_goal_tolerance_ = dist_to_goal_tolerance;
-  angle_to_goal_tolerance_ = angle_to_goal_tolerance;
+  tolerance_from_action_ = tolerance_from_action;
+  action_dist_tolerance_ = action_dist_tolerance;
+  action_angle_tolerance_ = action_angle_tolerance;
 }
 
 
@@ -247,10 +247,10 @@ bool AbstractControllerExecution::isMoving()
 bool AbstractControllerExecution::reachedGoalCheck()
 {
   //if action has a specific tolerance, check goal reached with those tolerances
-  if(has_tolerance_){
-    return controller_->isGoalReached(dist_to_goal_tolerance_, angle_to_goal_tolerance_) ||
-        (mbf_utility::distance(robot_pose_, plan_.back()) < dist_to_goal_tolerance_
-        && mbf_utility::angle(robot_pose_, plan_.back()) < angle_to_goal_tolerance_);
+  if(tolerance_from_action_){
+    return controller_->isGoalReached(action_dist_tolerance_, action_angle_tolerance_) ||
+        (mbf_tolerance_check_ && mbf_utility::distance(robot_pose_, plan_.back()) < action_dist_tolerance_
+        && mbf_utility::angle(robot_pose_, plan_.back()) < action_angle_tolerance_);
   }
 
   // Otherwise, check whether the controller plugin returns goal reached or if mbf should check for goal reached.

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -130,7 +130,11 @@ AbstractControllerExecution::getState()
   return state_;
 }
 
-void AbstractControllerExecution::setNewPlan(const std::vector<geometry_msgs::PoseStamped> &plan, bool has_tolerance, double dist_to_goal_tolerance, double angle_to_goal_tolerance)
+void AbstractControllerExecution::setNewPlan(
+  const std::vector<geometry_msgs::PoseStamped> &plan,
+  bool has_tolerance,
+  double dist_to_goal_tolerance,
+  double angle_to_goal_tolerance)
 {
   if (moving_)
   {
@@ -141,6 +145,9 @@ void AbstractControllerExecution::setNewPlan(const std::vector<geometry_msgs::Po
   new_plan_ = true;
 
   plan_ = plan;
+  has_tolerance_ = has_tolerance;
+  dist_to_goal_tolerance_ = dist_to_goal_tolerance;
+  angle_to_goal_tolerance_ = angle_to_goal_tolerance;
 }
 
 
@@ -239,7 +246,14 @@ bool AbstractControllerExecution::isMoving()
 
 bool AbstractControllerExecution::reachedGoalCheck()
 {
-  // check whether the controller plugin returns goal reached or if mbf should check for goal reached.
+  //if action has a specific tolerance, check goal reached with those tolerances
+  if(has_tolerance_){
+    return controller_->isGoalReached(dist_to_goal_tolerance_, angle_to_goal_tolerance_) ||
+        (mbf_utility::distance(robot_pose_, plan_.back()) < dist_to_goal_tolerance_
+        && mbf_utility::angle(robot_pose_, plan_.back()) < angle_to_goal_tolerance_);
+  }
+
+  // Otherwise, check whether the controller plugin returns goal reached or if mbf should check for goal reached.
   return controller_->isGoalReached(dist_tolerance_, angle_tolerance_) || (mbf_tolerance_check_
       && mbf_utility::distance(robot_pose_, plan_.back()) < dist_tolerance_
       && mbf_utility::angle(robot_pose_, plan_.back()) < angle_tolerance_);

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -130,7 +130,7 @@ AbstractControllerExecution::getState()
   return state_;
 }
 
-void AbstractControllerExecution::setNewPlan(const std::vector<geometry_msgs::PoseStamped> &plan)
+void AbstractControllerExecution::setNewPlan(const std::vector<geometry_msgs::PoseStamped> &plan, bool has_tolerance, double dist_to_goal_tolerance, double angle_to_goal_tolerance)
 {
   if (moving_)
   {

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -76,7 +76,10 @@ void ControllerAction::start(
       // Goal requests to run the same controller on the same concurrency slot:
       // we update the goal handle and pass the new plan to the execution without stopping it
       execution_ptr = slot_it->second.execution;
-      execution_ptr->setNewPlan(goal_handle.getGoal()->path.poses);
+      execution_ptr->setNewPlan(goal_handle.getGoal()->path.poses,
+                                goal_handle.getGoal()->goal_tolerance,
+                                goal_handle.getGoal()->dist_to_goal_tolerance,
+                                goal_handle.getGoal()->angle_to_goal_tolerance);
       // Update also goal pose, so the feedback remains consistent
       goal_pose_ = goal_handle.getGoal()->path.poses.back();
       mbf_msgs::ExePathResult result;
@@ -179,7 +182,7 @@ void ControllerAction::run(GoalHandle &goal_handle, AbstractControllerExecution 
     switch (state_moving_input)
     {
       case AbstractControllerExecution::INITIALIZED:
-        execution.setNewPlan(plan);
+        execution.setNewPlan(plan, goal.goal_tolerance, goal.dist_to_goal_tolerance, goal.angle_to_goal_tolerance);
         execution.start();
         break;
 

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -74,12 +74,13 @@ void ControllerAction::start(
     {
       update_plan = true;
       // Goal requests to run the same controller on the same concurrency slot:
-      // we update the goal handle and pass the new plan to the execution without stopping it
+      // we update the goal handle and pass the new plan and tolerances from action
+      // to the execution without stopping it
       execution_ptr = slot_it->second.execution;
       execution_ptr->setNewPlan(goal_handle.getGoal()->path.poses,
-                                goal_handle.getGoal()->goal_tolerance,
-                                goal_handle.getGoal()->dist_to_goal_tolerance,
-                                goal_handle.getGoal()->angle_to_goal_tolerance);
+                                goal_handle.getGoal()->tolerance_from_action,
+                                goal_handle.getGoal()->dist_tolerance,
+                                goal_handle.getGoal()->angle_tolerance);
       // Update also goal pose, so the feedback remains consistent
       goal_pose_ = goal_handle.getGoal()->path.poses.back();
       mbf_msgs::ExePathResult result;
@@ -182,7 +183,7 @@ void ControllerAction::run(GoalHandle &goal_handle, AbstractControllerExecution 
     switch (state_moving_input)
     {
       case AbstractControllerExecution::INITIALIZED:
-        execution.setNewPlan(plan, goal.goal_tolerance, goal.dist_to_goal_tolerance, goal.angle_to_goal_tolerance);
+        execution.setNewPlan(plan, goal.tolerance_from_action, goal.dist_tolerance, goal.angle_tolerance);
         execution.start();
         break;
 

--- a/mbf_msgs/action/ExePath.action
+++ b/mbf_msgs/action/ExePath.action
@@ -8,10 +8,10 @@ string controller
 # use different slots for concurrency
 uint8 concurrency_slot
 
-# define goal tolerance for the mission
-bool goal_tolerance
-float32 dist_to_goal_tolerance
-float32 angle_to_goal_tolerance
+# define goal tolerance for the action
+bool tolerance_from_action
+float32 dist_tolerance
+float32 angle_tolerance
 ---
 
 # Predefined success codes:

--- a/mbf_msgs/action/ExePath.action
+++ b/mbf_msgs/action/ExePath.action
@@ -8,6 +8,11 @@ string controller
 # use different slots for concurrency
 uint8 concurrency_slot
 
+# define goal tolerance for the mission
+bool specific_goal_tolerance
+float32 dist_to_goal_tolerance
+float32 angle_to_goal_tolerance
+
 ---
 
 # Predefined success codes:

--- a/mbf_msgs/action/ExePath.action
+++ b/mbf_msgs/action/ExePath.action
@@ -9,7 +9,7 @@ string controller
 uint8 concurrency_slot
 
 # define goal tolerance for the mission
-bool specific_goal_tolerance
+bool goal_tolerance
 float32 dist_to_goal_tolerance
 float32 angle_to_goal_tolerance
 

--- a/mbf_msgs/action/ExePath.action
+++ b/mbf_msgs/action/ExePath.action
@@ -12,7 +12,6 @@ uint8 concurrency_slot
 bool goal_tolerance
 float32 dist_to_goal_tolerance
 float32 angle_to_goal_tolerance
-
 ---
 
 # Predefined success codes:


### PR DESCRIPTION
It would be valuable if we could set/change the goal tolerance for each mission that is submitted to the mbf. This is mainly to capture the knowledge of the human operator about the goal point environment. For instance, depending on the accuracy of the localization at the goal point area or whether it might be too many obstacles around/at goal point location, the operator can change the tolerance for a goal point. This change is backward compatible and turned off by default, i.e., if user does not specify a tolerance for the goal, mbf will use the default logic to check for goal_reached criteria