### PR TITLE
fix controller termination

### DIFF
--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -405,6 +405,8 @@ void AbstractControllerExecution::run()
           else
           {
             setState(NO_LOCAL_CMD); // useful for server feedback
+            // we keep on moving if we have retries left or if the user has granted us some patience.
+            moving_ = max_retries_ || !patience_.isZero();
           }
           // could not compute a valid velocity command -> stop moving the robot
           publishZeroVelocity(); // command the robot to stop; we still feedback command calculated by the plugin

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -258,12 +258,15 @@ void ControllerAction::runImpl(GoalHandle &goal_handle, AbstractControllerExecut
         ROS_WARN_STREAM_THROTTLE_NAMED(3, name_, "No velocity command received from controller! "
             << execution.getMessage());
         controller_active = execution.isMoving();
-        if(!controller_active){
+        if (!controller_active)
+        {
           fillExePathResult(execution.getOutcome(), execution.getMessage(), result);
           goal_handle.setAborted(result, result.message);
         }
-        else{
-          publishExePathFeedback(goal_handle, execution.getOutcome(), execution.getMessage(), execution.getVelocityCmd());
+        else
+        {
+          publishExePathFeedback(goal_handle, execution.getOutcome(), execution.getMessage(),
+                                 execution.getVelocityCmd());
         }
         break;
 

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -257,7 +257,14 @@ void ControllerAction::runImpl(GoalHandle &goal_handle, AbstractControllerExecut
       case AbstractControllerExecution::NO_LOCAL_CMD:
         ROS_WARN_STREAM_THROTTLE_NAMED(3, name_, "No velocity command received from controller! "
             << execution.getMessage());
-        publishExePathFeedback(goal_handle, execution.getOutcome(), execution.getMessage(), execution.getVelocityCmd());
+        controller_active = execution.isMoving();
+        if(!controller_active){
+          fillExePathResult(execution.getOutcome(), execution.getMessage(), result);
+          goal_handle.setAborted(result, result.message);
+        }
+        else{
+          publishExePathFeedback(goal_handle, execution.getOutcome(), execution.getMessage(), execution.getVelocityCmd());
+        }
         break;
 
       case AbstractControllerExecution::GOT_LOCAL_CMD:


### PR DESCRIPTION
With the #262 merge, we have introduced a regression in the termination criteria of our controllers: 

If the user doesn't specify max_rettries_ or patience_ we would not terminate at all. I've made the behavior congruent with the behavior of abstract_planner_execution - terminating the loop if both parameters are disabled. 

Keep in mind that the #261 PR will provide some testing the affected class (but I would need to adjust the tests to the changed behavior).

Best,
Dima