### PR TITLE
Fixed error: reference to TF is ambiguous

### DIFF
--- a/mbf_costmap_core/include/mbf_costmap_core/costmap_controller.h
+++ b/mbf_costmap_core/include/mbf_costmap_core/costmap_controller.h
@@ -116,7 +116,7 @@ namespace mbf_costmap_core {
        * @param tf A pointer to a transform listener
        * @param costmap_ros The cost map to use for assigning costs to local plans
        */
-      virtual void initialize(std::string name, TF *tf, costmap_2d::Costmap2DROS *costmap_ros) = 0;
+      virtual void initialize(std::string name, ::TF *tf, costmap_2d::Costmap2DROS *costmap_ros) = 0;
 
       /**
        * @brief  Virtual destructor for the interface


### PR DESCRIPTION
I have different TF class. So, ambiguous TF is fixed through the Scope Operator (::)