### PR TITLE
Allow the controller to handle cancel if properly implemented

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -119,10 +119,12 @@ namespace mbf_abstract_nav
       double action_angle_tolerance = 3.1415);
 
     /**
-     * @brief Cancel the controller execution.
-     * This calls the cancel method of the controller plugin, sets the cancel_ flag to true,
-     * and waits for the control loop to stop. Normally called upon aborting the navigation.
-     * @return true, if the control loop stops within a cycle time.
+     * @brief Cancel the controller execution. Normally called upon aborting the navigation.
+     * This calls the cancel method of the controller plugin. If the plugins returns true, it becomes
+     * responsible of stopping, and we will keep requesting velocity commands until it returns CANCELED.
+     * If it returns false (meaning cancel is not implemented, or that the controller defers handling it),
+     * MBF will set the cancel_ flag to true, and wait for the control loop to stop.
+     * @return true, if the controller handles the stooping, or the control loop stops within a cycle time.
      */
     virtual bool cancel();
 


### PR DESCRIPTION
Possibly a much safer solution for #273. This allows smooth cancels with decreasing velocities without risking the deadlocks reported in #273. The controller becomes responsible of slowing down by returning decreasing speeds on computeVelocityCommands and SUCCESS outcome. When he considers that the robot can stop, returns zero velocity and CANCELED outcome.

Trivial example implementation for TEB:

![image](https://user-images.githubusercontent.com/322610/125277923-0c1ac500-e34d-11eb-9239-b2eb783dd62a.png)

If the controller doesn't implement the controller plugin API cancel method, or returns false, we use the normal stop method with an abrupt zero-velocity.

:warning::warning::warning:
One corner case is when we cancel the controller but it reaches the goal while slowing down. In this case, we will report success, which is a sensible result because we accomplish the requested goal despite the cancel, but one could argue that we should return preempted.
:warning::warning::warning:

Example:

1. send goal to exe_path
2. cancel it, slowing down
3. send the same goal before it stops  --> we preempt the canceling and start executing the new goal

https://user-images.githubusercontent.com/322610/125382572-d91a1500-e3d0-11eb-92fc-cc8776a2a791.mp4

