### PR TITLE
fix test

### DIFF
--- a/mbf_abstract_nav/test/abstract_execution_base.cpp
+++ b/mbf_abstract_nav/test/abstract_execution_base.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include <mbf_abstract_nav/abstract_execution_base.h>
 
+#include <boost/chrono.hpp>
+
 using namespace mbf_abstract_nav;
 
 // our dummy implementation of the AbstractExecutionBase
@@ -26,7 +28,9 @@ protected:
     boost::unique_lock<boost::mutex> lock(mutex);
 
     // wait until someone says we are done (== cancel or stop)
-    condition_.wait(lock);
+    // we set a timeout, since we might miss the cancel call (especially if we
+    // run on an environment with high CPU load)
+    condition_.wait_for(lock, boost::chrono::seconds(1));
     outcome_ = 0;
   }
 };


### PR DESCRIPTION
If we run on Github, we run into a race-condition within the newly added gtest. To replicate start stress-ng on your machine such that stress-ng runs on all cores but one. Then run the tests in a separate terminal.