### PR TITLE
fix blind driving

### DIFF
--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
@@ -106,7 +106,7 @@ private:
    */
   virtual mbf_abstract_nav::AbstractPlannerExecution::Ptr newPlannerExecution(
       const std::string &plugin_name,
-      const mbf_abstract_core::AbstractPlanner::Ptr plugin_ptr);
+      const mbf_abstract_core::AbstractPlanner::Ptr &plugin_ptr);
 
   /**
    * @brief Create a new controller execution.
@@ -116,7 +116,7 @@ private:
    */
   virtual mbf_abstract_nav::AbstractControllerExecution::Ptr newControllerExecution(
       const std::string &plugin_name,
-      const mbf_abstract_core::AbstractController::Ptr plugin_ptr);
+      const mbf_abstract_core::AbstractController::Ptr &plugin_ptr);
 
   /**
    * @brief Create a new recovery behavior execution.
@@ -126,7 +126,7 @@ private:
    */
   virtual mbf_abstract_nav::AbstractRecoveryExecution::Ptr newRecoveryExecution(
       const std::string &plugin_name,
-      const mbf_abstract_core::AbstractRecovery::Ptr plugin_ptr);
+      const mbf_abstract_core::AbstractRecovery::Ptr &plugin_ptr);
 
   /**
    * @brief Loads the plugin associated with the given planner_type parameter.

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -103,7 +103,7 @@ CostmapNavigationServer::~CostmapNavigationServer()
 
 mbf_abstract_nav::AbstractPlannerExecution::Ptr CostmapNavigationServer::newPlannerExecution(
     const std::string &plugin_name,
-    const mbf_abstract_core::AbstractPlanner::Ptr plugin_ptr)
+    const mbf_abstract_core::AbstractPlanner::Ptr &plugin_ptr)
 {
   return boost::make_shared<mbf_costmap_nav::CostmapPlannerExecution>(
       plugin_name,
@@ -114,7 +114,7 @@ mbf_abstract_nav::AbstractPlannerExecution::Ptr CostmapNavigationServer::newPlan
 
 mbf_abstract_nav::AbstractControllerExecution::Ptr CostmapNavigationServer::newControllerExecution(
     const std::string &plugin_name,
-    const mbf_abstract_core::AbstractController::Ptr plugin_ptr)
+    const mbf_abstract_core::AbstractController::Ptr &plugin_ptr)
 {
   return boost::make_shared<mbf_costmap_nav::CostmapControllerExecution>(
       plugin_name,
@@ -128,7 +128,7 @@ mbf_abstract_nav::AbstractControllerExecution::Ptr CostmapNavigationServer::newC
 
 mbf_abstract_nav::AbstractRecoveryExecution::Ptr CostmapNavigationServer::newRecoveryExecution(
     const std::string &plugin_name,
-    const mbf_abstract_core::AbstractRecovery::Ptr plugin_ptr)
+    const mbf_abstract_core::AbstractRecovery::Ptr &plugin_ptr)
 {
   return boost::make_shared<mbf_costmap_nav::CostmapRecoveryExecution>(
       plugin_name,


### PR DESCRIPTION
Hey guys,

In the PR #198 we changed the signature of the abstract_navigation_server. However, the signature of the costmap_navigation_server was forgotten; the effect was that we were driving "blindly" - without a costmap. This PR fixes the issue. Maybe we can at one point embrace c++11 (override would have helped here)