### PR TITLE
Dima/abstract controller execution

### DIFF
--- a/mbf_abstract_nav/CMakeLists.txt
+++ b/mbf_abstract_nav/CMakeLists.txt
@@ -99,7 +99,12 @@ if(CATKIN_ENABLE_TESTING)
     test/abstract_action_base.launch
     test/abstract_action_base.cpp)
   target_link_libraries(abstract_action_base_test ${MBF_ABSTRACT_SERVER_LIB})
-  
+
+  add_rostest_gmock(abstract_controller_execution_test
+    test/abstract_controller_execution.launch
+    test/abstract_controller_execution.cpp)
+  target_link_libraries(abstract_controller_execution_test ${MBF_ABSTRACT_SERVER_LIB})
+
   add_rostest_gmock(abstract_planner_execution_test
     test/abstract_planner_execution.launch
     test/abstract_planner_execution.cpp)

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -151,13 +151,13 @@ namespace mbf_abstract_nav
      * @brief Return the current state of the controller execution. Thread communication safe.
      * @return current state, enum value of ControllerState
      */
-    ControllerState getState();
+    ControllerState getState() const;
 
     /**
      * @brief Returns the time of the last plugin call
      * @return Time of the last plugin call
      */
-    ros::Time getLastPluginCallTime();
+    ros::Time getLastPluginCallTime() const;
 
     /**
      * @brief Returns the last velocity command calculated by the plugin. Set by setVelocityCmd method.
@@ -165,13 +165,13 @@ namespace mbf_abstract_nav
      * to the plugin on controller action feedback.
      * @return The last valid velocity command.
      */
-    geometry_msgs::TwistStamped getVelocityCmd();
+    geometry_msgs::TwistStamped getVelocityCmd() const;
 
     /**
      * @brief Checks whether the patience duration time has been exceeded, ot not
      * @return true, if the patience has been exceeded.
      */
-    bool isPatienceExceeded();
+    bool isPatienceExceeded() const;
 
     /**
      * @brief Sets the controller frequency
@@ -191,7 +191,7 @@ namespace mbf_abstract_nav
      * @brief Returns whether the robot should normally move or not. True if the controller seems to work properly.
      * @return true, if the robot should normally move, false otherwise
      */
-    bool isMoving();
+    bool isMoving() const;
 
   protected:
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -286,16 +286,16 @@ namespace mbf_abstract_nav
     void setState(ControllerState state);
 
     //! mutex to handle safe thread communication for the current value of the state
-    boost::mutex state_mtx_;
+    mutable boost::mutex state_mtx_;
 
     //! mutex to handle safe thread communication for the current plan
-    boost::mutex plan_mtx_;
+    mutable boost::mutex plan_mtx_;
 
     //! mutex to handle safe thread communication for the current velocity command
-    boost::mutex vel_cmd_mtx_;
+    mutable boost::mutex vel_cmd_mtx_;
 
     //! mutex to handle safe thread communication for the last plugin call time
-    boost::mutex lct_mtx_;
+    mutable boost::mutex lct_mtx_;
 
     //! true, if a new plan is available. See hasNewPlan()!
     bool new_plan_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -238,6 +238,12 @@ namespace mbf_abstract_nav
 
     //! The time / duration of patience, before changing the state.
     ros::Duration patience_;
+  
+      //! the frame of the robot, which will be used to determine its position.
+    std::string robot_frame_;
+
+    //! the global frame the robot is controlling in.
+    std::string global_frame_;
 
     /**
      * @brief The main run method, a thread will execute this method. It contains the main controller execution loop.
@@ -314,12 +320,6 @@ namespace mbf_abstract_nav
 
     //! the loop_rate which corresponds with the controller frequency.
     ros::Rate loop_rate_;
-
-    //! the frame of the robot, which will be used to determine its position.
-    std::string robot_frame_;
-
-    //! the global frame the robot is controlling in.
-    std::string global_frame_;
 
     //! publisher for the current velocity command
     ros::Publisher vel_pub_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -238,8 +238,8 @@ namespace mbf_abstract_nav
 
     //! The time / duration of patience, before changing the state.
     ros::Duration patience_;
-  
-      //! the frame of the robot, which will be used to determine its position.
+
+    //! the frame of the robot, which will be used to determine its position.
     std::string robot_frame_;
 
     //! the global frame the robot is controlling in.

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -299,8 +299,8 @@ void AbstractControllerExecution::run()
           publishZeroVelocity(); // command the robot to stop on canceling navigation
         }
         setState(CANCELED);
-        condition_.notify_all();
         moving_ = false;
+        condition_.notify_all();
         return;
       }
 
@@ -321,8 +321,8 @@ void AbstractControllerExecution::run()
         if (plan.empty())
         {
           setState(EMPTY_PLAN);
-          condition_.notify_all();
           moving_ = false;
+          condition_.notify_all();
           return;
         }
 
@@ -330,8 +330,8 @@ void AbstractControllerExecution::run()
         if (!controller_->setPlan(plan))
         {
           setState(INVALID_PLAN);
-          condition_.notify_all();
           moving_ = false;
+          condition_.notify_all();
           return;
         }
         current_goal_pub_.publish(plan.back());
@@ -342,8 +342,8 @@ void AbstractControllerExecution::run()
       {
         publishZeroVelocity();
         setState(INTERNAL_ERROR);
-        condition_.notify_all();
         moving_ = false;
+        condition_.notify_all();
         return;
       }
 
@@ -357,8 +357,8 @@ void AbstractControllerExecution::run()
         }
         setState(ARRIVED_GOAL);
         // goal reached, tell it the controller
-        condition_.notify_all();
         moving_ = false;
+        condition_.notify_all();
         // if not, keep moving
       }
       else

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -444,6 +444,8 @@ void AbstractControllerExecution::run()
     message_ = "Unknown error occurred: " + boost::current_exception_diagnostic_information();
     ROS_FATAL_STREAM(message_);
     setState(INTERNAL_ERROR);
+    moving_ = false;
+    condition_.notify_all();
   }
 }
 

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -125,7 +125,7 @@ void AbstractControllerExecution::setState(ControllerState state)
 
 
 typename AbstractControllerExecution::ControllerState
-AbstractControllerExecution::getState()
+AbstractControllerExecution::getState() const
 {
   boost::lock_guard<boost::mutex> guard(state_mtx_);
   return state_;
@@ -203,21 +203,21 @@ void AbstractControllerExecution::setVelocityCmd(const geometry_msgs::TwistStamp
 }
 
 
-geometry_msgs::TwistStamped AbstractControllerExecution::getVelocityCmd()
+geometry_msgs::TwistStamped AbstractControllerExecution::getVelocityCmd() const
 {
   boost::lock_guard<boost::mutex> guard(vel_cmd_mtx_);
   return vel_cmd_stamped_;
 }
 
 
-ros::Time AbstractControllerExecution::getLastPluginCallTime()
+ros::Time AbstractControllerExecution::getLastPluginCallTime() const
 {
   boost::lock_guard<boost::mutex> guard(lct_mtx_);
   return last_call_time_;
 }
 
 
-bool AbstractControllerExecution::isPatienceExceeded()
+bool AbstractControllerExecution::isPatienceExceeded() const
 {
   boost::lock_guard<boost::mutex> guard(lct_mtx_);
   if(!patience_.isZero() && ros::Time::now() - start_time_ > patience_) // not zero -> activated, start_time handles init case
@@ -237,7 +237,7 @@ bool AbstractControllerExecution::isPatienceExceeded()
 }
 
 
-bool AbstractControllerExecution::isMoving()
+bool AbstractControllerExecution::isMoving() const
 {
   return moving_;
 }

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -123,9 +123,7 @@ void AbstractControllerExecution::setState(ControllerState state)
   state_ = state;
 }
 
-
-typename AbstractControllerExecution::ControllerState
-AbstractControllerExecution::getState() const
+typename AbstractControllerExecution::ControllerState AbstractControllerExecution::getState() const
 {
   boost::lock_guard<boost::mutex> guard(state_mtx_);
   return state_;
@@ -202,20 +200,17 @@ void AbstractControllerExecution::setVelocityCmd(const geometry_msgs::TwistStamp
   // TODO so there should be no loss of information in the feedback stream
 }
 
-
 geometry_msgs::TwistStamped AbstractControllerExecution::getVelocityCmd() const
 {
   boost::lock_guard<boost::mutex> guard(vel_cmd_mtx_);
   return vel_cmd_stamped_;
 }
 
-
 ros::Time AbstractControllerExecution::getLastPluginCallTime() const
 {
   boost::lock_guard<boost::mutex> guard(lct_mtx_);
   return last_call_time_;
 }
-
 
 bool AbstractControllerExecution::isPatienceExceeded() const
 {
@@ -235,7 +230,6 @@ bool AbstractControllerExecution::isPatienceExceeded() const
   }
   return false;
 }
-
 
 bool AbstractControllerExecution::isMoving() const
 {

--- a/mbf_abstract_nav/test/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_controller_execution.cpp
@@ -1,10 +1,293 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <ros/ros.h>
+
+#include <mbf_abstract_core/abstract_controller.h>
+#include <mbf_abstract_nav/MoveBaseFlexConfig.h>
+#include <mbf_abstract_nav/abstract_controller_execution.h>
+
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <geometry_msgs/Twist.h>
+#include <geometry_msgs/TransformStamped.h>
+
+#include <string>
+#include <vector>
+
+using geometry_msgs::PoseStamped;
+using geometry_msgs::TransformStamped;
+using geometry_msgs::Twist;
+using geometry_msgs::TwistStamped;
+using mbf_abstract_core::AbstractController;
+using mbf_abstract_nav::AbstractControllerExecution;
+using mbf_abstract_nav::MoveBaseFlexConfig;
+using testing::_;
+using testing::Return;
+using testing::Test;
+
+// the plan as a vector of poses
+typedef std::vector<PoseStamped> plan_t;
+
+// mocked planner so we can control its output
+struct AbstractControllerMock : public AbstractController
+{
+  // the mocked pure virtual members
+  MOCK_METHOD4(computeVelocityCommands, uint32_t(const PoseStamped&, const TwistStamped&, TwistStamped&, std::string&));
+  MOCK_METHOD2(isGoalReached, bool(double, double));
+  MOCK_METHOD1(setPlan, bool(const plan_t&));
+  MOCK_METHOD0(cancel, bool());
+};
+
+ros::Publisher VEL_PUB, GOAL_PUB;
+TFPtr TF_PTR;
+
+// fixture for our tests
+// we need
+struct AbstractControllerExecutionFixture : public Test, public AbstractControllerExecution
+{
+  AbstractControllerExecutionFixture()
+    : AbstractControllerExecution("a name", AbstractController::Ptr(new AbstractControllerMock()), VEL_PUB, GOAL_PUB,
+                                  TF_PTR, MoveBaseFlexConfig{})
+  {
+  }
+
+  void TearDown() override
+  {
+    // we have to stop the thread when the test is done
+    join();
+  }
+};
+
+TEST_F(AbstractControllerExecutionFixture, noPlan)
+{
+  // test checks the case where we call start() without setting a plan.
+  // the expected output is NO_PLAN.
+
+  // start the controller
+  ASSERT_TRUE(start());
+
+  // wait for the status update
+  waitForStateUpdate(boost::chrono::seconds(1));
+  ASSERT_EQ(getState(), NO_PLAN);
+}
+
+TEST_F(AbstractControllerExecutionFixture, emptyPlan)
+{
+  // test checks the case where we pass an empty path to the controller.
+  // the expected output is EMPTY_PLAN
+
+  // set an empty plan
+  setNewPlan(plan_t{}, true, 1, 1);
+
+  // start the controller
+  ASSERT_TRUE(start());
+
+  // wait for the status update
+  waitForStateUpdate(boost::chrono::seconds(1));
+  ASSERT_EQ(getState(), EMPTY_PLAN);
+}
+
+TEST_F(AbstractControllerExecutionFixture, invalidPlan)
+{
+  // test checks the case where the controller recjets the plan.
+  // the expected output is INVALID_PLAN
+
+  // setup the expectation: the controller rejects the plan
+  AbstractControllerMock& mock = dynamic_cast<AbstractControllerMock&>(*controller_);
+  EXPECT_CALL(mock, setPlan(_)).WillOnce(Return(false));
+  // set a plan
+  plan_t plan(10);
+  setNewPlan(plan, true, 1, 1);
+
+  // start the controller
+  ASSERT_TRUE(start());
+
+  // wait for the status update
+  waitForStateUpdate(boost::chrono::seconds(1));
+  ASSERT_EQ(getState(), INVALID_PLAN);
+}
+
+TEST_F(AbstractControllerExecutionFixture, internalError)
+{
+  // test checks the case where we cannot compute the current robot pose
+  // the expected output is INTERNAL_ERROR
+
+  // setup the expectation: the controller accepts the plan
+  AbstractControllerMock& mock = dynamic_cast<AbstractControllerMock&>(*controller_);
+  EXPECT_CALL(mock, setPlan(_)).WillOnce(Return(true));
+
+  // set a plan
+  plan_t plan(10);
+  setNewPlan(plan, true, 1, 1);
+
+  // set the robot frame to some thing else then the global frame (for our test case)
+  global_frame_ = "global_frame";
+  robot_frame_ = "not_global_frame";
+
+  // start the controller
+  ASSERT_TRUE(start());
+
+  // wait for the status update
+  // note: this timeout must be larget then the default tf-timeout
+  waitForStateUpdate(boost::chrono::seconds(2));
+  ASSERT_EQ(getState(), INTERNAL_ERROR);
+}
+
+TEST_F(AbstractControllerExecutionFixture, arrivedGoal)
+{
+  // test checks the case where we reach the goal.
+  // the expected output is ARRIVED_GOAL
+
+  // setup the expectation: the controller accepts the plan and says we are arrived
+  AbstractControllerMock& mock = dynamic_cast<AbstractControllerMock&>(*controller_);
+  EXPECT_CALL(mock, setPlan(_)).WillOnce(Return(true));
+  EXPECT_CALL(mock, isGoalReached(_, _)).WillOnce(Return(true));
+
+  // we compare against the back-pose of the plan
+  plan_t plan(10);
+  plan.back().header.frame_id = global_frame_ = "global_frame";
+  plan.back().pose.orientation.w = 1;
+
+  // make the toleraces small
+  setNewPlan(plan, true, 1e-3, 1e-3);
+
+  // for identical frames the lookup should return 0
+  robot_frame_ = "robot_frame";
+
+  // setup the transform.
+  // todo right now the mbf_utility checks on the transform age - but this does not work for static transforms
+  TransformStamped transform;
+  transform.header.stamp = ros::Time::now();
+  transform.header.frame_id = global_frame_;
+  transform.child_frame_id = robot_frame_;
+  transform.transform.rotation.w = 1;
+  TF_PTR->setTransform(transform, "mama", false);
+
+  // call staret
+  ASSERT_TRUE(start());
+
+  // wait for the status update
+  waitForStateUpdate(boost::chrono::seconds(1));
+  ASSERT_EQ(getState(), ARRIVED_GOAL);
+}
+
+TEST_F(AbstractControllerExecutionFixture, maxRetries)
+{
+  // test verfies the case where we exceed the max-retries.
+  // the expected output is MAX_RETRIES
+
+  // setup the expectation: the controller accepts the plan and says we are arrived
+  AbstractControllerMock& mock = dynamic_cast<AbstractControllerMock&>(*controller_);
+  EXPECT_CALL(mock, setPlan(_)).WillOnce(Return(true));
+  EXPECT_CALL(mock, isGoalReached(_, _)).WillRepeatedly(Return(false));
+  EXPECT_CALL(mock, computeVelocityCommands(_, _, _, _)).WillRepeatedly(Return(11));
+
+  // we compare against the back-pose of the plan
+  plan_t plan(10);
+  global_frame_ = "global_frame";
+  robot_frame_ = "robot_frame";
+  // make the toleraces small
+  setNewPlan(plan, true, 1e-3, 1e-3);
+
+  TransformStamped transform;
+  transform.header.stamp = ros::Time::now();
+  transform.header.frame_id = global_frame_;
+  transform.child_frame_id = robot_frame_;
+  transform.transform.rotation.w = 1;
+  TF_PTR->setTransform(transform, "mama", false);
+
+  // call staret
+  ASSERT_TRUE(start());
+
+  // wait for the status update
+  waitForStateUpdate(boost::chrono::seconds(1));
+  ASSERT_EQ(getState(), MAX_RETRIES);
+}
+
+TEST_F(AbstractControllerExecutionFixture, noValidCmd)
+{
+  // test verfies the case where we don't exceed the patience or max-retries conditions
+  // the expected output is NO_VALID_CMD
+
+  // setup the expectation: the controller accepts the plan and says we are arrived
+  AbstractControllerMock& mock = dynamic_cast<AbstractControllerMock&>(*controller_);
+  EXPECT_CALL(mock, setPlan(_)).WillOnce(Return(true));
+  EXPECT_CALL(mock, isGoalReached(_, _)).WillRepeatedly(Return(false));
+  EXPECT_CALL(mock, computeVelocityCommands(_, _, _, _)).WillRepeatedly(Return(11));
+
+  // we compare against the back-pose of the plan
+  plan_t plan(10);
+  global_frame_ = "global_frame";
+  robot_frame_ = "robot_frame";
+  // make the toleraces small
+  setNewPlan(plan, true, 1e-3, 1e-3);
+
+  TransformStamped transform;
+  transform.header.stamp = ros::Time::now();
+  transform.header.frame_id = global_frame_;
+  transform.child_frame_id = robot_frame_;
+  transform.transform.rotation.w = 1;
+  TF_PTR->setTransform(transform, "mama", false);
+
+  // disable the retries logic
+  max_retries_ = -1;
+  // call staret
+  ASSERT_TRUE(start());
+
+  // wait for the status update
+  waitForStateUpdate(boost::chrono::seconds(1));
+  ASSERT_EQ(getState(), NO_LOCAL_CMD);
+}
+
+TEST_F(AbstractControllerExecutionFixture, patExceeded)
+{
+  // test verfies the case where we exceed the patience
+  // the expected output is PAT_EXCEEDED
+
+  // setup the expectation: the controller accepts the plan and says we are arrived
+  AbstractControllerMock& mock = dynamic_cast<AbstractControllerMock&>(*controller_);
+  EXPECT_CALL(mock, setPlan(_)).WillOnce(Return(true));
+  EXPECT_CALL(mock, isGoalReached(_, _)).WillOnce(Return(false));
+  EXPECT_CALL(mock, computeVelocityCommands(_, _, _, _)).WillOnce(Return(11));
+
+  // we compare against the back-pose of the plan
+  plan_t plan(10);
+  global_frame_ = "global_frame";
+  robot_frame_ = "robot_frame";
+  // make the toleraces small
+  setNewPlan(plan, true, 1e-3, 1e-3);
+
+  TransformStamped transform;
+  transform.header.stamp = ros::Time::now();
+  transform.header.frame_id = global_frame_;
+  transform.child_frame_id = robot_frame_;
+  transform.transform.rotation.w = 1;
+  TF_PTR->setTransform(transform, "mama", false);
+
+  // disable the retries logic and enable the patience logic
+  max_retries_ = -1;
+  patience_ = ros::Duration(-1e-3);
+
+  // call staret
+  ASSERT_TRUE(start());
+
+  // wait for the status update
+  waitForStateUpdate(boost::chrono::seconds(1));
+  ASSERT_EQ(getState(), PAT_EXCEEDED);
+}
 
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "read_types");
   ros::NodeHandle nh;
+  // setup the pubs as global objects
+  VEL_PUB = nh.advertise<Twist>("vel", 1);
+  GOAL_PUB = nh.advertise<PoseStamped>("pose", 1);
+
+  // setup the tf-publisher as a global object
+  TF_PTR.reset(new TF());
+  TF_PTR->setUsingDedicatedThread(true);
+
   // suppress the logging since we don't want warnings to polute the test-outcome
   if (ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Fatal))
   {
@@ -13,4 +296,3 @@ int main(int argc, char** argv)
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/mbf_abstract_nav/test/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_controller_execution.cpp
@@ -264,7 +264,7 @@ TEST_F(AbstractControllerExecutionFixture, patExceeded)
   transform.transform.rotation.w = 1;
   TF_PTR->setTransform(transform, "mama", false);
 
-  // disable the retries logic and enable the patience logic
+  // disable the retries logic and enable the patience logic: we cheat by setting it to a negative duration.
   max_retries_ = -1;
   patience_ = ros::Duration(-1e-3);
 

--- a/mbf_abstract_nav/test/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_controller_execution.cpp
@@ -9,6 +9,7 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <geometry_msgs/Twist.h>
+#include <tf/transform_datatypes.h>
 #include <geometry_msgs/TransformStamped.h>
 
 #include <string>
@@ -24,6 +25,8 @@ using mbf_abstract_nav::MoveBaseFlexConfig;
 using testing::_;
 using testing::Return;
 using testing::Test;
+// for kinetic
+using tf::StampedTransform;
 
 // the plan as a vector of poses
 typedef std::vector<PoseStamped> plan_t;
@@ -146,13 +149,20 @@ struct ComputeRobotPoseFixture : public AbstractControllerExecutionFixture
     // setup the transform.
     global_frame_ = "global_frame";
     robot_frame_ = "robot_frame";
-    // todo right now the mbf_utility checks on the transform age - but this does not work for static transforms
+#ifdef USE_OLD_TF
+    StampedTransform transform;
+    transform.child_frame_id_ = robot_frame_;
+    transform.frame_id_ = global_frame_;
+    transform.stamp_ = ros::Time::now();
+#else
     TransformStamped transform;
     transform.header.stamp = ros::Time::now();
     transform.header.frame_id = global_frame_;
     transform.child_frame_id = robot_frame_;
     transform.transform.rotation.w = 1;
-    TF_PTR->setTransform(transform, "mama", false);
+#endif
+    // todo right now the mbf_utility checks on the transform age - but this does not work for static transforms
+    TF_PTR->setTransform(transform, "mama");
   }
 };
 

--- a/mbf_abstract_nav/test/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_controller_execution.cpp
@@ -45,7 +45,6 @@ ros::Publisher VEL_PUB, GOAL_PUB;
 TFPtr TF_PTR;
 
 // fixture for our tests
-// we need
 struct AbstractControllerExecutionFixture : public Test, public AbstractControllerExecution
 {
   AbstractControllerExecutionFixture()

--- a/mbf_abstract_nav/test/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_controller_execution.cpp
@@ -174,7 +174,7 @@ TEST_F(ComputeRobotPoseFixture, arrivedGoal)
   // make the toleraces small
   setNewPlan(plan, true, 1e-3, 1e-3);
 
-  // call staret
+  // call start
   ASSERT_TRUE(start());
 
   // wait for the status update

--- a/mbf_abstract_nav/test/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_controller_execution.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "read_types");
+  ros::NodeHandle nh;
+  // suppress the logging since we don't want warnings to polute the test-outcome
+  if (ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Fatal))
+  {
+    ros::console::notifyLoggerLevelsChanged();
+  }
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+

--- a/mbf_abstract_nav/test/abstract_controller_execution.launch
+++ b/mbf_abstract_nav/test/abstract_controller_execution.launch
@@ -1,0 +1,3 @@
+<launch>
+  <test time-limit="10" test-name="abstract_controller_execution" pkg="mbf_abstract_nav" type="abstract_controller_execution_test"/>
+</launch>


### PR DESCRIPTION
This pr adds unit tests for the AbstractControllerExecution

## Minor Fixes
- adds m&m for the mutecies so we can make the getter functions constant
- fixes race-conditions with respect to moving_ (has no real effect on the lib)

## Other changes
For better testing i've changed the access of global_frame and robot_frame from private to protected

Best, 
Dima