### PR TITLE
Send move_base result when canceled during exe_path and recovery

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
@@ -104,8 +104,12 @@ class MoveBaseAction
 
   bool attemptRecovery();
 
-  void cancelActiveClients();
-
+  /**
+   * Utility method that fills move base action result with the result of any of the action clients.
+   * @tparam ResultType
+   * @param result
+   * @param move_base_result
+   */
   template <typename ResultType>
   void fillMoveBaseResult(const ResultType& result, mbf_msgs::MoveBaseResult& move_base_result)
   {

--- a/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
@@ -104,6 +104,8 @@ class MoveBaseAction
 
   bool attemptRecovery();
 
+  void cancelActiveClients();
+
   template <typename ResultType>
   void fillMoveBaseResult(const ResultType& result, mbf_msgs::MoveBaseResult& move_base_result)
   {

--- a/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
@@ -104,6 +104,17 @@ class MoveBaseAction
 
   bool attemptRecovery();
 
+  template <typename ResultType>
+  void fillMoveBaseResult(const ResultType& result, mbf_msgs::MoveBaseResult& move_base_result)
+  {
+    // copy outcome and message from action client result
+    move_base_result.outcome = result.outcome;
+    move_base_result.message = result.message;
+    move_base_result.dist_to_goal = static_cast<float>(mbf_utility::distance(robot_pose_, goal_pose_));
+    move_base_result.angle_to_goal = static_cast<float>(mbf_utility::angle(robot_pose_, goal_pose_));
+    move_base_result.final_pose = robot_pose_;
+  }
+
   mbf_msgs::ExePathGoal exe_path_goal_;
   mbf_msgs::GetPathGoal get_path_goal_;
   mbf_msgs::RecoveryGoal recovery_goal_;
@@ -147,8 +158,6 @@ class MoveBaseAction
 
   //! true, if recovery behavior for the MoveBase action is enabled.
   bool recovery_enabled_;
-
-  mbf_msgs::MoveBaseFeedback move_base_feedback_;
 
   std::vector<std::string> recovery_behaviors_;
 

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -102,11 +102,7 @@ void MoveBaseAction::reconfigure(
 void MoveBaseAction::cancel()
 {
   action_state_ = CANCELED;
-  cancelActiveClients();
-}
 
-void MoveBaseAction::cancelActiveClients()
-{
   if (!action_client_get_path_.getState().isDone())
   {
     action_client_get_path_.cancelGoal();
@@ -225,7 +221,7 @@ void MoveBaseAction::actionExePathFeedback(
       std::stringstream oscillation_msgs;
       oscillation_msgs << "Robot is oscillating for " << (ros::Time::now() - last_oscillation_reset_).toSec() << "s!";
       ROS_WARN_STREAM_NAMED("move_base", oscillation_msgs.str());
-      cancelActiveClients();
+      action_client_exe_path_.cancelGoal();
 
       if (attemptRecovery())
       {

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -129,7 +129,7 @@ void MoveBaseAction::start(GoalHandle &goal_handle)
 
   ROS_DEBUG_STREAM_NAMED("move_base", "Start action "  << "move_base");
 
-  const mbf_msgs::MoveBaseGoal& goal = *(goal_handle.getGoal().get());
+  const mbf_msgs::MoveBaseGoal& goal = *goal_handle.getGoal();
 
   mbf_msgs::MoveBaseResult move_base_result;
 
@@ -187,14 +187,15 @@ void MoveBaseAction::actionExePathActive()
 void MoveBaseAction::actionExePathFeedback(
     const mbf_msgs::ExePathFeedbackConstPtr &feedback)
 {
-  move_base_feedback_.outcome = feedback->outcome;
-  move_base_feedback_.message = feedback->message;
-  move_base_feedback_.angle_to_goal = feedback->angle_to_goal;
-  move_base_feedback_.dist_to_goal = feedback->dist_to_goal;
-  move_base_feedback_.current_pose = feedback->current_pose;
-  move_base_feedback_.last_cmd_vel = feedback->last_cmd_vel;
+  mbf_msgs::MoveBaseFeedback move_base_feedback;
+  move_base_feedback.outcome = feedback->outcome;
+  move_base_feedback.message = feedback->message;
+  move_base_feedback.angle_to_goal = feedback->angle_to_goal;
+  move_base_feedback.dist_to_goal = feedback->dist_to_goal;
+  move_base_feedback.current_pose = feedback->current_pose;
+  move_base_feedback.last_cmd_vel = feedback->last_cmd_vel;
   robot_pose_ = feedback->current_pose;
-  goal_handle_.publishFeedback(move_base_feedback_);
+  goal_handle_.publishFeedback(move_base_feedback);
 
   // we create a navigation-level oscillation detection using exe_path action's feedback,
   // as the later doesn't handle oscillations created by quickly failing repeated plans
@@ -233,8 +234,8 @@ void MoveBaseAction::actionExePathFeedback(
         move_base_result.outcome = mbf_msgs::MoveBaseResult::OSCILLATION;
         move_base_result.message = oscillation_msgs.str();
         move_base_result.final_pose = robot_pose_;
-        move_base_result.angle_to_goal = move_base_feedback_.angle_to_goal;
-        move_base_result.dist_to_goal = move_base_feedback_.dist_to_goal;
+        move_base_result.angle_to_goal = move_base_feedback.angle_to_goal;
+        move_base_result.dist_to_goal = move_base_feedback.dist_to_goal;
         goal_handle_.setAborted(move_base_result, move_base_result.message);
       }
     }
@@ -245,12 +246,7 @@ void MoveBaseAction::actionGetPathDone(
     const actionlib::SimpleClientGoalState &state,
     const mbf_msgs::GetPathResultConstPtr &result_ptr)
 {
-  if (action_state_ == CANCELED)
-    return;
-
-  action_state_ =  FAILED;
-
-  const mbf_msgs::GetPathResult &result = *(result_ptr.get());
+  const mbf_msgs::GetPathResult &get_path_result = *result_ptr;
   mbf_msgs::MoveBaseResult move_base_result;
   switch (state.state_)
   {
@@ -263,7 +259,7 @@ void MoveBaseAction::actionGetPathDone(
           << "move_base\" received a path from \""
           << "get_path\": " << state.getText());
 
-      exe_path_goal_.path = result.path;
+      exe_path_goal_.path = get_path_result.path;
       ROS_DEBUG_STREAM_NAMED("move_base", "Action \""
           << "move_base\" sends the path to \""
           << "exe_path\".");
@@ -292,26 +288,21 @@ void MoveBaseAction::actionGetPathDone(
       else
       {
         // copy result from get_path action
-        move_base_result.outcome = result.outcome;
-        move_base_result.message = result.message;
-        move_base_result.dist_to_goal = static_cast<float>(mbf_utility::distance(robot_pose_, goal_pose_));
-        move_base_result.angle_to_goal = static_cast<float>(mbf_utility::angle(robot_pose_, goal_pose_));
-        move_base_result.final_pose = robot_pose_;
-
-        ROS_WARN_STREAM_NAMED("move_base", "Abort the execution of the planner: " << result.message);
+        fillMoveBaseResult(get_path_result, move_base_result);
+        ROS_WARN_STREAM_NAMED("move_base", "Abort the execution of the planner: " << get_path_result.message);
         goal_handle_.setAborted(move_base_result, state.getText());
       }
+      action_state_ =  FAILED;
       break;
 
     case actionlib::SimpleClientGoalState::PREEMPTED:
-      // the get_path action has been preempted.
+      ROS_ASSERT_MSG(action_state_ == CANCELED,
+                     "GetPath PREEMPTED: action state must be CANCELED, not %d", action_state_);
+    ROS_WARN_STREAM_NAMED("move_base", "The action \"" << "get_path" << "\" was preempted successfully!  "<< action_state_ << "   must be "<< CANCELED);
 
-      // copy result from get_path action
-      move_base_result.outcome = result.outcome;
-      move_base_result.message = result.message;
-      move_base_result.dist_to_goal = static_cast<float>(mbf_utility::distance(robot_pose_, goal_pose_));
-      move_base_result.angle_to_goal = static_cast<float>(mbf_utility::angle(robot_pose_, goal_pose_));
-      move_base_result.final_pose = robot_pose_;
+      // the get_path action has been preempted; copy result into move_base result
+      ROS_WARN_STREAM_NAMED("move_base", "The get_path action has been preempted!");
+      fillMoveBaseResult(get_path_result, move_base_result);
       goal_handle_.setCanceled(move_base_result, state.getText());
       break;
 
@@ -356,22 +347,13 @@ void MoveBaseAction::actionExePathDone(
     const actionlib::SimpleClientGoalState &state,
     const mbf_msgs::ExePathResultConstPtr &result_ptr)
 {
-  if (action_state_ == CANCELED)
-    return;
-
-  action_state_ =  FAILED;
-
   ROS_DEBUG_STREAM_NAMED("move_base", "Action \"exe_path\" finished.");
 
-  const mbf_msgs::ExePathResult& result = *(result_ptr.get());
+  const mbf_msgs::ExePathResult& exe_path_result = *result_ptr;
   mbf_msgs::MoveBaseResult move_base_result;
 
-  // copy result from get_path action
-  move_base_result.outcome = result.outcome;
-  move_base_result.message = result.message;
-  move_base_result.dist_to_goal = result.dist_to_goal;
-  move_base_result.angle_to_goal = result.angle_to_goal;
-  move_base_result.final_pose = result.final_pose;
+  // copy result from exe_path action
+  fillMoveBaseResult(exe_path_result, move_base_result);
 
   ROS_DEBUG_STREAM_NAMED("exe_path", "Current state:" << state.toString());
 
@@ -386,7 +368,9 @@ void MoveBaseAction::actionExePathDone(
       break;
 
     case actionlib::SimpleClientGoalState::ABORTED:
-      switch (result.outcome)
+      action_state_ =  FAILED;
+
+      switch (exe_path_result.outcome)
       {
         case mbf_msgs::ExePathResult::INVALID_PATH:
         case mbf_msgs::ExePathResult::TF_ERROR:
@@ -406,7 +390,7 @@ void MoveBaseAction::actionExePathDone(
           }
           else
           {
-            ROS_WARN_STREAM_NAMED("move_base", "Abort the execution of the controller: " << result.message);
+            ROS_WARN_STREAM_NAMED("move_base", "Abort the execution of the controller: " << exe_path_result.message);
             goal_handle_.setAborted(move_base_result, state.getText());
           }
           break;
@@ -414,10 +398,13 @@ void MoveBaseAction::actionExePathDone(
       break;
 
     case actionlib::SimpleClientGoalState::PREEMPTED:
-      // action was preempted successfully!
-      ROS_DEBUG_STREAM_NAMED("move_base", "The action \""
-          << "exe_path" << "\" was preempted successfully!");
-      // TODO
+      ROS_ASSERT_MSG(action_state_ == CANCELED,
+                     "ExePath PREEMPTED: action state must be CANCELED, not %d", action_state_);
+      ROS_WARN_STREAM_NAMED("move_base", "The action \"" << "exe_path" << "\" was preempted successfully!  "<< action_state_ << "   must be "<< CANCELED);
+
+      // the exe_path action has been preempted; copy result into move_base result
+      fillMoveBaseResult(exe_path_result, move_base_result);
+      goal_handle_.setCanceled(move_base_result, state.getText());
       break;
 
     case actionlib::SimpleClientGoalState::RECALLED:
@@ -483,29 +470,22 @@ void MoveBaseAction::actionRecoveryDone(
   // give the robot some time to stop oscillating after executing the recovery behavior
   last_oscillation_reset_ = ros::Time::now();
 
-  if (action_state_ == CANCELED)
-    return;
-
-  action_state_ =  FAILED;  // unless recovery succeeds or gets canceled...
-
-  const mbf_msgs::RecoveryResult& result = *(result_ptr.get());
+  const mbf_msgs::RecoveryResult& recovery_result = *result_ptr;
   mbf_msgs::MoveBaseResult move_base_result;
 
-  // copy result from get_path action
-  move_base_result.outcome = result.outcome;
-  move_base_result.message = result.message;
-  move_base_result.dist_to_goal = static_cast<float>(mbf_utility::distance(robot_pose_, goal_pose_));
-  move_base_result.angle_to_goal = static_cast<float>(mbf_utility::angle(robot_pose_, goal_pose_));
-  move_base_result.final_pose = robot_pose_;
+  // copy result from recovery action
+  fillMoveBaseResult(recovery_result, move_base_result);
 
   switch (state.state_)
   {
     case actionlib::SimpleClientGoalState::ABORTED:
+      action_state_ =  FAILED;
+
       ROS_DEBUG_STREAM_NAMED("move_base", "Recovery behavior aborted!");
       ROS_DEBUG_STREAM_NAMED("move_base", "The recovery behavior \""
           << *current_recovery_behavior_ << "\" failed. ");
-      ROS_DEBUG_STREAM("Recovery behavior message: " << result.message
-                                                     << ", outcome: " << result.outcome);
+      ROS_DEBUG_STREAM("Recovery behavior message: " << recovery_result.message
+                                    << ", outcome: " << recovery_result.outcome);
 
       current_recovery_behavior_++; // use next behavior;
       if (current_recovery_behavior_ == recovery_behaviors_.end())
@@ -540,13 +520,18 @@ void MoveBaseAction::actionRecoveryDone(
       );
       break;
     case actionlib::SimpleClientGoalState::PREEMPTED:
-      ROS_INFO_STREAM_NAMED("move_base",
-                             "The recovery action has been preempted!");
-      if(action_state_ == CANCELED)
-        goal_handle_.setCanceled();
+//      ROS_INFO_STREAM_NAMED("move_base", "The recovery action has been preempted!");
+
+      ROS_ASSERT_MSG(action_state_ == CANCELED,
+                     "Recovery PREEMPTED: action state must be CANCELED, not %d", action_state_);
+      ROS_WARN_STREAM_NAMED("move_base", "The action \"" << "recovery" << "\" was preempted successfully!  "<< action_state_ << "   must be "<< CANCELED);
+
+      // the recovery action has been preempted; copy result into move_base result
+      fillMoveBaseResult(recovery_result, move_base_result);
+      goal_handle_.setCanceled(move_base_result, state.getText());
       break;
 
-    case actionlib::SimpleClientGoalState::RECALLED:
+  case actionlib::SimpleClientGoalState::RECALLED:
       ROS_INFO_STREAM_NAMED("move_base",
                             "The recovery action has been recalled!");
       if(action_state_ == CANCELED)


### PR DESCRIPTION
On cancelling move_base action, we were calling goal_handle_.setCanceled only while running get_path, but not during exe_path nor recovery. So the action client didn't get any result (I noticed that because SMACH simple action state freezes after sending a cancel)

Other related changes (sorry, was too cumbersome to make a separated PR):
* Cancel whatever is running on oscillation (we can be also planning or recovering)
* Refactored a bit the code

Easily tested by sending any goal with axclient and canceling it, cause the status bar gets frozen in pink with the msg "Canceling goal":

`rosrun actionlib axclient.py /move_base_flex/move_base`