### PR TITLE
fix deallocation on shutdown

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_plugin_manager.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_plugin_manager.h
@@ -68,6 +68,8 @@ class AbstractPluginManager
 
   typename PluginType::Ptr getPlugin(const std::string& name);
 
+  void clearPlugins();
+
  protected:
   std::map<std::string, typename PluginType::Ptr> plugins_;
   std::map<std::string, std::string> plugins_type_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/impl/abstract_plugin_manager.tcc
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/impl/abstract_plugin_manager.tcc
@@ -149,6 +149,13 @@ typename PluginType::Ptr AbstractPluginManager<PluginType>::getPlugin(const std:
   }
 }
 
+template <typename PluginType>
+void AbstractPluginManager<PluginType>::clearPlugins() {
+  plugins_.clear();
+  plugins_type_.clear();
+  names_.clear();
+}
+
 } /* namespace mbf_abstract_nav */
 
 #endif //MBF_ABSTRACT_NAV__ABSTRACT_PLUGIN_MANAGER_TCC_

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -89,6 +89,30 @@ CostmapNavigationServer::CostmapNavigationServer(const TFPtr &tf_listener_ptr) :
 
 CostmapNavigationServer::~CostmapNavigationServer()
 {
+  // remove every plugin before its classLoader goes out of scope.
+  {
+    const auto& names = planner_plugin_manager_.getLoadedNames();
+    for(const auto& name : names) {
+      planner_plugin_manager_.getPlugin(name).reset();
+    }
+  }
+  {
+    const auto& names = controller_plugin_manager_.getLoadedNames();
+    for(const auto& name : names) {
+      controller_plugin_manager_.getPlugin(name).reset();
+    }
+  }
+  {
+    const auto& names = recovery_plugin_manager_.getLoadedNames();
+    for(const auto& name : names) {
+      recovery_plugin_manager_.getPlugin(name).reset();
+    }
+  }
+
+  action_server_recovery_ptr_.reset();
+  action_server_exe_path_ptr_.reset();
+  action_server_get_path_ptr_.reset();
+  action_server_move_base_ptr_.reset();
 }
 
 mbf_abstract_nav::AbstractPlannerExecution::Ptr CostmapNavigationServer::newPlannerExecution(

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -90,24 +90,9 @@ CostmapNavigationServer::CostmapNavigationServer(const TFPtr &tf_listener_ptr) :
 CostmapNavigationServer::~CostmapNavigationServer()
 {
   // remove every plugin before its classLoader goes out of scope.
-  {
-    const auto& names = planner_plugin_manager_.getLoadedNames();
-    for(const auto& name : names) {
-      planner_plugin_manager_.getPlugin(name).reset();
-    }
-  }
-  {
-    const auto& names = controller_plugin_manager_.getLoadedNames();
-    for(const auto& name : names) {
-      controller_plugin_manager_.getPlugin(name).reset();
-    }
-  }
-  {
-    const auto& names = recovery_plugin_manager_.getLoadedNames();
-    for(const auto& name : names) {
-      recovery_plugin_manager_.getPlugin(name).reset();
-    }
-  }
+  controller_plugin_manager_.clearPlugins();
+  planner_plugin_manager_.clearPlugins();
+  recovery_plugin_manager_.clearPlugins();
 
   action_server_recovery_ptr_.reset();
   action_server_exe_path_ptr_.reset();


### PR DESCRIPTION
Hey guys, we had issues with bad noisy shutdowns.

Here is what happens: The CostmapNavigaitonServer owns the classLoader for every plugin. Its base-class holds the the loaded plugins. When the destructor of the CostmapNavigaitonServer is called, the classLoaders go out of scope before the loaded plugins. 

The solution is to destruct explicitly all loaded plugins of inside the CostmapNavigaitonServer destructor - allowing a clear shutdown. 
