### PR TITLE
Use `catkin_install_python` to install legacy relay. #noetic

### DIFF
--- a/mbf_costmap_nav/CMakeLists.txt
+++ b/mbf_costmap_nav/CMakeLists.txt
@@ -105,6 +105,6 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
-install(PROGRAMS scripts/move_base_legacy_relay.py
+catkin_install_python(PROGRAMS scripts/move_base_legacy_relay.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )


### PR DESCRIPTION
According to [Changing_shebangs](http://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs) we need to install python scripts with `catkin_install_python()` to let `catkin` decide whether to run it with Python 2 or 3. This makes it runnable on future distributions, e.g. Ubuntu 20.04 focal and ROS noetic, as well as on older ones like 18.04 bionic and melodic.