### PR TITLE
Controller fails if robot pose gets older than tf_timeout

### DIFF
--- a/mbf_abstract_nav/src/planner_action.cpp
+++ b/mbf_abstract_nav/src/planner_action.cpp
@@ -269,8 +269,8 @@ bool PlannerAction::transformPlanToGlobalFrame(
   for (iter = plan.begin(); iter != plan.end(); ++iter)
   {
     geometry_msgs::PoseStamped global_pose;
-    tf_success = mbf_utility::transformPose(robot_info_.getTransformListener(), robot_info_.getGlobalFrame(), iter->header.stamp,
-                                            robot_info_.getTfTimeout(), *iter, robot_info_.getGlobalFrame(), global_pose);
+    tf_success = mbf_utility::transformPose(robot_info_.getTransformListener(), robot_info_.getGlobalFrame(),
+                                            robot_info_.getTfTimeout(), *iter, global_pose);
     if (!tf_success)
     {
       ROS_ERROR_STREAM("Can not transform pose from the \"" << iter->header.frame_id << "\" frame into the \""

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -390,8 +390,7 @@ bool CostmapNavigationServer::callServiceCheckPointCost(mbf_msgs::CheckPoint::Re
   std::string costmap_frame = costmap->getGlobalFrameID();
 
   geometry_msgs::PointStamped point;
-  if (! mbf_utility::transformPoint(*tf_listener_ptr_, costmap_frame, request.point.header.stamp,
-                                     ros::Duration(0.5), request.point, global_frame_, point))
+  if (!mbf_utility::transformPoint(*tf_listener_ptr_, costmap_frame, ros::Duration(0.5), request.point, point))
   {
     ROS_ERROR_STREAM("Transform target point to " << costmap_name << " frame '" << costmap_frame << "' failed");
     return false;
@@ -470,7 +469,7 @@ bool CostmapNavigationServer::callServiceCheckPoseCost(mbf_msgs::CheckPose::Requ
   geometry_msgs::PoseStamped pose;
   if (request.current_pose)
   {
-    if (! mbf_utility::getRobotPose(*tf_listener_ptr_, robot_frame_, costmap_frame, ros::Duration(0.5), pose))
+    if (!mbf_utility::getRobotPose(*tf_listener_ptr_, robot_frame_, costmap_frame, ros::Duration(0.5), pose))
     {
       ROS_ERROR_STREAM("Get robot pose on " << costmap_name << " frame '" << costmap_frame << "' failed");
       return false;
@@ -478,8 +477,7 @@ bool CostmapNavigationServer::callServiceCheckPoseCost(mbf_msgs::CheckPose::Requ
   }
   else
   {
-    if (! mbf_utility::transformPose(*tf_listener_ptr_, costmap_frame, request.pose.header.stamp,
-                                     ros::Duration(0.5), request.pose, global_frame_, pose))
+    if (!mbf_utility::transformPose(*tf_listener_ptr_, costmap_frame, ros::Duration(0.5), request.pose, pose))
     {
       ROS_ERROR_STREAM("Transform target pose to " << costmap_name << " frame '" << costmap_frame << "' failed");
       return false;
@@ -614,8 +612,7 @@ bool CostmapNavigationServer::callServiceCheckPathCost(mbf_msgs::CheckPath::Requ
   {
     response.last_checked = i;
 
-    if (! mbf_utility::transformPose(*tf_listener_ptr_, costmap_frame, request.path.header.stamp,
-                                     ros::Duration(0.5), request.path.poses[i], global_frame_, pose))
+    if (!mbf_utility::transformPose(*tf_listener_ptr_, costmap_frame, ros::Duration(0.5), request.path.poses[i], pose))
     {
       ROS_ERROR_STREAM("Transform target pose to " << costmap_name << " frame '" << costmap_frame << "' failed");
       return false;

--- a/mbf_utility/include/mbf_utility/navigation_utility.h
+++ b/mbf_utility/include/mbf_utility/navigation_utility.h
@@ -58,38 +58,30 @@ namespace mbf_utility
  * @brief Transforms a point from one frame into another.
  * @param tf_listener TransformListener.
  * @param target_frame Target frame for the point.
- * @param target_time Time, in that the frames should be used.
  * @param timeout Timeout for looking up the transformation.
  * @param in Point to transform.
- * @param fixed_frame Fixed frame of the source and target frame.
  * @param out Transformed point.
  * @return true, if the transformation succeeded.
  */
 bool transformPoint(const TF &tf,
                     const std::string &target_frame,
-                    const ros::Time &target_time,
                     const ros::Duration &timeout,
                     const geometry_msgs::PointStamped &in,
-                    const std::string &fixed_frame,
                     geometry_msgs::PointStamped &out);
 
 /**
  * @brief Transforms a pose from one frame into another.
  * @param tf_listener TransformListener.
  * @param target_frame Target frame for the pose.
- * @param target_time Time, in that the frames should be used.
  * @param timeout Timeout for looking up the transformation.
  * @param in Pose to transform.
- * @param fixed_frame Fixed frame of the source and target frame.
  * @param out Transformed pose.
  * @return true, if the transformation succeeded.
  */
 bool transformPose(const TF &tf,
                    const std::string &target_frame,
-                   const ros::Time &target_time,
                    const ros::Duration &timeout,
                    const geometry_msgs::PoseStamped &in,
-                   const std::string &fixed_frame,
                    geometry_msgs::PoseStamped &out);
 
 /**

--- a/mbf_utility/src/robot_information.cpp
+++ b/mbf_utility/src/robot_information.cpp
@@ -56,7 +56,6 @@ bool RobotInformation::getRobotPose(geometry_msgs::PoseStamped &robot_pose) cons
 {
   bool tf_success = mbf_utility::getRobotPose(tf_listener_, robot_frame_, global_frame_,
                                               ros::Duration(tf_timeout_), robot_pose);
-  robot_pose.header.stamp = ros::Time::now(); // would be 0 if not, as we ask tf listener for the last pose available
   if (!tf_success)
   {
     ROS_ERROR_STREAM("Can not get the robot pose in the global frame. - robot frame: \""


### PR DESCRIPTION
Current code uses the advanced tf2 interfaces, that returns a pose with stamp 0 (we request time 0 to get the latest available transform when getting robot pose). We then overwrite with time now, what is not realistic. Worse, if localization goes off, getRobotPose will keep providing the latest available tf without any warning. If we are not using costmaps, that means that the robot will keep moving while thinking he's standing!

This PR changes to the simple tf2 interfaces that returns the stamp of the latest available tf, and considers it as non valid if older than tf_timeout. Exe path will fail in that case, and the robot will stop, even if not using costmaps.
Moreover, using the simple tf2 interface allows us to simplify in turn the interface of the utility functions.

:warning: Not tested on Kinetic or older that use TF 1. Can anyone do it? :warning: 