### PR TITLE
On controller cancel, wait for the control loop to stop

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -119,9 +119,10 @@ namespace mbf_abstract_nav
       double action_angle_tolerance = 3.1415);
 
     /**
-     * @brief Cancel the planner execution. This calls the cancel method of the planner plugin. This could be useful if the
-     * computation takes too much time.
-     * @return true, if the planner plugin tries / tried to cancel the planning step.
+     * @brief Cancel the controller execution.
+     * This calls the cancel method of the controller plugin, sets the cancel_ flag to true,
+     * and waits for the control loop to stop. Normally called upon aborting the navigation.
+     * @return true, if the control loop stops within a cycle time.
      */
     virtual bool cancel();
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
@@ -66,7 +66,7 @@ class AbstractExecutionBase
 
   void join();
 
-  void waitForStateUpdate(boost::chrono::microseconds const &duration);
+  boost::cv_status waitForStateUpdate(boost::chrono::microseconds const &duration);
 
   /**
    * @brief Gets the current plugin execution outcome

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -145,8 +145,8 @@ namespace mbf_abstract_nav
     double getCost();
 
     /**
-     * @brief Cancel the planner execution. This calls the cancel method of the planner plugin. This could be useful if the
-     * computation takes too much time.
+     * @brief Cancel the planner execution. This calls the cancel method of the planner plugin.
+     * This could be useful if the computation takes too much time, or if we are aborting the navigation.
      * @return true, if the planner plugin tries / tried to cancel the planning step.
      */
     virtual bool cancel();

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
@@ -99,8 +99,8 @@ namespace mbf_abstract_nav
     bool isPatienceExceeded();
 
     /**
-     * @brief Cancel the planner execution. This calls the cancel method of the planner plugin. This could be useful if the
-     * computation takes too much time.
+     * @brief Cancel the planner execution. This calls the cancel method of the planner plugin.
+     * This could be useful if the computation takes too much time, or if we are aborting the navigation.
      * @return true, if the planner plugin tries / tried to cancel the planning step.
      */
     virtual bool cancel();

--- a/mbf_abstract_nav/src/abstract_execution_base.cpp
+++ b/mbf_abstract_nav/src/abstract_execution_base.cpp
@@ -63,11 +63,11 @@ void AbstractExecutionBase::join(){
     thread_.join();
 }
 
-void AbstractExecutionBase::waitForStateUpdate(boost::chrono::microseconds const &duration)
+boost::cv_status AbstractExecutionBase::waitForStateUpdate(boost::chrono::microseconds const &duration)
 {
   boost::mutex mutex;
   boost::unique_lock<boost::mutex> lock(mutex);
-  condition_.wait_for(lock, duration);
+  return condition_.wait_for(lock, duration);
 }
 
 uint32_t AbstractExecutionBase::getOutcome()


### PR DESCRIPTION
This fixes the sometimes appearing `To transition to a cancelled state, the goal must be in a pending, recalling, active, or preempting state, it is currently in state: 4`

I have noticed that it happens when we call exe_path right after it fails, e.g. when running a very fast recovery behavior in between. The reason seems to be that we set the goal as aborted and exit the control loop, but the execution is still active:

If you send another goal to exe_path immediately, MBF prints the error shown above and doesn't execute the new goal. use the following script to reproduce:

```
#!/usr/bin/env python

import rospy
import actionlib

from geometry_msgs.msg import PoseStamped

from mbf_msgs.msg import GetPathAction, GetPathGoal, GetPathResult
from mbf_msgs.msg import ExePathAction, ExePathGoal, ExePathResult

__author__ = 'santos'

""" 
Simplest possible MBF executive: sends goals provided through RViz on 2D Nav Goal tool to
move_base_flex/get_path action and sends the resulting path to move_base_flex/exe_path action
No fancy recovery or retry strategies.
"""

exe_path_goal = None


def nav_goal_cb(msg):
    global target_pose
    target_pose = msg
    goal = GetPathGoal(use_start_pose=False,
                       start_pose=msg,
                       target_pose=msg)
    get_path_ac.send_goal(goal, done_cb=plan_done_cb)

def plan_done_cb(status, result):
    if result.outcome == GetPathResult.SUCCESS:
        rospy.loginfo("Get path action succeeded")

        global exe_path_goal
        exe_path_goal = ExePathGoal(path=result.path, controller="PoseFollower")
        exe_path_ac.send_goal(exe_path_goal, done_cb=follow_done_cb)
    else:
        rospy.logerr("Get path action failed with error code [%d]: %s", result.outcome, result.message)

def follow_done_cb(status, result):
    if result.outcome == GetPathResult.SUCCESS:
        rospy.loginfo("Follow path action succeeded")
    else:
        rospy.logerr("Follow path action failed with error code [%d]: %s", result.outcome, result.message)
    #rospy.sleep(0.5)  TODO uncomment to make current code work
    exe_path_ac.send_goal(exe_path_goal, done_cb=follow_done_cb)

if __name__ == '__main__':
    rospy.init_node("simple_mbf_executive")

    target_pose = None

    get_path_ac = actionlib.SimpleActionClient("/move_base_flex/get_path", GetPathAction)
    get_path_ac.wait_for_server(rospy.Duration(5))
    exe_path_ac = actionlib.SimpleActionClient("/move_base_flex/exe_path", ExePathAction)
    exe_path_ac.wait_for_server(rospy.Duration(5))

    rospy.Subscriber('/move_base_simple/goal', PoseStamped, nav_goal_cb)

    rospy.spin()
```

Steps

1. run the script
2. send any goal with RViz
3. force the robot (easier on simulation) to not move, so oscillation triggers
4. on master, it freezes with the second iteration
5. uncomment the sleep in the script; not shouldn't freeze
6. comment again and try this PR; should also work

@Timple, would be great if you can try this, as you where toying with gentle controller canceling 