### PR TITLE
clear the costmap before deactivating it

### DIFF
--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_wrapper.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_wrapper.cpp
@@ -130,10 +130,10 @@ void CostmapWrapper::deactivate(const ros::TimerEvent &event)
   boost::mutex::scoped_lock sl(check_costmap_mutex_);
 
   ROS_ASSERT_MSG(!costmap_users_, "Deactivating costmap with %d active users!", costmap_users_);
+  if (clear_on_shutdown_)
+    clear();  // do before stop, as some layers (e.g. obstacle and voxel) reactivate their subscribers on reset
   stop();
   ROS_DEBUG_STREAM("" << name_ << " deactivated");
-  if(clear_on_shutdown_)
-    clear();
 }
 
 } /* namespace mbf_costmap_nav */


### PR DESCRIPTION
Hi guys,

the clear_on_shutdown logic is flawed because obstacle- and voxel-grid-layers restart thier subscribers when their reset() is called. This means that the costmap itself is shutdown but the layers are still running in the background and processing the data.

I moved the reset before the stop. This is not ideal, since it is not guaranteed that the costmap will be really empty - but the best thing we can do without changing the costmap layers.