### PR TITLE
Do not call isGoalReached on controller when mbf_tolerance_check parameter is true

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -311,13 +311,13 @@ namespace mbf_abstract_nav
     //! the last set plan which is currently processed by the controller
     std::vector<geometry_msgs::PoseStamped> plan_;
 
-    //! the duration which corresponds with the controller frequency.
+    //! the duration which corresponds with the controller frequency
     boost::chrono::microseconds calling_duration_;
 
-    //! the frame of the robot, which will be used to determine its position.
+    //! the frame of the robot, which will be used to determine its position
     std::string robot_frame_;
 
-    //! the global frame the robot is controlling in.
+    //! the global frame the robot is controlling in
     std::string global_frame_;
 
     //! publisher for the current velocity command
@@ -338,13 +338,13 @@ namespace mbf_abstract_nav
     //! main controller loop variable, true if the controller is running, false otherwise
     bool moving_;
 
-    //! whether move base flex should check for the goal tolerance or not.
-    bool mbf_tolerance_check_;
+    //! whether MBF should check if the robot has reached the goal, or delegate on the controller instead
+    bool mbf_check_goal_reached_;
 
-    //! whether move base flex should force the robot to stop once the goal is reached.
+    //! whether move base flex should force the robot to stop once the goal is reached
     bool force_stop_at_goal_;
 
-    //! whether move base flex should force the robot to stop on canceling navigation.
+    //! whether move base flex should force the robot to stop on canceling navigation
     bool force_stop_on_cancel_;
 
     //! distance tolerance to the given goal pose

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -67,7 +67,7 @@ AbstractControllerExecution::AbstractControllerExecution(
   private_nh.param("map_frame", global_frame_, std::string("map"));
   private_nh.param("force_stop_at_goal", force_stop_at_goal_, false);
   private_nh.param("force_stop_on_cancel", force_stop_on_cancel_, false);
-  private_nh.param("mbf_tolerance_check", mbf_tolerance_check_, false);
+  private_nh.param("check_goal_reached", mbf_check_goal_reached_, false);
   private_nh.param("dist_tolerance", dist_tolerance_, 0.1);
   private_nh.param("angle_tolerance", angle_tolerance_, M_PI / 18.0);
   private_nh.param("tf_timeout", tf_timeout_, 1.0);
@@ -247,18 +247,18 @@ bool AbstractControllerExecution::isMoving()
 
 bool AbstractControllerExecution::reachedGoalCheck()
 {
-  //if action has a specific tolerance, check goal reached with those tolerances
-  if (tolerance_from_action_)
-  {
-    return controller_->isGoalReached(action_dist_tolerance_, action_angle_tolerance_) ||
-        (mbf_tolerance_check_ && mbf_utility::distance(robot_pose_, plan_.back()) < action_dist_tolerance_
-        && mbf_utility::angle(robot_pose_, plan_.back()) < action_angle_tolerance_);
-  }
+  // Use action-provided tolerances if requested, or use parameter values otherwise
+  double dist_tolerance = tolerance_from_action_ ? action_dist_tolerance_ : dist_tolerance_;
+  double angle_tolerance = tolerance_from_action_ ? action_angle_tolerance_ : angle_tolerance_;
 
-  // Otherwise, check whether the controller plugin returns goal reached or if mbf should check for goal reached.
-  return controller_->isGoalReached(dist_tolerance_, angle_tolerance_) || (mbf_tolerance_check_
-      && mbf_utility::distance(robot_pose_, plan_.back()) < dist_tolerance_
-      && mbf_utility::angle(robot_pose_, plan_.back()) < angle_tolerance_);
+  if (mbf_check_goal_reached_)
+  {
+    // MBF checks if we have reached the goal, or...
+    return mbf_utility::distance(robot_pose_, plan_.back()) < dist_tolerance_ &&
+           mbf_utility::angle(robot_pose_, plan_.back()) < angle_tolerance_;
+  }
+  // ...we let the controller decide
+  return controller_->isGoalReached(dist_tolerance_, angle_tolerance_);
 }
 
 bool AbstractControllerExecution::cancel()

--- a/mbf_costmap_core/include/mbf_costmap_core/costmap_controller.h
+++ b/mbf_costmap_core/include/mbf_costmap_core/costmap_controller.h
@@ -116,7 +116,7 @@ namespace mbf_costmap_core {
        * @param tf A pointer to a transform listener
        * @param costmap_ros The cost map to use for assigning costs to local plans
        */
-      virtual void initialize(std::string name, TF *tf, costmap_2d::Costmap2DROS *costmap_ros) = 0;
+      virtual void initialize(std::string name, ::TF *tf, costmap_2d::Costmap2DROS *costmap_ros) = 0;
 
       /**
        * @brief  Virtual destructor for the interface


### PR DESCRIPTION
With this PR, we check if we have arrived instead of asking the controller. Current code considers that we have arrived when EITHER the controller or MBF consider that we have arrived, what is much less useful and confusing. You cannot, for example, enforce a higher precision than usual without calling controller dynamic reconfigure (assuming it has).

Caveat: as described in #213, MBF won't check if the robot is stopped when `check_goal_reached` is true, what is dangerous. As explained in the issue, it would be better instead to always delegate the arrived check to the controller, but pass him the tolerances provided in the goal when requested.

I also rename `mbf_tolerance_check` as `check_goal_reached`, as we are checking if we have arrived, independently of tolerances.