### PR TITLE
Issue #183: Reuse execution slots; cleanup only at destruction

### DIFF
--- a/mbf_abstract_nav/src/abstract_execution_base.cpp
+++ b/mbf_abstract_nav/src/abstract_execution_base.cpp
@@ -59,7 +59,8 @@ void AbstractExecutionBase::stop()
 }
 
 void AbstractExecutionBase::join(){
-  thread_.join();
+  if (thread_.joinable())
+    thread_.join();
 }
 
 void AbstractExecutionBase::waitForStateUpdate(boost::chrono::microseconds const &duration)


### PR DESCRIPTION
Problem is that [here](https://github.com/magazino/move_base_flex/compare/get_path_freeze?expand=1#diff-21ac5e472653abd3e54d1178f443bb6eL88) we are joining a thread that can be already destroyed [here](https://github.com/magazino/move_base_flex/compare/get_path_freeze?expand=1#diff-21ac5e472653abd3e54d1178f443bb6eL83), because we do after unlocking slot_map_mtx_ [here](https://github.com/magazino/move_base_flex/compare/get_path_freeze?expand=1#diff-21ac5e472653abd3e54d1178f443bb6eL83).

With this PR, we don't cleanup execution slots, but reuse them (and cleanup remnants on shutdown).
I did heavy load with get_path/exe_path and the issue is fixed. I cannot detect neither any new memory or thread leak (though I noticed we have some at shutdown, se valgrind report below). I didn't perform stress testing with recovery actions.

```
==28807== HEAP SUMMARY:
==28807==     in use at exit: 688,798 bytes in 542 blocks
==28807==   total heap usage: 1,079,384 allocs, 1,078,842 frees, 570,985,052 bytes allocated
==28807== 
==28807== LEAK SUMMARY:
==28807==    definitely lost: 483,696 bytes in 33 blocks
==28807==    indirectly lost: 7,194 bytes in 122 blocks
==28807==      possibly lost: 304 bytes in 1 blocks
==28807==    still reachable: 197,604 bytes in 386 blocks
==28807==         suppressed: 0 bytes in 0 blocks
==28807== Rerun with --leak-check=full to see details of leaked memory
```