### PR TITLE
Fix spelling error and remove trailing dots

### DIFF
--- a/mbf_abstract_nav/src/mbf_abstract_nav/__init__.py
+++ b/mbf_abstract_nav/src/mbf_abstract_nav/__init__.py
@@ -16,25 +16,25 @@ from dynamic_reconfigure.parameter_generator_catkin import str_t, double_t, int_
 
 def add_mbf_abstract_nav_params(gen):
     gen.add("planner_frequency", double_t, 0,
-            "The rate in Hz at which to run the planning loop.", 0, 0, 100)
+            "The rate in Hz at which to run the planning loop", 0, 0, 100)
     gen.add("planner_patience", double_t, 0,
-            "How long the planner will wait in seconds in an attempt to find a valid plan before giving up.", 5.0, 0, 100)
+            "How long the planner will wait in seconds in an attempt to find a valid plan before giving up", 5.0, 0, 100)
     gen.add("planner_max_retries", int_t, 0,
             "How many times we will recall the planner in an attempt to find a valid plan before giving up", -1, -1, 1000)
 
     gen.add("controller_frequency", double_t, 0,
-            "The rate in Hz at which to run the control loop and send velocity commands to the base.", 20, 0, 100)
+            "The rate in Hz at which to run the control loop and send velocity commands to the base", 20, 0, 100)
     gen.add("controller_patience", double_t, 0,
-            "How long the controller will wait in seconds without receiving a valid control before giving up.", 5.0, 0, 100)
+            "How long the controller will wait in seconds without receiving a valid control before giving up", 5.0, 0, 100)
     gen.add("controller_max_retries", int_t, 0,
-            "How many times we will recall the controller in an attempt to find a valid comand before giving up", -1, -1, 1000)
+            "How many times we will recall the controller in an attempt to find a valid command before giving up", -1, -1, 1000)
 
     gen.add("recovery_enabled", bool_t, 0,
-            "Whether or not to enable the move_base_flex recovery behaviors to attempt to clear out space.", True)
+            "Whether or not to enable the move_base_flex recovery behaviors to attempt to clear out space", True)
     gen.add("recovery_patience", double_t, 0,
             "How much time we allow recovery behaviors to complete before canceling (or stopping if cancel fails) them", 15.0, 0, 100)
 
     gen.add("oscillation_timeout", double_t, 0,
-            "How long in seconds to allow for oscillation before executing recovery behaviors.", 0.0, 0, 60)
+            "How long in seconds to allow for oscillation before executing recovery behaviors", 0.0, 0, 60)
     gen.add("oscillation_distance", double_t, 0,
-            "How far in meters the robot must move to be considered not to be oscillating.", 0.5, 0, 10)
+            "How far in meters the robot must move to be considered not to be oscillating", 0.5, 0, 10)

--- a/mbf_costmap_nav/cfg/MoveBaseFlex.cfg
+++ b/mbf_costmap_nav/cfg/MoveBaseFlex.cfg
@@ -14,7 +14,7 @@ gen.add("shutdown_costmaps", bool_t, 0,
         "Determines whether or not to shutdown the costmaps of the node when move_base_flex is in an inactive state",
         False)
 gen.add("shutdown_costmaps_delay", double_t, 0,
-        "How long in seconds to wait after last action before shutting down the costmaps.", 1.0, 0, 60)
+        "How long in seconds to wait after last action before shutting down the costmaps", 1.0, 0, 60)
 
 gen.add("restore_defaults", bool_t, 0, "Restore to the original configuration", False)
 


### PR DESCRIPTION
Trailing dots look bad on the tool tip messages, and some where missing anyway