### PR TITLE
Dima/abstract action base

### DIFF
--- a/mbf_abstract_nav/CMakeLists.txt
+++ b/mbf_abstract_nav/CMakeLists.txt
@@ -90,8 +90,8 @@ install(DIRECTORY include/${PROJECT_NAME}/
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
 
-  catkin_add_gmock(${PROJECT_NAME}_test test/abstract_action_base.cpp)
-  if(TARGET ${PROJECT_NAME}_test)
-    target_link_libraries(${PROJECT_NAME}_test ${MBF_ABSTRACT_SERVER_LIB})
-  endif()
+  add_rostest_gmock(abstract_action_base_test
+    test/abstract_action_base.launch
+    test/abstract_action_base.cpp)
+  target_link_libraries(abstract_action_base_test ${MBF_ABSTRACT_SERVER_LIB})
 endif()

--- a/mbf_abstract_nav/CMakeLists.txt
+++ b/mbf_abstract_nav/CMakeLists.txt
@@ -87,3 +87,11 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+
+  catkin_add_gmock(${PROJECT_NAME}_test test/abstract_action_base.cpp)
+  if(TARGET ${PROJECT_NAME}_test)
+    target_link_libraries(${PROJECT_NAME}_test ${MBF_ABSTRACT_SERVER_LIB})
+  endif()
+endif()

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -106,7 +106,8 @@ public:
     {
       // cancel and join all spawned threads.
       slot_it->second.execution->cancel();
-      slot_it->second.thread_ptr->join();
+      if(slot_it->second.thread_ptr->joinable())
+        slot_it->second.thread_ptr->join();
 
       // unregister and delete
       threads_.remove_thread(slot_it->second.thread_ptr);

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -65,8 +65,8 @@ namespace mbf_abstract_nav
  * @tparam Execution a class implementing the AbstractExecutionBase
  *
  * Place the implementation specific code into AbstractActionBase::runImpl.
- * Also it is required, that you have to define MyExecution::Ptr as a
- * shared pointer for your execution.
+ * Also it is required, that you define MyExecution::Ptr as a shared pointer
+ * for your execution.
  *
  */
 template <typename Action, typename Execution>
@@ -80,7 +80,7 @@ class AbstractActionBase
   struct ConcurrencySlot{
     ConcurrencySlot() : thread_ptr(NULL), in_use(false){}
     typename Execution::Ptr execution;
-    boost::thread* thread_ptr;
+    boost::thread* thread_ptr; ///< Owned pointer to a thread
     GoalHandle goal_handle;
     bool in_use;
   };
@@ -91,7 +91,15 @@ protected:
   typedef std::map<uint8_t, ConcurrencySlot> ConcurrencyMap;
 public:
 
-
+  /**
+   * @brief Construct a new AbstractActionBase
+   *
+   * @param name name of the AbstractActionBase
+   * @param robot_info robot information
+   *
+   * @warning Both arguments are stored by ref. You have to ensure, that
+   * the lifetime of name and robot_info exceeds the lifetime of this object.
+   */
   AbstractActionBase(
       const std::string &name,
       const mbf_utility::RobotInformation &robot_info

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -47,6 +47,13 @@
 namespace mbf_abstract_nav
 {
 
+/**
+ * Base class for managing multiple concurrent executions.
+ *
+ * @tparam Action an actionlib-compatible action
+ * @tparam Execution a class adhering to the AbstractExecutionBase
+ *
+ */
 template <typename Action, typename Execution>
 class AbstractActionBase
 {

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -77,12 +77,13 @@ class AbstractActionBase
   typedef typename actionlib::ActionServer<Action>::GoalHandle GoalHandle;
 
   /// @brief POD holding info for one execution
-  typedef struct{
+  struct ConcurrencySlot{
+    ConcurrencySlot() : thread_ptr(NULL), in_use(false){}
     typename Execution::Ptr execution;
-    boost::thread* thread_ptr = NULL;
+    boost::thread* thread_ptr;
     GoalHandle goal_handle;
-    bool in_use = false;
-  } ConcurrencySlot;
+    bool in_use;
+  };
 
 protected:
   // not part of the public interface

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -39,6 +39,15 @@
 #ifndef MBF_ABSTRACT_NAV__ABSTRACT_ACTION_BASE_H_
 #define MBF_ABSTRACT_NAV__ABSTRACT_ACTION_BASE_H_
 
+#include <boost/thread/thread.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/lock_guard.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/bind.hpp>
+
+#include <string>
+#include <map>
+
 #include <actionlib/server/action_server.h>
 #include <mbf_utility/robot_information.h>
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -137,14 +137,17 @@ public:
         if (slot_it->second.thread_ptr->joinable()) {
           slot_it->second.thread_ptr->join();
         }
+      }
 
+      if(slot_it != concurrency_slots_.end())
+      {
         // cleanup previous execution; otherwise we will leak threads
         threads_.remove_thread(concurrency_slots_[slot].thread_ptr);
         delete concurrency_slots_[slot].thread_ptr;
       }
-
-      // create a new map object in order to avoid costly lookups
-      if(slot_it == concurrency_slots_.end()) {
+      else
+      {
+        // create a new map object in order to avoid costly lookups
         // note: currently unchecked
         slot_it = concurrency_slots_.insert(std::make_pair(slot, ConcurrencySlot())).first;
       }

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
@@ -93,6 +93,11 @@ class AbstractExecutionBase
    */
   virtual void postRun() { };
 
+  /**
+   * @brief Optional implementaiton-specific configuration function.
+   */
+  virtual void reconfigure(MoveBaseFlexConfig& _cfg){}
+
 protected:
   virtual void run() = 0;
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -73,7 +73,7 @@ class ControllerAction :
       typename AbstractControllerExecution::Ptr execution_ptr
   );
 
-  void run(GoalHandle &goal_handle, AbstractControllerExecution &execution);
+  void runImpl(GoalHandle &goal_handle, AbstractControllerExecution& execution);
 
 protected:
   void publishExePathFeedback(

--- a/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
@@ -64,7 +64,7 @@ class PlannerAction : public AbstractActionBase<mbf_msgs::GetPathAction, Abstrac
       const mbf_utility::RobotInformation &robot_info
   );
 
-  void run(GoalHandle &goal_handle, AbstractPlannerExecution &execution);
+  void runImpl(GoalHandle &goal_handle, AbstractPlannerExecution &execution);
 
  protected:
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/recovery_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/recovery_action.h
@@ -61,7 +61,7 @@ class RecoveryAction : public AbstractActionBase<mbf_msgs::RecoveryAction, Abstr
 
   RecoveryAction(const std::string &name, const mbf_utility::RobotInformation &robot_info);
 
-  void run(GoalHandle &goal_handle, AbstractRecoveryExecution &execution);
+  void runImpl(GoalHandle &goal_handle, AbstractRecoveryExecution &execution);
 
 };
 

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -46,7 +46,7 @@ namespace mbf_abstract_nav
 ControllerAction::ControllerAction(
     const std::string &action_name,
     const mbf_utility::RobotInformation &robot_info)
-    : AbstractActionBase(action_name, robot_info, boost::bind(&mbf_abstract_nav::ControllerAction::run, this, _1, _2))
+    : AbstractActionBase(action_name, robot_info)
 {
 }
 
@@ -98,7 +98,7 @@ void ControllerAction::start(
   }
 }
 
-void ControllerAction::run(GoalHandle &goal_handle, AbstractControllerExecution &execution)
+void ControllerAction::runImpl(GoalHandle &goal_handle, AbstractControllerExecution &execution)
 {
   goal_mtx_.lock();
   // Note that we always use the goal handle stored on the concurrency slots map, as it can change when replanning

--- a/mbf_abstract_nav/src/planner_action.cpp
+++ b/mbf_abstract_nav/src/planner_action.cpp
@@ -48,14 +48,14 @@ namespace mbf_abstract_nav
 PlannerAction::PlannerAction(
     const std::string &name,
     const mbf_utility::RobotInformation &robot_info)
-  : AbstractActionBase(name, robot_info, boost::bind(&mbf_abstract_nav::PlannerAction::run, this, _1, _2)), path_seq_count_(0)
+  : AbstractActionBase(name, robot_info), path_seq_count_(0)
 {
   ros::NodeHandle private_nh("~");
   // informative topics: current navigation goal
   current_goal_pub_ = private_nh.advertise<geometry_msgs::PoseStamped>("current_goal", 1);
 }
 
-void PlannerAction::run(GoalHandle &goal_handle, AbstractPlannerExecution &execution)
+void PlannerAction::runImpl(GoalHandle &goal_handle, AbstractPlannerExecution &execution)
 {
   const mbf_msgs::GetPathGoal& goal = *(goal_handle.getGoal().get());
 

--- a/mbf_abstract_nav/src/recovery_action.cpp
+++ b/mbf_abstract_nav/src/recovery_action.cpp
@@ -44,9 +44,9 @@ namespace mbf_abstract_nav
 {
 
 RecoveryAction::RecoveryAction(const std::string &name, const mbf_utility::RobotInformation &robot_info)
-  : AbstractActionBase(name, robot_info, boost::bind(&mbf_abstract_nav::RecoveryAction::run, this, _1, _2)){}
+  : AbstractActionBase(name, robot_info){}
 
-void RecoveryAction::run(GoalHandle &goal_handle, AbstractRecoveryExecution &execution)
+void RecoveryAction::runImpl(GoalHandle &goal_handle, AbstractRecoveryExecution &execution)
 {
   ROS_DEBUG_STREAM_NAMED(name_, "Start action "  << name_);
 

--- a/mbf_abstract_nav/test/abstract_action_base.cpp
+++ b/mbf_abstract_nav/test/abstract_action_base.cpp
@@ -30,7 +30,7 @@ struct AbstractActionBaseFixture
       public Test {
   // required members for the c'tor
   TF tf_;
-  std::string test_name = "action_base";
+  std::string test_name;
   mbf_utility::RobotInformation ri;
 
   AbstractActionBaseFixture()
@@ -40,7 +40,7 @@ struct AbstractActionBaseFixture
   {
   }
 
-  void runImpl(GoalHandle &goal_handle, MockedExecution &execution) override {}
+  void runImpl(GoalHandle &goal_handle, MockedExecution &execution) {}
 };
 
 TEST_F(AbstractActionBaseFixture, thread_stop)

--- a/mbf_abstract_nav/test/abstract_action_base.cpp
+++ b/mbf_abstract_nav/test/abstract_action_base.cpp
@@ -64,8 +64,8 @@ TEST_F(AbstractActionBaseFixture, cancelAll)
   cancelAll();
 
   // check the result
-  for(const auto& slot : concurrency_slots_)
-    ASSERT_FALSE(slot.second.in_use);
+  for(ConcurrencyMap::iterator slot = concurrency_slots_.begin(); slot != concurrency_slots_.end(); ++slot)
+    ASSERT_FALSE(slot->second.in_use);
 
 }
 

--- a/mbf_abstract_nav/test/abstract_action_base.cpp
+++ b/mbf_abstract_nav/test/abstract_action_base.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+// dummy message
+#include <mbf_msgs/GetPathAction.h>
+#include <mbf_utility/robot_information.h>
+
+#include <mbf_abstract_nav/abstract_action_base.hpp>
+#include <mbf_abstract_nav/abstract_execution_base.h>
+
+using namespace mbf_abstract_nav;
+
+// mocked version of an execution
+struct MockedExecution : public AbstractExecutionBase
+{
+  typedef boost::shared_ptr<MockedExecution> Ptr;
+
+  MockedExecution() : AbstractExecutionBase("mocked_execution") {}
+
+  MOCK_METHOD0(cancel, bool());
+
+protected:
+  MOCK_METHOD0(run, void());
+};
+
+using testing::Test;
+
+struct AbstractActionBaseFixture : public AbstractActionBase<mbf_msgs::GetPathAction, MockedExecution>,
+                                   public Test
+{
+  TF tf_;
+  std::string test_name = "action_base";
+  mbf_utility::RobotInformation ri;
+  AbstractActionBaseFixture() : test_name("action_base"), ri(tf_, "global_frame", "local_frame", ros::Duration(0)), AbstractActionBase(test_name, ri) {}
+  void runImpl(GoalHandle &goal_handle, MockedExecution &execution) override {}
+};
+
+TEST_F(AbstractActionBaseFixture, thread_stop)
+{
+  unsigned char slot = 1;
+  concurrency_slots_[slot].execution.reset(new MockedExecution());
+  concurrency_slots_[slot].thread_ptr =
+      threads_.create_thread(boost::bind(&AbstractActionBaseFixture::run, this, boost::ref(concurrency_slots_[slot])));
+}
+
+using testing::Return;
+
+TEST_F(AbstractActionBaseFixture, cancelAll)
+{ 
+  // spawn a bunch of threads
+  for (unsigned char slot = 0; slot != 10; ++slot)
+  {
+    concurrency_slots_[slot].execution.reset(new MockedExecution());
+    // set the expectation
+    EXPECT_CALL(*concurrency_slots_[slot].execution, cancel()).WillRepeatedly(Return(true));
+
+    // set the in_use flag --> this should turn to false
+    concurrency_slots_[slot].in_use = true;
+    concurrency_slots_[slot].thread_ptr =
+        threads_.create_thread(boost::bind(&AbstractActionBaseFixture::run, this, boost::ref(concurrency_slots_[slot])));
+  }
+
+  // cancel all of slots
+  cancelAll();
+
+  // check the result
+  for(const auto& slot : concurrency_slots_)
+    ASSERT_FALSE(slot.second.in_use);
+
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/mbf_abstract_nav/test/abstract_action_base.cpp
+++ b/mbf_abstract_nav/test/abstract_action_base.cpp
@@ -1,5 +1,5 @@
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 // dummy message
 #include <mbf_msgs/GetPathAction.h>
@@ -11,8 +11,7 @@
 using namespace mbf_abstract_nav;
 
 // mocked version of an execution
-struct MockedExecution : public AbstractExecutionBase
-{
+struct MockedExecution : public AbstractExecutionBase {
   typedef boost::shared_ptr<MockedExecution> Ptr;
 
   MockedExecution() : AbstractExecutionBase("mocked_execution") {}
@@ -25,13 +24,22 @@ protected:
 
 using testing::Test;
 
-struct AbstractActionBaseFixture : public AbstractActionBase<mbf_msgs::GetPathAction, MockedExecution>,
-                                   public Test
-{
+// fixture with access to the AbstracActionBase's internals
+struct AbstractActionBaseFixture
+    : public AbstractActionBase<mbf_msgs::GetPathAction, MockedExecution>,
+      public Test {
+  // required members for the c'tor
   TF tf_;
   std::string test_name = "action_base";
   mbf_utility::RobotInformation ri;
-  AbstractActionBaseFixture() : test_name("action_base"), ri(tf_, "global_frame", "local_frame", ros::Duration(0)), AbstractActionBase(test_name, ri) {}
+
+  AbstractActionBaseFixture()
+      : test_name("action_base"),
+        ri(tf_, "global_frame", "local_frame", ros::Duration(0)),
+        AbstractActionBase(test_name, ri)
+  {
+  }
+
   void runImpl(GoalHandle &goal_handle, MockedExecution &execution) override {}
 };
 
@@ -40,37 +48,42 @@ TEST_F(AbstractActionBaseFixture, thread_stop)
   unsigned char slot = 1;
   concurrency_slots_[slot].execution.reset(new MockedExecution());
   concurrency_slots_[slot].thread_ptr =
-      threads_.create_thread(boost::bind(&AbstractActionBaseFixture::run, this, boost::ref(concurrency_slots_[slot])));
+      threads_.create_thread(boost::bind(&AbstractActionBaseFixture::run, this,
+                                         boost::ref(concurrency_slots_[slot])));
 }
 
 using testing::Return;
 
 TEST_F(AbstractActionBaseFixture, cancelAll)
-{ 
+{
   // spawn a bunch of threads
-  for (unsigned char slot = 0; slot != 10; ++slot)
-  {
+  for (unsigned char slot = 0; slot != 10; ++slot) {
     concurrency_slots_[slot].execution.reset(new MockedExecution());
     // set the expectation
-    EXPECT_CALL(*concurrency_slots_[slot].execution, cancel()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*concurrency_slots_[slot].execution, cancel())
+        .WillRepeatedly(Return(true));
 
     // set the in_use flag --> this should turn to false
     concurrency_slots_[slot].in_use = true;
-    concurrency_slots_[slot].thread_ptr =
-        threads_.create_thread(boost::bind(&AbstractActionBaseFixture::run, this, boost::ref(concurrency_slots_[slot])));
+    concurrency_slots_[slot].thread_ptr = threads_.create_thread(
+        boost::bind(&AbstractActionBaseFixture::run, this,
+                    boost::ref(concurrency_slots_[slot])));
   }
 
   // cancel all of slots
   cancelAll();
 
   // check the result
-  for(ConcurrencyMap::iterator slot = concurrency_slots_.begin(); slot != concurrency_slots_.end(); ++slot)
+  for (ConcurrencyMap::iterator slot = concurrency_slots_.begin();
+       slot != concurrency_slots_.end(); ++slot)
     ASSERT_FALSE(slot->second.in_use);
-
 }
 
 int main(int argc, char **argv)
 {
+  // we need this only for kinetic and lunar distros
+  ros::init(argc, argv, "abstract_action_base");
+  ros::NodeHandle nh;
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/mbf_abstract_nav/test/abstract_action_base.launch
+++ b/mbf_abstract_nav/test/abstract_action_base.launch
@@ -1,0 +1,3 @@
+<launch>
+  <test time-limit="10" test-name="abstract_action_base" pkg="mbf_abstract_nav" type="abstract_action_base_test"/>
+</launch>


### PR DESCRIPTION
Hey guys,

in this PR I fixup some minor issues and provide basic testing to the abstract_action_base class.

List of changes

## Misc
1. add missing includes
2. add some documentation for the abstract_action_base class
3. add a typedef for the concurrency map; we should change this later to unordered_map
4. avoid costly calls to concurrency_slots_[slot] but do it once

## API adjustments
1. this is really debatable but I added a runImpl function, which allows us to skip the boost::bind stuff. i think it expresses/documents  better what is exactly required to implement the action base
2. We call execution.reconfigure() from the abstract_action_base. I've added that as a virtual method to the abstract_execution_base to account for that.

## Fixes
1. Our destructor would not join the threads. fixed that.