### PR TITLE
enable max retries logic for controller execution test

### DIFF
--- a/mbf_abstract_nav/test/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_controller_execution.cpp
@@ -240,17 +240,17 @@ struct FailureFixture : public ComputeRobotPoseFixture
 
 TEST_F(FailureFixture, maxRetries)
 {
-  // test verfies the case where we exceed the max-retries.
+  // test verifies the case where we exceed the max-retries.
   // the expected output is MAX_RETRIES
 
   // enable the retries logic (max_retries > 0)
-  max_retries_ = 2;
+  max_retries_ = 1;
 
   // call start
   ASSERT_TRUE(start());
 
   // wait for the status update
-  waitForStateUpdate(boost::chrono::seconds(1));
+  waitForStateUpdate(boost::chrono::seconds(5));
   ASSERT_EQ(getState(), MAX_RETRIES);
 }
 

--- a/mbf_abstract_nav/test/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_controller_execution.cpp
@@ -243,6 +243,9 @@ TEST_F(FailureFixture, maxRetries)
   // test verfies the case where we exceed the max-retries.
   // the expected output is MAX_RETRIES
 
+  // enable the retries logic (max_retries > 0)
+  max_retries_ = 2;
+
   // call start
   ASSERT_TRUE(start());
 

--- a/mbf_abstract_nav/test/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_controller_execution.cpp
@@ -249,8 +249,13 @@ TEST_F(FailureFixture, maxRetries)
   // call start
   ASSERT_TRUE(start());
 
-  // wait for the status update
-  waitForStateUpdate(boost::chrono::seconds(5));
+  // wait for the status update: in first iteration NO_LOCAL_CMD
+  waitForStateUpdate(boost::chrono::seconds(1));
+  ASSERT_EQ(getState(), NO_LOCAL_CMD);
+
+  // wait for the status update: in second iteration MAX_RETRIES
+  // bcs max_retries_ > 0 && ++retries > max_retries_
+  waitForStateUpdate(boost::chrono::seconds(1));
   ASSERT_EQ(getState(), MAX_RETRIES);
 }
 


### PR DESCRIPTION
> Keep in mind that the #261 PR will provide some testing the affected class (but I would need to adjust the tests to the changed behavior). [source](https://github.com/magazino/move_base_flex/pull/263#issue-584644876)

Attemps to fix the controller execution test broken since #263 

Steps taken to pass [this condition](https://github.com/magazino/move_base_flex/blob/a03a61341c66bb5783da57aa29ed3d6291a8095f/mbf_abstract_nav/src/abstract_controller_execution.cpp#L388):
* enable max_tries: `max_tries_ = 1` 
* in first Iteration, the code reaches [this condition](https://github.com/magazino/move_base_flex/blob/a03a61341c66bb5783da57aa29ed3d6291a8095f/mbf_abstract_nav/src/abstract_controller_execution.cpp#L401), which is tested after the first `waitForStatusUpdate()` call in the test
 
```cpp
else
{
  setState(NO_LOCAL_CMD); // useful for server feedback
  // we keep on moving if we have retries left or if the user has granted us some patience.
  moving_ = max_retries_ || !patience_.isZero();
}
```
* in second interation, code reaches crucial part: after calling second `waitForStatusUpdate()`, the state is now finally `MAX_RETRIES`

```cpp
if (max_retries_ > 0 && ++retries > max_retries_)
{
  setState(MAX_RETRIES);
  moving_ = false;
}
```

Cheers
