### PR TITLE
m&m for const-correctness

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -96,19 +96,19 @@ namespace mbf_abstract_nav
      * @param plan A reference to a plan, which then will be filled.
      * @param cost A reference to the costs, which then will be filled.
      */
-    std::vector<geometry_msgs::PoseStamped> getPlan();
+    std::vector<geometry_msgs::PoseStamped> getPlan() const;
 
     /**
      * @brief Returns the last time a valid plan was available.
      * @return time, the last valid plan was available.
      */
-    ros::Time getLastValidPlanTime();
+    ros::Time getLastValidPlanTime() const;
 
     /**
      * @brief Checks whether the patience was exceeded.
      * @return true, if the patience duration was exceeded.
      */
-    bool isPatienceExceeded();
+    bool isPatienceExceeded() const;
 
     /**
      * @brief Internal states
@@ -131,18 +131,18 @@ namespace mbf_abstract_nav
      * @brief Returns the current internal state
      * @return the current internal state
      */
-    PlanningState getState();
+    PlanningState getState() const;
 
     /**
      * @brief Gets planning frequency
      */
-    double getFrequency() { return frequency_; };
+    double getFrequency() const { return frequency_; };
 
     /**
      * @brief Gets computed costs
      * @return The costs of the computed path
      */
-    double getCost();
+    double getCost() const;
 
     /**
      * @brief Cancel the planner execution. This calls the cancel method of the planner plugin.
@@ -231,16 +231,19 @@ namespace mbf_abstract_nav
     void setState(PlanningState state);
 
     //! mutex to handle safe thread communication for the current state
-    boost::mutex state_mtx_;
+    mutable boost::mutex state_mtx_;
 
     //! mutex to handle safe thread communication for the plan and plan-costs
-    boost::mutex plan_mtx_;
+    mutable boost::mutex plan_mtx_;
 
     //! mutex to handle safe thread communication for the goal and start pose.
-    boost::mutex goal_start_mtx_;
+    mutable boost::mutex goal_start_mtx_;
 
     //! mutex to handle safe thread communication for the planning_ flag.
-    boost::mutex planning_mtx_;
+    mutable boost::mutex planning_mtx_;
+
+    //! dynamic reconfigure mutex for a thread safe communication
+    mutable boost::mutex configuration_mutex_;
 
     //! true, if a new goal pose has been set, until it is used.
     bool has_new_goal_;
@@ -292,9 +295,6 @@ namespace mbf_abstract_nav
 
     //! current internal state
     PlanningState state_;
-
-    //! dynamic reconfigure mutex for a thread safe communication
-    boost::mutex configuration_mutex_;
 
   };
 

--- a/mbf_abstract_nav/src/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_planner_execution.cpp
@@ -66,7 +66,7 @@ AbstractPlannerExecution::~AbstractPlannerExecution()
 }
 
 
-double AbstractPlannerExecution::getCost()
+double AbstractPlannerExecution::getCost() const
 {
   boost::lock_guard<boost::mutex> guard(plan_mtx_);
   // copy plan and costs to output
@@ -77,7 +77,7 @@ double AbstractPlannerExecution::getCost()
     double cost = 0;
 
     geometry_msgs::PoseStamped prev_pose = plan_.front();
-    for(std::vector<geometry_msgs::PoseStamped>::iterator iter = plan_.begin() + 1; iter != plan_.end(); ++iter)
+    for(std::vector<geometry_msgs::PoseStamped>::const_iterator iter = plan_.begin() + 1; iter != plan_.end(); ++iter)
     {
       cost += mbf_utility::distance(prev_pose, *iter);
       prev_pose = *iter;
@@ -100,7 +100,7 @@ void AbstractPlannerExecution::reconfigure(const MoveBaseFlexConfig &config)
 }
 
 
-typename AbstractPlannerExecution::PlanningState AbstractPlannerExecution::getState()
+typename AbstractPlannerExecution::PlanningState AbstractPlannerExecution::getState() const
 {
   boost::lock_guard<boost::mutex> guard(state_mtx_);
   return state_;
@@ -113,20 +113,20 @@ void AbstractPlannerExecution::setState(PlanningState state)
 }
 
 
-ros::Time AbstractPlannerExecution::getLastValidPlanTime()
+ros::Time AbstractPlannerExecution::getLastValidPlanTime() const
 {
   boost::lock_guard<boost::mutex> guard(plan_mtx_);
   return last_valid_plan_time_;
 }
 
 
-bool AbstractPlannerExecution::isPatienceExceeded()
+bool AbstractPlannerExecution::isPatienceExceeded() const
 {
   return !patience_.isZero() && (ros::Time::now() - last_call_start_time_ > patience_);
 }
 
 
-std::vector<geometry_msgs::PoseStamped> AbstractPlannerExecution::getPlan()
+std::vector<geometry_msgs::PoseStamped> AbstractPlannerExecution::getPlan() const
 {
   boost::lock_guard<boost::mutex> guard(plan_mtx_);
   // copy plan and costs to output


### PR DESCRIPTION
I've m&med all the mutexes from abstract_planner_execution and made all getters const; so it should be clearer that these functions don't alter the internal state of the class