### PR TITLE
make the costmaps used for planning and controlling configurable

### DIFF
--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
@@ -58,6 +58,11 @@
 #include "mbf_costmap_nav/costmap_recovery_execution.h"
 #include "mbf_costmap_nav/costmap_wrapper.h"
 
+// Change this to std::unordered_map, once we move to C++11.
+#include <boost/unordered_map.hpp>
+#include <boost/shared_ptr.hpp>
+
+#include <string>
 
 namespace mbf_costmap_nav
 {
@@ -68,6 +73,9 @@ namespace mbf_costmap_nav
 
 
 typedef boost::shared_ptr<dynamic_reconfigure::Server<mbf_costmap_nav::MoveBaseFlexConfig> > DynamicReconfigureServerCostmapNav;
+
+/// @brief A mapping from a string to a map-ptr.
+typedef boost::unordered_map<std::string, CostmapWrapper::Ptr> StringToMap;
 
 /**
  * @brief The CostmapNavigationServer makes Move Base Flex backwards compatible to the old move_base. It combines the
@@ -249,6 +257,12 @@ private:
 
   //! Shared pointer to the common global costmap
   const CostmapWrapper::Ptr global_costmap_ptr_;
+
+  //! Maps planner names to the costmap ptr.
+  StringToMap planner_name_to_costmap_ptr_;
+
+  //! Maps the controller names to the costmap ptr.
+  StringToMap controller_name_to_costmap_ptr_;
 
   //! Service Server for the check_point_cost service
   ros::ServiceServer check_point_cost_srv_;

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -54,46 +54,46 @@
 
 namespace mbf_costmap_nav
 {
-/// @brief Returns a string element with the tag _tag from _v.
+/// @brief Returns a string element with the tag from value.
 /// @throw XmlRpc::XmlRpcException if the tag is missing.
-static std::string getStringElement(const XmlRpc::XmlRpcValue& _v, const std::string& _tag)
+static std::string getStringElement(const XmlRpc::XmlRpcValue& value, const std::string& tag)
 {
-  // We have to check manually, since XmlRpc would just return _tag if its
+  // We have to check manually, since XmlRpc would just return tag if its
   // missing...
-  if (!_v.hasMember(_tag))
-    throw XmlRpc::XmlRpcException(_tag + " not found");
+  if (!value.hasMember(tag))
+    throw XmlRpc::XmlRpcException(tag + " not found");
 
-  return static_cast<std::string>(_v[_tag]);
+  return static_cast<std::string>(value[tag]);
 }
 
 /**
  * @brief Returns the mapping from 'names' to 'costmaps' for the defined resource.
  *
- * @param _resource The name of the resource (e.g 'planners').
- * @param _nh The private node handle containing the given resource.
- * @param _global_costmap_ptr Ptr to the global costmap.
- * @param _local_costmap_ptr Ptr to the local costmap.
+ * @param resource The name of the resource (e.g 'planners').
+ * @param nh The private node handle containing the given resource.
+ * @param global_costmap_ptr Ptr to the global costmap.
+ * @param local_costmap_ptr Ptr to the local costmap.
  */
-StringToMap loadStringToMapsImpl(const std::string& _resource, const ros::NodeHandle& _nh,
-                                 const CostmapWrapper::Ptr& _global_costmap_ptr,
-                                 const CostmapWrapper::Ptr& _local_costmap_ptr)
+StringToMap loadStringToMapsImpl(const std::string& resource, const ros::NodeHandle& nh,
+                                 const CostmapWrapper::Ptr& global_costmap_ptr,
+                                 const CostmapWrapper::Ptr& local_costmap_ptr)
 {
   using namespace XmlRpc;
   XmlRpcValue raw;
 
   // Load the data from the param server
-  if (!_nh.getParam(_resource, raw))
-    throw std::runtime_error("No parameter " + _resource);
+  if (!nh.getParam(resource, raw))
+    throw std::runtime_error("No parameter " + resource);
 
-  // We expect that _resource defines an array
+  // We expect that resource defines an array
   if (raw.getType() != XmlRpcValue::TypeArray)
-    throw std::runtime_error(_resource + " must be an XmlRpcValue::TypeArray");
+    throw std::runtime_error(resource + " must be an XmlRpcValue::TypeArray");
 
   StringToMap output, mapping;
 
   // We support only 'local' or 'global' names for the costmap tag.
-  mapping["global"] = _global_costmap_ptr;
-  mapping["local"] = _local_costmap_ptr;
+  mapping["global"] = global_costmap_ptr;
+  mapping["local"] = local_costmap_ptr;
 
   const int size = raw.size();
   for (int ii = 0; ii != size; ++ii)
@@ -134,12 +134,13 @@ StringToMap loadStringToMapsImpl(const std::string& _resource, const ros::NodeHa
  * @brief Non-throwing version of loadStringToMapsImpl.
  * @copydetails loadStringToMapsImpl
  */
-StringToMap loadStringToMaps(const std::string& _resource, const ros::NodeHandle& _nh,
-                             const CostmapWrapper::Ptr& _global, const CostmapWrapper::Ptr& _local)
+StringToMap loadStringToMaps(const std::string& resource, const ros::NodeHandle& nh,
+                             const CostmapWrapper::Ptr& global_costmap_ptr,
+                             const CostmapWrapper::Ptr& local_costmap_ptr)
 {
   try
   {
-    return loadStringToMapsImpl(_resource, _nh, _global, _local);
+    return loadStringToMapsImpl(resource, nh, global_costmap_ptr, local_costmap_ptr);
   }
   catch (const XmlRpc::XmlRpcException& _ex)
   {
@@ -204,12 +205,12 @@ CostmapNavigationServer::~CostmapNavigationServer()
 }
 
 template <typename Key, typename Value>
-const Value& findWithDefault(const boost::unordered_map<Key, Value>& _map, const Key& _key, const Value& _default)
+const Value& findWithDefault(const boost::unordered_map<Key, Value>& map, const Key& key, const Value& default_value)
 {
   typedef boost::unordered_map<Key, Value> MapType;
-  typename MapType::const_iterator iter = _map.find(_key);
-  if (iter == _map.end())
-    return _default;
+  typename MapType::const_iterator iter = map.find(key);
+  if (iter == map.end())
+    return default_value;
   return iter->second;
 }
 

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -47,13 +47,110 @@
 #include <nav_core_wrapper/wrapper_global_planner.h>
 #include <nav_core_wrapper/wrapper_local_planner.h>
 #include <nav_core_wrapper/wrapper_recovery_behavior.h>
+#include <xmlrpcpp/XmlRpc.h>
 
 #include "mbf_costmap_nav/footprint_helper.h"
 #include "mbf_costmap_nav/costmap_navigation_server.h"
 
 namespace mbf_costmap_nav
 {
+/// @brief Returns a string element with the tag _tag from _v.
+/// @throw XmlRpc::XmlRpcException if the tag is missing.
+static std::string getStringElement(const XmlRpc::XmlRpcValue& _v, const std::string& _tag)
+{
+  // We have to check manually, since XmlRpc would just return _tag if its
+  // missing...
+  if (!_v.hasMember(_tag))
+    throw XmlRpc::XmlRpcException(_tag + " not found");
 
+  return static_cast<std::string>(_v[_tag]);
+}
+
+/**
+ * @brief Returns the mapping from 'names' to 'costmaps' for the defined resource.
+ *
+ * @param _resource The name of the resource (e.g 'planners').
+ * @param _nh The private node handle containing the given resource.
+ * @param _global_costmap_ptr Ptr to the global costmap.
+ * @param _local_costmap_ptr Ptr to the local costmap.
+ */
+StringToMap loadStringToMapsImpl(const std::string& _resource, const ros::NodeHandle& _nh,
+                                 const CostmapWrapper::Ptr& _global_costmap_ptr,
+                                 const CostmapWrapper::Ptr& _local_costmap_ptr)
+{
+  using namespace XmlRpc;
+  XmlRpcValue raw;
+
+  // Load the data from the param server
+  if (!_nh.getParam(_resource, raw))
+    throw std::runtime_error("No parameter " + _resource);
+
+  // We expect that _resource defines an array
+  if (raw.getType() != XmlRpcValue::TypeArray)
+    throw std::runtime_error(_resource + " must be an XmlRpcValue::TypeArray");
+
+  StringToMap output, mapping;
+
+  // We support only 'local' or 'global' names for the costmap tag.
+  mapping["global"] = _global_costmap_ptr;
+  mapping["local"] = _local_costmap_ptr;
+
+  const int size = raw.size();
+  for (int ii = 0; ii != size; ++ii)
+  {
+    const XmlRpcValue& element = raw[ii];
+
+    // The element must be of the type struct.
+    if (element.getType() != XmlRpcValue::TypeStruct)
+      continue;
+
+    // Check if the tags name and costmap are defined and ignore the element if not.
+    if (!element.hasMember("name") || !element.hasMember("costmap"))
+      continue;
+
+    try
+    {
+      // Try to convert the tags to strings. If the elements cannot be
+      // converted, we will throw.
+      const std::string name = getStringElement(element, "name");
+      const std::string costmap = getStringElement(element, "costmap");
+
+      // If the costmap tag is not 'local' or 'global', we will throw.
+      output[name] = mapping.at(costmap);
+    }
+    catch (const XmlRpcException& ex)
+    {
+      ROS_ERROR_STREAM("Failed to read the tags 'name' and 'costmap': " << ex.getMessage());
+    }
+    catch (const std::out_of_range& _ex)
+    {
+      ROS_ERROR_STREAM("Unknown costmap name. It must be either 'local' or 'global'");
+    }
+  }
+  return output;
+}
+
+/**
+ * @brief Non-throwing version of loadStringToMapsImpl.
+ * @copydetails loadStringToMapsImpl
+ */
+StringToMap loadStringToMaps(const std::string& _resource, const ros::NodeHandle& _nh,
+                             const CostmapWrapper::Ptr& _global, const CostmapWrapper::Ptr& _local)
+{
+  try
+  {
+    return loadStringToMapsImpl(_resource, _nh, _global, _local);
+  }
+  catch (const XmlRpc::XmlRpcException& _ex)
+  {
+    ROS_ERROR_STREAM("Failed to load the mapping: " << _ex.getMessage());
+  }
+  catch (const std::exception& _ex)
+  {
+    ROS_ERROR_STREAM("Failed to load the mapping: " << _ex.what());
+  }
+  return StringToMap();
+}
 
 CostmapNavigationServer::CostmapNavigationServer(const TFPtr &tf_listener_ptr) :
   AbstractNavigationServer(tf_listener_ptr),
@@ -81,6 +178,11 @@ CostmapNavigationServer::CostmapNavigationServer(const TFPtr &tf_listener_ptr) :
   dsrv_costmap_ = boost::make_shared<dynamic_reconfigure::Server<mbf_costmap_nav::MoveBaseFlexConfig> >(private_nh_);
   dsrv_costmap_->setCallback(boost::bind(&CostmapNavigationServer::reconfigure, this, _1, _2));
 
+  // Load the optional mapping from planner/controller name to the costmap.
+  planner_name_to_costmap_ptr_ = loadStringToMaps("planners", private_nh_, global_costmap_ptr_, local_costmap_ptr_);
+  controller_name_to_costmap_ptr_ =
+      loadStringToMaps("controllers", private_nh_, global_costmap_ptr_, local_costmap_ptr_);
+
   // initialize all plugins
   initializeServerComponents();
 
@@ -101,27 +203,36 @@ CostmapNavigationServer::~CostmapNavigationServer()
   action_server_move_base_ptr_.reset();
 }
 
+template <typename Key, typename Value>
+const Value& findWithDefault(const boost::unordered_map<Key, Value>& _map, const Key& _key, const Value& _default)
+{
+  typedef boost::unordered_map<Key, Value> MapType;
+  typename MapType::const_iterator iter = _map.find(_key);
+  if (iter == _map.end())
+    return _default;
+  return iter->second;
+}
+
 mbf_abstract_nav::AbstractPlannerExecution::Ptr CostmapNavigationServer::newPlannerExecution(
     const std::string &plugin_name,
     const mbf_abstract_core::AbstractPlanner::Ptr &plugin_ptr)
 {
+  const CostmapWrapper::Ptr& costmap_ptr =
+      findWithDefault(planner_name_to_costmap_ptr_, plugin_name, global_costmap_ptr_);
   return boost::make_shared<mbf_costmap_nav::CostmapPlannerExecution>(
       plugin_name, boost::static_pointer_cast<mbf_costmap_core::CostmapPlanner>(plugin_ptr), tf_listener_ptr_,
-      global_costmap_ptr_, last_config_);
+      costmap_ptr, last_config_);
 }
 
 mbf_abstract_nav::AbstractControllerExecution::Ptr CostmapNavigationServer::newControllerExecution(
     const std::string &plugin_name,
     const mbf_abstract_core::AbstractController::Ptr &plugin_ptr)
 {
+  const CostmapWrapper::Ptr& costmap_ptr =
+      findWithDefault(controller_name_to_costmap_ptr_, plugin_name, local_costmap_ptr_);
   return boost::make_shared<mbf_costmap_nav::CostmapControllerExecution>(
-      plugin_name,
-      boost::static_pointer_cast<mbf_costmap_core::CostmapController>(plugin_ptr),
-      vel_pub_,
-      goal_pub_,
-      tf_listener_ptr_,
-      local_costmap_ptr_,
-      last_config_);
+      plugin_name, boost::static_pointer_cast<mbf_costmap_core::CostmapController>(plugin_ptr), vel_pub_, goal_pub_,
+      tf_listener_ptr_, costmap_ptr, last_config_);
 }
 
 mbf_abstract_nav::AbstractRecoveryExecution::Ptr CostmapNavigationServer::newRecoveryExecution(
@@ -178,14 +289,15 @@ bool CostmapNavigationServer::initializePlannerPlugin(
       = boost::static_pointer_cast<mbf_costmap_core::CostmapPlanner>(planner_ptr);
   ROS_DEBUG_STREAM("Initialize planner \"" << name << "\".");
 
-  if (!global_costmap_ptr_)
+  const CostmapWrapper::Ptr& costmap_ptr = findWithDefault(planner_name_to_costmap_ptr_, name, global_costmap_ptr_);
+
+  if (!costmap_ptr)
   {
     ROS_FATAL_STREAM("The costmap pointer has not been initialized!");
     return false;
   }
 
-  costmap_planner_ptr->initialize(name, global_costmap_ptr_.get());
-  ROS_DEBUG("Planner plugin initialized.");
+  costmap_planner_ptr->initialize(name, costmap_ptr.get());
   return true;
 }
 
@@ -233,7 +345,9 @@ bool CostmapNavigationServer::initializeControllerPlugin(
     return false;
   }
 
-  if (!local_costmap_ptr_)
+  const CostmapWrapper::Ptr& costmap_ptr = findWithDefault(controller_name_to_costmap_ptr_, name, local_costmap_ptr_);
+
+  if (!costmap_ptr)
   {
     ROS_FATAL_STREAM("The costmap pointer has not been initialized!");
     return false;
@@ -241,7 +355,7 @@ bool CostmapNavigationServer::initializeControllerPlugin(
 
   mbf_costmap_core::CostmapController::Ptr costmap_controller_ptr
       = boost::static_pointer_cast<mbf_costmap_core::CostmapController>(controller_ptr);
-  costmap_controller_ptr->initialize(name, tf_listener_ptr_.get(), local_costmap_ptr_.get());
+  costmap_controller_ptr->initialize(name, tf_listener_ptr_.get(), costmap_ptr.get());
   ROS_DEBUG_STREAM("Controller plugin \"" << name << "\" initialized.");
   return true;
 }


### PR DESCRIPTION
Hey,

I have a proposal to extend the current mbf-costmap-nav and to allow the users to specify on which map they want to run their planners/controllers. 

Running a planner on the local costmap allows the users to "bridge the gap" between planners and controllers. In particular, this might help if in one costmap the robot configuration appears free, while being blocked on the other - something which happens if both costmaps have largely different resolutions or run at different update frequencies.

I don't have a clear application for the other use-case (running the controller on the global costmap) but implemented it just for completeness.

The default behavior does not change. The user may specify an optional "costmap" tag, taking either "global" or "local" arguments.

Example:
```yaml

planners:
    - {name: global_planner_global_1,    type: global_planner/GlobalPlanner} # runs on the global costmap    
    - {name: global_planner_global_2,    type: global_planner/GlobalPlanner, costmap: "global"} # explicitly on the global costmap              
    - {name: global_planner_local_1,      type: global_planner/GlobalPlanner, costmap: "local"} # on the local costmap                  
   
```

We are currently evaluating this setup for our replanning. The pseudo code for the replanning might look something like the code below (note: this won't run, just demonstrates the idea)

```python

from geometry_msgs.msg import PoseStamped
from nav_msgs.msg import Path
from mbf_msgs.msg import GetPathGoal, GetPathAction, ExePathAction, ExePathGoal
from actionlib import SimpleActionClient

get_path_ac = SimpleActionClient("/move_base_flex/get_path", GetPathAction)
exe_path_ac = SimpleActionClient("/move_base_flex/exe_path", ExePathAction)

def advance_along_path(global_path: Path, robot_pose: PoseStamped, distance: float) -> PoseStamped:
    """Return the pose in path which has the distance to the robot_pose."""
    return PoseStamped()

def current_robot_pose() -> PoseStamped:
    """Return the current robot pose."""
    return PoseStamped()

def get_local_path(global_path) -> Path():
    """Returns the local path."""
    if not global_path:
        raise RuntimeError("No Path")
    
    # Dummy value for the local costmap size.
    local_costmap_size: float = 10.

    goal = GetPathGoal()
    
    # Advance along the global path until we reach the last valid pose within the local costmap
    goal.target_pose = advance_along_path(global_path, current_robot_pose(), local_costmap_size)
    goal.planner = "global_planner_local_1"

    # Call move_base_flex/get_path
    get_path_ac.send_goal_and_wait(goal)
    return get_path_ac.get_result()


def get_global_path(target_pose: PoseStamped) -> Path():
    """Calls a planner running on the global costmap."""

    goal = GetPathGoal()
    goal.tagret_pose = target_pose
    goal.planner = "global_planner_global_1"

    # ... Call the move_base_flex/get_path and return a result. If there is no
    # plan, we return an empty path.
    return Path()


def navigate(goal: PoseStamped) -> None:
    global_path = Path()
    local_path = Path()

    # Checks if the robot has arrived.
    while not is_arrived(goal):
        try:
            # Throws is the global_path is empty.
            local_path = get_local_path(global_path)
        except RuntimeError:
            # Regenerate the global_path
            global_path = get_global_path(goal)
            continue
        
        # Call the controller with the current local_path
        exe_goal = ExePathGoal(path=local_path)
        exe_path_ac.send_goal(exe_goal, ...)

        # Sleep before replanning.
        rospy.sleep(0.5)

```

