### PR TITLE
Hotfix: Prevent unrelated type casts for Cell

### DIFF
--- a/mbf_costmap_nav/include/mbf_costmap_nav/footprint_helper.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/footprint_helper.h
@@ -46,10 +46,10 @@
 namespace mbf_costmap_nav
 {
 
-typedef struct
+struct Cell
 {
-  uint16_t x, y;
-} Cell;
+  unsigned int x, y;
+};
 
 class FootprintHelper
 {

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -618,8 +618,10 @@ bool CostmapNavigationServer::callServiceCheckPathCost(mbf_msgs::CheckPath::Requ
     if (request.path_cells_only)
     {
       Cell cell;
-      if (costmap->getCostmap()->worldToMap(x, y, (unsigned int&)cell.x, (unsigned int&)cell.y))
+      if (costmap->getCostmap()->worldToMap(x, y, cell.x, cell.y))
+      {
         cells_to_check.push_back(cell);  // out of map if false; cells_to_check will be empty
+      }
     }
     else
     {


### PR DESCRIPTION
Hello @corot and @spuetz,

An `'unsigned int'` value was c-style casted to an unrelated type `'uint16_t'` (aka `'unsigned short'`). The width of both data models might differ on platforms. Thus, memory is accessed out-of-bounds which results in non-deterministic return values of the `CheckPath` service and probably other methods of the `FootprintHelper`. 

I created two small examples demonstrating the issue with godbolt:

https://godbolt.org/z/rxpvjM
https://godbolt.org/z/X-pibJ

Best Fabian

