### PR TITLE
Check the absolute angle difference when checking angular tolerance

### DIFF
--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -252,13 +252,13 @@ bool AbstractControllerExecution::reachedGoalCheck()
   {
     return controller_->isGoalReached(action_dist_tolerance_, action_angle_tolerance_) ||
         (mbf_tolerance_check_ && mbf_utility::distance(robot_pose_, plan_.back()) < action_dist_tolerance_
-        && mbf_utility::angle(robot_pose_, plan_.back()) < action_angle_tolerance_);
+        && std::abs(mbf_utility::angle(robot_pose_, plan_.back())) < action_angle_tolerance_);
   }
 
   // Otherwise, check whether the controller plugin returns goal reached or if mbf should check for goal reached.
   return controller_->isGoalReached(dist_tolerance_, angle_tolerance_) || (mbf_tolerance_check_
       && mbf_utility::distance(robot_pose_, plan_.back()) < dist_tolerance_
-      && mbf_utility::angle(robot_pose_, plan_.back()) < angle_tolerance_);
+      && std::abs(mbf_utility::angle(robot_pose_, plan_.back())) < angle_tolerance_);
 }
 
 bool AbstractControllerExecution::cancel()


### PR DESCRIPTION
Actually, this is still not enough, as we also need to check that the robot is almost stopped. Like in the base_local_planner:
```
  bool stopped(const nav_msgs::Odometry& base_odom, 
      const double& rot_stopped_velocity, const double& trans_stopped_velocity){
    return fabs(base_odom.twist.twist.angular.z) <= rot_stopped_velocity 
      && fabs(base_odom.twist.twist.linear.x) <= trans_stopped_velocity
      && fabs(base_odom.twist.twist.linear.y) <= trans_stopped_velocity;
  }
```
But wee need to merge #189 to have actual robot speed to check that, so I'll do in another PR.