### PR TITLE
Use the new extended tolerance options also in MoveBase and GetPath actions

### DIFF
--- a/mbf_abstract_core/include/mbf_abstract_core/abstract_planner.h
+++ b/mbf_abstract_core/include/mbf_abstract_core/abstract_planner.h
@@ -59,11 +59,13 @@ namespace mbf_abstract_core
       virtual ~AbstractPlanner(){};
 
       /**
-       * @brief Given a goal pose in the world, compute a plan
+       * @brief Given a goal pose in the world, compute a plan.
+       * The final pose of the path must be within tolerance range (position and orientation) for this method
+       * to return a success outcome.
        * @param start The start pose
        * @param goal The goal pose
-       * @param dist_tolerance how many meters away from the goal can end the created path
-       * @param angle_tolerance how many radians away from the goal can end the created path
+       * @param dist_tolerance Tolerance in meters to the goal position
+       * @param angle_tolerance Tolerance in radians to the goal orientation
        * @param plan The plan... filled by the planner
        * @param cost The cost for the the plan
        * @param message Optional more detailed outcome as a string

--- a/mbf_abstract_core/include/mbf_abstract_core/abstract_planner.h
+++ b/mbf_abstract_core/include/mbf_abstract_core/abstract_planner.h
@@ -62,8 +62,8 @@ namespace mbf_abstract_core
        * @brief Given a goal pose in the world, compute a plan
        * @param start The start pose
        * @param goal The goal pose
-       * @param tolerance If the goal is obstructed, how many meters the planner can relax the constraint
-       *        in x and y before failing
+       * @param dist_tolerance how many meters away from the goal can end the created path
+       * @param angle_tolerance how many radians away from the goal can end the created path
        * @param plan The plan... filled by the planner
        * @param cost The cost for the the plan
        * @param message Optional more detailed outcome as a string
@@ -84,8 +84,8 @@ namespace mbf_abstract_core
        *         71..99 are reserved as plugin specific errors
        */
       virtual uint32_t makePlan(const geometry_msgs::PoseStamped &start, const geometry_msgs::PoseStamped &goal,
-                                double tolerance, std::vector<geometry_msgs::PoseStamped> &plan, double &cost,
-                                std::string &message) = 0;
+                                double dist_tolerance, double angle_tolerance,
+                                std::vector<geometry_msgs::PoseStamped> &plan, double &cost, std::string &message) = 0;
 
       /**
        * @brief Requests the planner to cancel, e.g. if it takes too much time.

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -154,8 +154,8 @@ namespace mbf_abstract_nav
     /**
      * @brief Sets a new goal pose for the planner execution
      * @param goal the new goal pose
-     * @param dist_tolerance how many meters away from the goal can end the created path
-     * @param angle_tolerance how many radians away from the goal can end the created path
+     * @param dist_tolerance Tolerance in meters to the goal position
+     * @param angle_tolerance Tolerance in radians to the goal orientation
      */
     void setNewGoal(const geometry_msgs::PoseStamped &goal,
                     double dist_tolerance, double angle_tolerance);
@@ -170,8 +170,8 @@ namespace mbf_abstract_nav
      * @brief Sets a new star and goal pose for the planner execution
      * @param start new start pose
      * @param goal new goal pose
-     * @param dist_tolerance how many meters away from the goal can end the created path
-     * @param angle_tolerance how many radians away from the goal can end the created path
+     * @param dist_tolerance Tolerance in meters to the goal position
+     * @param angle_tolerance Tolerance in radians to the goal orientation
      */
     void setNewStartAndGoal(const geometry_msgs::PoseStamped &start, const geometry_msgs::PoseStamped &goal,
                             double dist_tolerance, double angle_tolerance);
@@ -180,8 +180,8 @@ namespace mbf_abstract_nav
      * @brief Starts the planner execution thread with the given parameters.
      * @param start start pose for the planning
      * @param goal goal pose for the planning
-     * @param dist_tolerance how many meters away from the goal can end the created path
-     * @param angle_tolerance how many radians away from the goal can end the created path
+     * @param dist_tolerance Tolerance in meters to the goal position
+     * @param angle_tolerance Tolerance in radians to the goal orientation
      * @return true, if the planner thread has been started, false if the thread is already running.
      */
     bool start(const geometry_msgs::PoseStamped &start, const geometry_msgs::PoseStamped &goal,
@@ -210,12 +210,13 @@ namespace mbf_abstract_nav
   private:
 
     /**
-     * @brief calls the planner plugin to make a plan from the start pose to the goal pose with the given tolerance,
-     *        if a goal tolerance is enabled in the planner plugin.
+     * @brief calls the planner plugin to make a plan from the start pose to the goal pose.
+     * The final pose of the path must be within tolerance range (position and orientation)
+     * for this method to return a success outcome.
      * @param start The start pose for planning
      * @param goal The goal pose for planning
-     * @param dist_tolerance how many meters away from the goal can end the created path
-     * @param angle_tolerance how many radians away from the goal can end the created path
+     * @param dist_tolerance Tolerance in meters to the goal position
+     * @param angle_tolerance Tolerance in radians to the goal orientation
      * @param plan The computed plan by the plugin
      * @param cost The computed costs for the corresponding plan
      * @param message An optional message which should correspond with the returned outcome

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -154,9 +154,11 @@ namespace mbf_abstract_nav
     /**
      * @brief Sets a new goal pose for the planner execution
      * @param goal the new goal pose
-     * @param tolerance tolerance to the goal for the planning
+     * @param dist_tolerance how many meters away from the goal can end the created path
+     * @param angle_tolerance how many radians away from the goal can end the created path
      */
-    void setNewGoal(const geometry_msgs::PoseStamped &goal, double tolerance);
+    void setNewGoal(const geometry_msgs::PoseStamped &goal,
+                    double dist_tolerance, double angle_tolerance);
 
     /**
      * @brief Sets a new start pose for the planner execution
@@ -168,20 +170,22 @@ namespace mbf_abstract_nav
      * @brief Sets a new star and goal pose for the planner execution
      * @param start new start pose
      * @param goal new goal pose
-     * @param tolerance tolerance to the new goal for the planning
+     * @param dist_tolerance how many meters away from the goal can end the created path
+     * @param angle_tolerance how many radians away from the goal can end the created path
      */
     void setNewStartAndGoal(const geometry_msgs::PoseStamped &start, const geometry_msgs::PoseStamped &goal,
-                            double tolerance);
+                            double dist_tolerance, double angle_tolerance);
 
     /**
      * @brief Starts the planner execution thread with the given parameters.
      * @param start start pose for the planning
      * @param goal goal pose for the planning
-     * @param tolerance tolerance to the goal pose for the planning
+     * @param dist_tolerance how many meters away from the goal can end the created path
+     * @param angle_tolerance how many radians away from the goal can end the created path
      * @return true, if the planner thread has been started, false if the thread is already running.
      */
     bool start(const geometry_msgs::PoseStamped &start, const geometry_msgs::PoseStamped &goal,
-               double tolerance);
+               double dist_tolerance, double angle_tolerance);
 
     /**
      * @brief Is called by the server thread to reconfigure the controller execution, if a user uses dynamic reconfigure
@@ -210,7 +214,8 @@ namespace mbf_abstract_nav
      *        if a goal tolerance is enabled in the planner plugin.
      * @param start The start pose for planning
      * @param goal The goal pose for planning
-     * @param tolerance The goal tolerance
+     * @param dist_tolerance how many meters away from the goal can end the created path
+     * @param angle_tolerance how many radians away from the goal can end the created path
      * @param plan The computed plan by the plugin
      * @param cost The computed costs for the corresponding plan
      * @param message An optional message which should correspond with the returned outcome
@@ -219,7 +224,7 @@ namespace mbf_abstract_nav
     virtual uint32_t makePlan(
         const geometry_msgs::PoseStamped &start,
         const geometry_msgs::PoseStamped &goal,
-        double tolerance,
+        double dist_tolerance, double angle_tolerance,
         std::vector<geometry_msgs::PoseStamped> &plan,
         double &cost,
         std::string &message);
@@ -266,8 +271,11 @@ namespace mbf_abstract_nav
     //! the current goal pose used for planning
     geometry_msgs::PoseStamped goal_;
 
-    //! optional goal tolerance, in meters
-    double tolerance_;
+    //! optional linear goal tolerance, in meters
+    double dist_tolerance_;
+
+    //! optional angular goal tolerance, in radians
+    double angle_tolerance_;
 
     //! planning cycle frequency (used only when running full navigation; we store here for grouping parameters nicely)
     double frequency_;

--- a/mbf_abstract_nav/src/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_planner_execution.cpp
@@ -134,11 +134,13 @@ std::vector<geometry_msgs::PoseStamped> AbstractPlannerExecution::getPlan()
 }
 
 
-void AbstractPlannerExecution::setNewGoal(const geometry_msgs::PoseStamped &goal, double tolerance)
+void AbstractPlannerExecution::setNewGoal(const geometry_msgs::PoseStamped &goal,
+                                          double dist_tolerance, double angle_tolerance)
 {
   boost::lock_guard<boost::mutex> guard(goal_start_mtx_);
   goal_ = goal;
-  tolerance_ = tolerance;
+  dist_tolerance_ = dist_tolerance;
+  angle_tolerance_ = angle_tolerance;
   has_new_goal_ = true;
 }
 
@@ -153,12 +155,13 @@ void AbstractPlannerExecution::setNewStart(const geometry_msgs::PoseStamped &sta
 
 void AbstractPlannerExecution::setNewStartAndGoal(const geometry_msgs::PoseStamped &start,
                                                   const geometry_msgs::PoseStamped &goal,
-                                                  double tolerance)
+                                                  double dist_tolerance, double angle_tolerance)
 {
   boost::lock_guard<boost::mutex> guard(goal_start_mtx_);
   start_ = start;
   goal_ = goal;
-  tolerance_ = tolerance;
+  dist_tolerance_ = dist_tolerance;
+  angle_tolerance_ = angle_tolerance;
   has_new_start_ = true;
   has_new_goal_ = true;
 }
@@ -166,7 +169,7 @@ void AbstractPlannerExecution::setNewStartAndGoal(const geometry_msgs::PoseStamp
 
 bool AbstractPlannerExecution::start(const geometry_msgs::PoseStamped &start,
                                      const geometry_msgs::PoseStamped &goal,
-                                     double tolerance)
+                                     double dist_tolerance, double angle_tolerance)
 {
   if (planning_)
   {
@@ -176,7 +179,8 @@ bool AbstractPlannerExecution::start(const geometry_msgs::PoseStamped &start,
   planning_ = true;
   start_ = start;
   goal_ = goal;
-  tolerance_ = tolerance;
+  dist_tolerance_ = dist_tolerance;
+  angle_tolerance_ = angle_tolerance;
 
   geometry_msgs::Point s = start.pose.position;
   geometry_msgs::Point g = goal.pose.position;
@@ -205,12 +209,12 @@ bool AbstractPlannerExecution::cancel()
 
 uint32_t AbstractPlannerExecution::makePlan(const geometry_msgs::PoseStamped &start,
                                             const geometry_msgs::PoseStamped &goal,
-                                            double tolerance,
+                                            double dist_tolerance, double angle_tolerance,
                                             std::vector<geometry_msgs::PoseStamped> &plan,
                                             double &cost,
                                             std::string &message)
 {
-  return planner_->makePlan(start, goal, tolerance, plan, cost, message);
+  return planner_->makePlan(start, goal, dist_tolerance, angle_tolerance, plan, cost, message);
 }
 
 void AbstractPlannerExecution::run()
@@ -220,7 +224,6 @@ void AbstractPlannerExecution::run()
   int retries = 0;
   geometry_msgs::PoseStamped current_start = start_;
   geometry_msgs::PoseStamped current_goal = goal_;
-  double current_tolerance = tolerance_;
 
   bool success = false;
   bool make_plan = false;
@@ -254,9 +257,8 @@ void AbstractPlannerExecution::run()
       {
         has_new_goal_ = false;
         current_goal = goal_;
-        current_tolerance = tolerance_;
-        ROS_INFO_STREAM("A new goal pose is available. Planning with the new goal pose and the tolerance: "
-                        << current_tolerance);
+        ROS_INFO_STREAM("A new goal pose is available. Planning with the new goal pose and tolerances: "
+                        << dist_tolerance_ << " m, " << angle_tolerance_ << " rad");
         exceeded = false;
         geometry_msgs::Point g = goal_.pose.position;
         ROS_INFO_STREAM("New goal pose: (" << g.x << ", " << g.y << ", " << g.z << ")");
@@ -269,7 +271,7 @@ void AbstractPlannerExecution::run()
       setState(PLANNING);
       if (make_plan)
       {
-        outcome_ = makePlan(current_start, current_goal, current_tolerance, plan, cost, message_);
+        outcome_ = makePlan(current_start, current_goal, dist_tolerance_, angle_tolerance_, plan, cost, message_);
         success = outcome_ < 10;
 
         boost::lock_guard<boost::mutex> guard(configuration_mutex_);

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -136,7 +136,14 @@ void MoveBaseAction::start(GoalHandle &goal_handle)
   get_path_goal_.target_pose = goal.target_pose;
   get_path_goal_.use_start_pose = false; // use the robot pose
   get_path_goal_.planner = goal.planner;
+  get_path_goal_.tolerance_from_action = goal.tolerance_from_action;
+  get_path_goal_.dist_tolerance = goal.dist_tolerance;
+  get_path_goal_.angle_tolerance = goal.angle_tolerance;
+
   exe_path_goal_.controller = goal.controller;
+  exe_path_goal_.tolerance_from_action = goal.tolerance_from_action;
+  exe_path_goal_.dist_tolerance = goal.dist_tolerance;
+  exe_path_goal_.angle_tolerance = goal.angle_tolerance;
 
   ros::Duration connection_timeout(1.0);
 

--- a/mbf_abstract_nav/src/planner_action.cpp
+++ b/mbf_abstract_nav/src/planner_action.cpp
@@ -65,13 +65,14 @@ void PlannerAction::run(GoalHandle &goal_handle, AbstractPlannerExecution &execu
   result.path.header.seq = path_seq_count_++;
   result.path.header.frame_id = robot_info_.getGlobalFrame();
 
-  double tolerance = goal.tolerance;
+  double dist_tolerance = goal.tolerance_from_action ? goal.dist_tolerance : 0.0;
+  double angle_tolerance = goal.tolerance_from_action ? goal.angle_tolerance : 0.0;
   bool use_start_pose = goal.use_start_pose;
   current_goal_pub_.publish(goal.target_pose);
 
   bool planner_active = true;
 
-  if(use_start_pose)
+  if (use_start_pose)
   {
     start_pose = goal.start_pose;
     const geometry_msgs::Point& p = start_pose.pose.position;
@@ -109,7 +110,7 @@ void PlannerAction::run(GoalHandle &goal_handle, AbstractPlannerExecution &execu
     {
       case AbstractPlannerExecution::INITIALIZED:
         ROS_DEBUG_STREAM_NAMED(name_, "planner state: initialized");
-        if (!execution.start(start_pose, goal.target_pose, tolerance))
+        if (!execution.start(start_pose, goal.target_pose, dist_tolerance, angle_tolerance))
         {
           result.outcome = mbf_msgs::GetPathResult::INTERNAL_ERROR;
           result.message = "Another thread is still planning!";

--- a/mbf_costmap_core/include/mbf_costmap_core/costmap_planner.h
+++ b/mbf_costmap_core/include/mbf_costmap_core/costmap_planner.h
@@ -56,10 +56,12 @@ namespace mbf_costmap_core {
 
       /**
        * @brief Given a goal pose in the world, compute a plan
+       * The final pose of the path must be within tolerance range (position and orientation)
+       * for this method to return a success outcome.
        * @param start The start pose
        * @param goal The goal pose
-       * @param dist_tolerance how many meters away from the goal can end the created path
-       * @param angle_tolerance how many radians away from the goal can end the created path
+       * @param dist_tolerance Tolerance in meters to the goal position
+       * @param angle_tolerance Tolerance in radians to the goal orientation
        * @param plan The plan... filled by the planner
        * @param cost The cost for the the plan
        * @param message Optional more detailed outcome as a string

--- a/mbf_costmap_core/include/mbf_costmap_core/costmap_planner.h
+++ b/mbf_costmap_core/include/mbf_costmap_core/costmap_planner.h
@@ -58,8 +58,8 @@ namespace mbf_costmap_core {
        * @brief Given a goal pose in the world, compute a plan
        * @param start The start pose
        * @param goal The goal pose
-       * @param tolerance If the goal is obstructed, how many meters the planner can relax the constraint
-       *        in x and y before failing
+       * @param dist_tolerance how many meters away from the goal can end the created path
+       * @param angle_tolerance how many radians away from the goal can end the created path
        * @param plan The plan... filled by the planner
        * @param cost The cost for the the plan
        * @param message Optional more detailed outcome as a string
@@ -80,8 +80,8 @@ namespace mbf_costmap_core {
        *         71..99 are reserved as plugin specific errors
        */
       virtual uint32_t makePlan(const geometry_msgs::PoseStamped &start, const geometry_msgs::PoseStamped &goal,
-                                double tolerance, std::vector<geometry_msgs::PoseStamped> &plan, double &cost,
-                                std::string &message) = 0;
+                                double dist_tolerance, double angle_tolerance,
+                                std::vector<geometry_msgs::PoseStamped> &plan, double &cost, std::string &message) = 0;
 
       /**
        * @brief Requests the planner to cancel, e.g. if it takes too much time.

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_planner_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_planner_execution.h
@@ -106,7 +106,8 @@ private:
    *        if a goal tolerance is enabled in the planner plugin.
    * @param start The start pose for planning
    * @param goal The goal pose for planning
-   * @param tolerance The goal tolerance
+   * @param dist_tolerance how many meters away from the goal can end the created path
+   * @param angle_tolerance how many radians away from the goal can end the created path
    * @param plan The computed plan by the plugin
    * @param cost The computed costs for the corresponding plan
    * @param message An optional message which should correspond with the returned outcome
@@ -115,7 +116,7 @@ private:
   virtual uint32_t makePlan(
       const geometry_msgs::PoseStamped &start,
       const geometry_msgs::PoseStamped &goal,
-      double tolerance,
+      double dist_tolerance, double angle_tolerance,
       std::vector<geometry_msgs::PoseStamped> &plan,
       double &cost,
       std::string &message);

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_planner_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_planner_execution.h
@@ -102,12 +102,13 @@ private:
   mbf_abstract_nav::MoveBaseFlexConfig toAbstract(const MoveBaseFlexConfig &config);
 
   /**
-   * @brief Calls the planner plugin to make a plan from the start pose to the goal pose with the given tolerance,
-   *        if a goal tolerance is enabled in the planner plugin.
+   * @brief Calls the planner plugin to make a plan from the start pose to the goal pose.
+   * The final pose of the path must be within tolerance range (position and orientation)
+   * for this method to return a success outcome.
    * @param start The start pose for planning
    * @param goal The goal pose for planning
-   * @param dist_tolerance how many meters away from the goal can end the created path
-   * @param angle_tolerance how many radians away from the goal can end the created path
+   * @param dist_tolerance Tolerance in meters to the goal position
+   * @param angle_tolerance Tolerance in radians to the goal orientation
    * @param plan The computed plan by the plugin
    * @param cost The computed costs for the corresponding plan
    * @param message An optional message which should correspond with the returned outcome

--- a/mbf_costmap_nav/include/nav_core_wrapper/wrapper_global_planner.h
+++ b/mbf_costmap_nav/include/nav_core_wrapper/wrapper_global_planner.h
@@ -56,10 +56,12 @@ namespace mbf_nav_core_wrapper {
 
       /**
        * @brief Given a goal pose in the world, compute a plan
+       * The final pose of the path must be within tolerance range (position and orientation)
+       * for this method to return a success outcome.
        * @param start The start pose
        * @param goal The goal pose
-       * @param dist_tolerance how many meters away from the goal can end the created path
-       * @param angle_tolerance how many radians away from the goal can end the created path
+       * @param dist_tolerance Tolerance in meters to the goal position
+       * @param angle_tolerance Tolerance in radians to the goal orientation
        * @param plan The plan... filled by the planner
        * @param cost The cost for the the plan
        * @param message Optional more detailed outcome as a string

--- a/mbf_costmap_nav/include/nav_core_wrapper/wrapper_global_planner.h
+++ b/mbf_costmap_nav/include/nav_core_wrapper/wrapper_global_planner.h
@@ -58,8 +58,8 @@ namespace mbf_nav_core_wrapper {
        * @brief Given a goal pose in the world, compute a plan
        * @param start The start pose
        * @param goal The goal pose
-       * @param tolerance If the goal is obstructed, how many meters the planner can relax the constraint
-       *        in x and y before failing
+       * @param dist_tolerance how many meters away from the goal can end the created path
+       * @param angle_tolerance how many radians away from the goal can end the created path
        * @param plan The plan... filled by the planner
        * @param cost The cost for the the plan
        * @param message Optional more detailed outcome as a string
@@ -67,8 +67,8 @@ namespace mbf_nav_core_wrapper {
        *         only 0 (SUCCESS) and 50 (FAILURE) are supported
        */
       virtual uint32_t makePlan(const geometry_msgs::PoseStamped &start, const geometry_msgs::PoseStamped &goal,
-                                double tolerance, std::vector<geometry_msgs::PoseStamped> &plan, double &cost,
-                                std::string &message);
+                                double dist_tolerance, double angle_tolerance,
+                                std::vector<geometry_msgs::PoseStamped> &plan, double &cost, std::string &message);
 
       /**
        * @brief Requests the planner to cancel, e.g. if it takes too much time.

--- a/mbf_costmap_nav/scripts/move_base_legacy_relay.py
+++ b/mbf_costmap_nav/scripts/move_base_legacy_relay.py
@@ -51,8 +51,9 @@ def mb_execute_cb(msg):
 
 def make_plan_cb(request):
     mbf_gp_ac.send_goal(mbf_msgs.GetPathGoal(start_pose=request.start, target_pose=request.goal,
-                                             use_start_pose=bool(request.start.header.frame_id),
-                                             planner=bgp, tolerance=request.tolerance))
+                                             use_start_pose=bool(request.start.header.frame_id), planner=bgp,
+                                             dist_tolerance=request.tolerance, angle_tolerance=request.tolerance,
+                                             tolerance_from_action=bool(request.tolerance > 0.0)))
     rospy.logdebug("Relaying legacy make_plan service to mbf get_path action server")
     mbf_gp_ac.wait_for_result()
 

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_planner_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_planner_execution.cpp
@@ -72,7 +72,7 @@ mbf_abstract_nav::MoveBaseFlexConfig CostmapPlannerExecution::toAbstract(const M
 
 uint32_t CostmapPlannerExecution::makePlan(const geometry_msgs::PoseStamped &start,
                                            const geometry_msgs::PoseStamped &goal,
-                                           double tolerance,
+                                           double dist_tolerance, double angle_tolerance,
                                            std::vector<geometry_msgs::PoseStamped> &plan,
                                            double &cost,
                                            std::string &message)
@@ -80,9 +80,9 @@ uint32_t CostmapPlannerExecution::makePlan(const geometry_msgs::PoseStamped &sta
   if (lock_costmap_)
   {
     boost::unique_lock<costmap_2d::Costmap2D::mutex_t> lock(*(costmap_ptr_->getCostmap()->getMutex()));
-    return planner_->makePlan(start, goal, tolerance, plan, cost, message);
+    return planner_->makePlan(start, goal, dist_tolerance, angle_tolerance, plan, cost, message);
   }
-  return planner_->makePlan(start, goal, tolerance, plan, cost, message);
+  return planner_->makePlan(start, goal, dist_tolerance, angle_tolerance, plan, cost, message);
 }
 
 } /* namespace mbf_costmap_nav */

--- a/mbf_costmap_nav/src/nav_core_wrapper/wrapper_global_planner.cpp
+++ b/mbf_costmap_nav/src/nav_core_wrapper/wrapper_global_planner.cpp
@@ -45,7 +45,7 @@ namespace mbf_nav_core_wrapper
 
 uint32_t WrapperGlobalPlanner::makePlan(const geometry_msgs::PoseStamped &start,
                                         const geometry_msgs::PoseStamped &goal,
-                                        double tolerance,
+                                        double dist_tolerance, double angle_tolerance,
                                         std::vector<geometry_msgs::PoseStamped> &plan,
                                         double &cost,
                                         std::string &message)

--- a/mbf_msgs/action/ExePath.action
+++ b/mbf_msgs/action/ExePath.action
@@ -8,10 +8,11 @@ string controller
 # use different slots for concurrency
 uint8 concurrency_slot
 
-# define goal tolerance for the action
+# Optionally overrule goal tolerances
 bool tolerance_from_action
 float32 dist_tolerance
 float32 angle_tolerance
+
 ---
 
 # Predefined success codes:

--- a/mbf_msgs/action/GetPath.action
+++ b/mbf_msgs/action/GetPath.action
@@ -15,7 +15,8 @@ string planner
 # use different slots for concurrency
 uint8 concurrency_slot
 
-# Optional: how many meters/radians away from the goal can end the created path
+# Optional: how many meters/radians away from the goal can end the created path. The final pose of the
+# path must be within tolerance range (position and orientation) for MBF to return a success outcome.
 bool tolerance_from_action
 float32 dist_tolerance
 float32 angle_tolerance

--- a/mbf_msgs/action/GetPath.action
+++ b/mbf_msgs/action/GetPath.action
@@ -9,14 +9,16 @@ geometry_msgs/PoseStamped start_pose
 # The pose to achieve with the path
 geometry_msgs/PoseStamped target_pose
 
-# If the goal is obstructed, how many meters the planner can relax the constraint in x and y before failing
-float64 tolerance
-
 # Planner to use; defaults to the first one specified on "planners" parameter
 string planner
 
 # use different slots for concurrency
 uint8 concurrency_slot
+
+# Optional: how many meters/radians away from the goal can end the created path
+bool tolerance_from_action
+float32 dist_tolerance
+float32 angle_tolerance
 
 ---
 

--- a/mbf_msgs/action/MoveBase.action
+++ b/mbf_msgs/action/MoveBase.action
@@ -12,6 +12,11 @@ string planner
 # Recovery behaviors to try on case of failure; defaults to the "recovery_behaviors" parameter value
 string[] recovery_behaviors
 
+# Optionally overrule controller's goal tolerances
+bool tolerance_from_action
+float32 dist_tolerance
+float32 angle_tolerance
+
 ---
 
 # Predefined success codes:


### PR DESCRIPTION
:warning: API-breaking changes... so only for master :disappointed: 

The idea is to extend the very useful tolerances-from-action concept to the other interfaces. It's both quite useful and a nice symmetry. Examples:

- For move_base action it's obvious that you want the same tool as on ExePath
- For GetPath, angle_tolerance is very useful to speed-up slow planners (e.g. sbpl) when you don't care about the final orientation

But I really, really, really want to rename the `tolerance_from_action` field... as it's very ackward (it's already in the action, so.... tolerances_from_where-if not???). I propose either

- use tolerances when both are > 0 (a bit subtle, but ok if well documented)
- rename as `use_tolerances`; nice symmetry with get_path.use_start_pose. @spuetz says it's ambiguous, but I disagree, given that it's a field in the goal, packed together with the tolerance values)
- rename as `tolerances_from_goal` (this my least preferred option, as it's only marginally better than `tolerance_from_action`)