### PR TITLE
Dima/abstract execution base

### DIFF
--- a/mbf_abstract_nav/CMakeLists.txt
+++ b/mbf_abstract_nav/CMakeLists.txt
@@ -90,6 +90,10 @@ install(DIRECTORY include/${PROJECT_NAME}/
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
 
+  # gtests
+  catkin_add_gtest(${MBF_ABSTRACT_SERVER_LIB}_gtest test/abstract_execution_base.cpp)
+  target_link_libraries(${MBF_ABSTRACT_SERVER_LIB}_gtest ${MBF_ABSTRACT_SERVER_LIB})
+  
   # ros-tests
   add_rostest_gmock(abstract_action_base_test
     test/abstract_action_base.launch

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
@@ -71,7 +71,10 @@ class AbstractExecutionBase
     * @brief Cancel the plugin execution.
     * @return true, if the plugin tries / tried to cancel the computation.
     */
-   virtual bool cancel() = 0;
+   virtual bool cancel()
+   {
+     return false;
+   };
 
    void join();
 
@@ -109,7 +112,7 @@ class AbstractExecutionBase
    {}
 
 protected:
-  virtual void run() = 0;
+  virtual void run(){};
 
   //! condition variable to wake up control thread
   boost::condition_variable condition_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
@@ -109,7 +109,8 @@ class AbstractExecutionBase
     * @brief Optional implementaiton-specific configuration function.
     */
    virtual void reconfigure(MoveBaseFlexConfig& _cfg)
-   {}
+   {
+   }
 
 protected:
   virtual void run(){};

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
@@ -45,58 +45,68 @@
 
 #include <mbf_abstract_nav/MoveBaseFlexConfig.h>
 
+#include <string>
+
 namespace mbf_abstract_nav
 {
-
+/**
+ * @brief Base class for running concurrent navigation tasks.
+ *
+ * The class uses a dedicated thread to run potentially long-lasting jobs.
+ * The user can use waitForStateUpdate to get notification about the progress
+ * of the said job.
+ */
 class AbstractExecutionBase
 {
  public:
+   AbstractExecutionBase(const std::string& name);
 
-  AbstractExecutionBase(std::string name);
+   virtual ~AbstractExecutionBase();
 
-  virtual bool start();
+   virtual bool start();
 
-  virtual void stop();
+   virtual void stop();
 
-  /**
-   * @brief Cancel the plugin execution.
-   * @return true, if the plugin tries / tried to cancel the computation.
-   */
-  virtual bool cancel() = 0;
+   /**
+    * @brief Cancel the plugin execution.
+    * @return true, if the plugin tries / tried to cancel the computation.
+    */
+   virtual bool cancel() = 0;
 
-  void join();
+   void join();
 
-  boost::cv_status waitForStateUpdate(boost::chrono::microseconds const &duration);
+   boost::cv_status waitForStateUpdate(boost::chrono::microseconds const& duration);
 
-  /**
-   * @brief Gets the current plugin execution outcome
-   */
-  uint32_t getOutcome();
+   /**
+    * @brief Gets the current plugin execution outcome
+    */
+   uint32_t getOutcome() const;
 
-  /**
-   * @brief Gets the current plugin execution message
-   */
-  std::string getMessage();
+   /**
+    * @brief Gets the current plugin execution message
+    */
+   const std::string& getMessage() const;
 
-  /**
-   * @brief Returns the name of the corresponding plugin
-   */
-  std::string getName();
+   /**
+    * @brief Returns the name of the corresponding plugin
+    */
+   const std::string& getName() const;
 
-  /**
-   * @brief Optional implementation-specific setup function, called right before execution.
-   */
-  virtual void preRun() { };
+   /**
+    * @brief Optional implementation-specific setup function, called right before execution.
+    */
+   virtual void preRun(){};
 
-  /**
-   * @brief Optional implementation-specific cleanup function, called right after execution.
-   */
-  virtual void postRun() { };
+   /**
+    * @brief Optional implementation-specific cleanup function, called right after execution.
+    */
+   virtual void postRun(){};
 
-  /**
-   * @brief Optional implementaiton-specific configuration function.
-   */
-  virtual void reconfigure(MoveBaseFlexConfig& _cfg){}
+   /**
+    * @brief Optional implementaiton-specific configuration function.
+    */
+   virtual void reconfigure(MoveBaseFlexConfig& _cfg)
+   {}
 
 protected:
   virtual void run() = 0;

--- a/mbf_abstract_nav/src/abstract_execution_base.cpp
+++ b/mbf_abstract_nav/src/abstract_execution_base.cpp
@@ -46,12 +46,28 @@ AbstractExecutionBase::AbstractExecutionBase(const std::string& name) : outcome_
 
 AbstractExecutionBase::~AbstractExecutionBase()
 {
-  stop();
-  join();
+  if (thread_.joinable())
+  {
+    // if the user forgets to call stop(), we have to kill it
+    stop();
+    thread_.join();
+  }
 }
 
 bool AbstractExecutionBase::start()
 {
+  if (thread_.joinable())
+  {
+    // if the user forgets to call stop(), we have to kill it
+    stop();
+    thread_.join();
+  }
+
+  // reset the member vars
+  cancel_ = false;
+  outcome_ = 255;
+  message_.clear();
+
   thread_ = boost::thread(&AbstractExecutionBase::run, this);
   return true;
 }

--- a/mbf_abstract_nav/src/abstract_execution_base.cpp
+++ b/mbf_abstract_nav/src/abstract_execution_base.cpp
@@ -40,10 +40,14 @@
 
 namespace mbf_abstract_nav
 {
-
-AbstractExecutionBase::AbstractExecutionBase(std::string name)
-  : outcome_(255), cancel_(false), name_(name)
+AbstractExecutionBase::AbstractExecutionBase(const std::string& name) : outcome_(255), cancel_(false), name_(name)
 {
+}
+
+AbstractExecutionBase::~AbstractExecutionBase()
+{
+  stop();
+  join();
 }
 
 bool AbstractExecutionBase::start()
@@ -70,17 +74,17 @@ boost::cv_status AbstractExecutionBase::waitForStateUpdate(boost::chrono::micros
   return condition_.wait_for(lock, duration);
 }
 
-uint32_t AbstractExecutionBase::getOutcome()
+uint32_t AbstractExecutionBase::getOutcome() const
 {
   return outcome_;
 }
 
-std::string AbstractExecutionBase::getMessage()
+const std::string& AbstractExecutionBase::getMessage() const
 {
   return message_;
 }
 
-std::string AbstractExecutionBase::getName()
+const std::string& AbstractExecutionBase::getName() const
 {
   return name_;
 }

--- a/mbf_abstract_nav/test/abstract_execution_base.cpp
+++ b/mbf_abstract_nav/test/abstract_execution_base.cpp
@@ -1,0 +1,90 @@
+#include <gtest/gtest.h>
+#include <mbf_abstract_nav/abstract_execution_base.h>
+
+using namespace mbf_abstract_nav;
+
+// our dummy implementation of the AbstractExecutionBase
+// it basically runs until we cancel it.
+struct DummyExecutionBase : public AbstractExecutionBase
+{
+  DummyExecutionBase(const std::string& _name) : AbstractExecutionBase(_name)
+  {
+  }
+
+  // implement the required interfaces
+  bool cancel()
+  {
+    cancel_ = true;
+    condition_.notify_all();
+    return true;
+  }
+
+protected:
+  void run()
+  {
+    boost::mutex mutex;
+    boost::unique_lock<boost::mutex> lock(mutex);
+
+    // wait until someone says we are done (== cancel or stop)
+    condition_.wait(lock);
+    outcome_ = 0;
+  }
+};
+
+// shortcuts...
+using testing::Test;
+
+// the fixture owning the instance of the DummyExecutionBase
+struct AbstractExecutionFixture : public Test
+{
+  DummyExecutionBase impl_;
+
+  AbstractExecutionFixture() : impl_("foo")
+  {
+  }
+};
+
+TEST_F(AbstractExecutionFixture, timeout)
+{
+  // start the thread
+  impl_.start();
+
+  // make sure that we timeout and dont alter the outcome
+  EXPECT_EQ(impl_.waitForStateUpdate(boost::chrono::microseconds(60)), boost::cv_status::timeout);
+  EXPECT_EQ(impl_.getOutcome(), 255);
+}
+
+TEST_F(AbstractExecutionFixture, success)
+{
+  // start the thread
+  impl_.start();
+  EXPECT_EQ(impl_.waitForStateUpdate(boost::chrono::microseconds(60)), boost::cv_status::timeout);
+
+  // cancel, so we set the outcome to 0
+  impl_.cancel();
+  impl_.join();
+  EXPECT_EQ(impl_.getOutcome(), 0);
+}
+
+TEST_F(AbstractExecutionFixture, restart)
+{
+  // call start multiple times without waiting for its termination
+  for (size_t ii = 0; ii != 10; ++ii)
+    impl_.start();
+}
+
+TEST_F(AbstractExecutionFixture, stop)
+{
+  // call stop/terminate multiple times. this should be a noop
+  for (size_t ii = 0; ii != 10; ++ii)
+  {
+    impl_.stop();
+    impl_.join();
+  }
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Hi guys, 

The testing goes on. In this pr its about the abstract_execution_base.

# MInor adjustments
- pass and get strings by const ref instread of by value

# Major Fixes
- we never joined threads when destructing the class.
- we never checked if the thread_ actually was stopped when starting it.
- I get a segfault if the instance would be destructed right after calling start(). The exact reason for this is rather complex (== not sure if I understand it fully myself) but converting the pure virtual methods to just virtual methods solves it.
- we never reset cancel_ and other execution related data. As far as i can see this would render the whole class unusable if the user would cancel an action once.

Best,
Dima