### PR TITLE
Ensure MBF does not crash upon receiving an empty path

### DIFF
--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -136,6 +136,8 @@ void ControllerAction::run(GoalHandle &goal_handle, AbstractControllerExecution 
     goal_handle.setAborted(result, result.message);
     ROS_ERROR_STREAM_NAMED(name_, result.message << " Canceling the action call.");
     controller_active = false;
+    goal_mtx_.unlock();
+    return;
   }
 
   goal_pose_ = plan.back();


### PR DESCRIPTION
To reproduce, open:
   ```rosrun actionlib axclient.py /move_base_flex/exe_path```
and send an empty goal.
master code will crash, while with this PR won't