### PR TITLE
Lock less aggressively slot_map_mtx_, so sending a new goal when canceling doesn't freeze MBF

### DIFF
--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -65,9 +65,7 @@ void ControllerAction::start(
 
   bool update_plan = false;
 
-  slot_map_mtx_.lock();
-  std::map<uint8_t, ConcurrencySlot>::iterator slot_it = concurrency_slots_.find(slot);
-  slot_map_mtx_.unlock();
+  typename ConcurrencyMap::iterator slot_it = findSlot(slot);
   if (slot_it != concurrency_slots_.end() && slot_it->second.in_use)
   {
     boost::lock_guard<boost::mutex> goal_guard(goal_mtx_);


### PR DESCRIPTION
We are locking the access to concurrency_slots_ map when doing any operation, as start and cancel. That's not needed. Interators to map [don't get invalidated by adding new entries to the map](https://www.cplusplus.com/reference/map/map/insert/), and we are not removing concurrency slots other than in shutdown.

With the current master, if we receive a new goal while performing a lengthy cancel (e.g. because we want to handle a smooth stop, as requested on [this PR](https://github.com/magazino/move_base_flex/pull/172)), MBF will freeze, as we lock twice slot_map_mtx_, [here](https://github.com/magazino/move_base_flex/pull/273/files#diff-9dd967a72350032851289ad39d52abbf057bc9ed6c90f61b0a06c5bd673c1fbaL140) and [here](https://github.com/magazino/move_base_flex/pull/273/files#diff-9dd967a72350032851289ad39d52abbf057bc9ed6c90f61b0a06c5bd673c1fbaL178).

With this PR, we accept the new goal, wait for the previous cancel to complete, and then execute the new goal.