### PR TITLE
Fix multiple retries despite planner_max_retries=0 (#287)

### DIFF
--- a/mbf_abstract_nav/src/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_planner_execution.cpp
@@ -344,7 +344,7 @@ void AbstractPlannerExecution::run()
                                                 << (cancel_ ? "; planner canceled!" : ""));
           setState(PAT_EXCEEDED, true);
         }
-        else if (max_retries_ == 0 && patience_.isZero())
+        else if (max_retries_ == 0)
         {
           ROS_INFO_STREAM("Planning could not find a plan!");
           setState(NO_PLAN_FOUND, true);

--- a/mbf_abstract_nav/test/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_planner_execution.cpp
@@ -23,6 +23,7 @@ using mbf_abstract_nav::AbstractPlannerExecution;
 using mbf_abstract_nav::MoveBaseFlexConfig;
 using testing::_;
 using testing::AtLeast;
+using testing::InSequence;
 using testing::Return;
 using testing::Test;
 
@@ -125,8 +126,9 @@ TEST_F(AbstractPlannerExecutionFixture, success_after_retries)
 
   // setup the expectations
   AbstractPlannerMock& mock = dynamic_cast<AbstractPlannerMock&>(*planner_);
-  auto& exp = EXPECT_CALL(mock, makePlan(_, _, _, _, _, _)).Times(config.planner_max_retries).WillRepeatedly(Return(11));
-  EXPECT_CALL(mock, makePlan(_, _, _, _, _, _)).Times(1).After(exp).WillOnce(Return(1));
+  InSequence seq;
+  EXPECT_CALL(mock, makePlan(_, _, _, _, _, _)).Times(config.planner_max_retries).WillRepeatedly(Return(11));
+  EXPECT_CALL(mock, makePlan(_, _, _, _, _, _)).Times(1).WillOnce(Return(1));
 
   // call and wait
   ASSERT_TRUE(start(pose, pose, 0));
@@ -238,7 +240,8 @@ TEST_F(AbstractPlannerExecutionFixture, patience_exceeded_waiting_for_planner_re
 
 TEST_F(AbstractPlannerExecutionFixture, patience_exceeded_infinite_retries)
 {
-  // if negative retries are configured, we expect makePlan to repeatedly get called, and PAT_EXCEEDED to be returned once the patience is exceeded
+  // if negative retries are configured, we expect makePlan to repeatedly get called, and PAT_EXCEEDED to be returned
+  // once the patience is exceeded
 
   // configure the class
   MoveBaseFlexConfig config;

--- a/mbf_abstract_nav/test/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_planner_execution.cpp
@@ -22,6 +22,7 @@ struct AbstractPlannerMock : public AbstractPlanner
 using mbf_abstract_nav::AbstractPlannerExecution;
 using mbf_abstract_nav::MoveBaseFlexConfig;
 using testing::_;
+using testing::AtLeast;
 using testing::Return;
 using testing::Test;
 
@@ -89,7 +90,7 @@ TEST_F(AbstractPlannerExecutionFixture, cancel)
 
 TEST_F(AbstractPlannerExecutionFixture, max_retries)
 {
-  // we expect that if the planner fails for max_retries times, that
+  // we expect that if the planner fails for 1 + max_retries times, that
   // the class returns MAX_RETRIES
 
   // configure the class
@@ -101,7 +102,7 @@ TEST_F(AbstractPlannerExecutionFixture, max_retries)
   // setup the expectations
   AbstractPlannerMock& mock = dynamic_cast<AbstractPlannerMock&>(*planner_);
 
-  EXPECT_CALL(mock, makePlan(_, _, _, _, _, _)).Times(config.planner_max_retries + 1).WillRepeatedly(Return(11));
+  EXPECT_CALL(mock, makePlan(_, _, _, _, _, _)).Times(1 + config.planner_max_retries).WillRepeatedly(Return(11));
 
   // call and wait
   ASSERT_TRUE(start(pose, pose, 0));
@@ -111,7 +112,31 @@ TEST_F(AbstractPlannerExecutionFixture, max_retries)
   ASSERT_EQ(getState(), MAX_RETRIES);
 }
 
-TEST_F(AbstractPlannerExecutionFixture, no_plan_found)
+TEST_F(AbstractPlannerExecutionFixture, success_after_retries)
+{
+  // we expect that if the planner fails for 1 + (max_retries - 1) times and then succeeds, that
+  // the class returns FOUND_PLAN
+
+  // configure the class
+  MoveBaseFlexConfig config;
+  config.planner_max_retries = 5;
+  config.planner_patience = 100;  // set a high patience
+  reconfigure(config);
+
+  // setup the expectations
+  AbstractPlannerMock& mock = dynamic_cast<AbstractPlannerMock&>(*planner_);
+  auto& exp = EXPECT_CALL(mock, makePlan(_, _, _, _, _, _)).Times(config.planner_max_retries).WillRepeatedly(Return(11));
+  EXPECT_CALL(mock, makePlan(_, _, _, _, _, _)).Times(1).After(exp).WillOnce(Return(1));
+
+  // call and wait
+  ASSERT_TRUE(start(pose, pose, 0));
+
+  // wait for the patience to elapse and check result
+  ASSERT_EQ(waitForStateUpdate(boost::chrono::seconds(1)), boost::cv_status::no_timeout);
+  ASSERT_EQ(getState(), FOUND_PLAN);
+}
+
+TEST_F(AbstractPlannerExecutionFixture, no_plan_found_zero_patience)
 {
   // if no retries and no patience are configured, we return NO_PLAN_FOUND on
   // planner failure
@@ -120,6 +145,29 @@ TEST_F(AbstractPlannerExecutionFixture, no_plan_found)
   MoveBaseFlexConfig config;
   config.planner_max_retries = 0;
   config.planner_patience = 0;
+  reconfigure(config);
+
+  // setup the expectations
+  AbstractPlannerMock& mock = dynamic_cast<AbstractPlannerMock&>(*planner_);
+  EXPECT_CALL(mock, makePlan(_, _, _, _, _, _)).Times(1).WillOnce(Return(11));
+
+  // call and wait
+  ASSERT_TRUE(start(pose, pose, 0));
+
+  // check result
+  ASSERT_EQ(waitForStateUpdate(boost::chrono::seconds(1)), boost::cv_status::no_timeout);
+  ASSERT_EQ(getState(), NO_PLAN_FOUND);
+}
+
+TEST_F(AbstractPlannerExecutionFixture, no_plan_found_non_zero_patience)
+{
+  // if no retries and a large patience are configured, we return NO_PLAN_FOUND on
+  // planner failure
+
+  // configure the class
+  MoveBaseFlexConfig config;
+  config.planner_max_retries = 0;
+  config.planner_patience = 1;
   reconfigure(config);
 
   // setup the expectations
@@ -161,10 +209,9 @@ TEST_F(AbstractPlannerExecutionFixture, sumDist)
   ASSERT_EQ(getCost(), 3);
 }
 
-TEST_F(AbstractPlannerExecutionFixture, patience_exceeded)
+TEST_F(AbstractPlannerExecutionFixture, patience_exceeded_waiting_for_planner_response)
 {
-  // if no retries and no patience are configured, we return NO_PLAN_FOUND on
-  // planner failure
+  // if makePlan does not return before the patience times out, we return PAT_EXCEEDED
 
   // configure the class
   MoveBaseFlexConfig config;
@@ -185,7 +232,29 @@ TEST_F(AbstractPlannerExecutionFixture, patience_exceeded)
   cv.notify_all();
 
   // check result
-  waitForStateUpdate(boost::chrono::seconds(1));
+  ASSERT_EQ(waitForStateUpdate(boost::chrono::seconds(1)), boost::cv_status::no_timeout);
+  ASSERT_EQ(getState(), PAT_EXCEEDED);
+}
+
+TEST_F(AbstractPlannerExecutionFixture, patience_exceeded_infinite_retries)
+{
+  // if negative retries are configured, we expect makePlan to repeatedly get called, and PAT_EXCEEDED to be returned once the patience is exceeded
+
+  // configure the class
+  MoveBaseFlexConfig config;
+  config.planner_max_retries = -1;
+  config.planner_patience = 0.5;
+  reconfigure(config);
+
+  // setup the expectations
+  AbstractPlannerMock& mock = dynamic_cast<AbstractPlannerMock&>(*planner_);
+  EXPECT_CALL(mock, makePlan(_, _, _, _, _, _)).Times(AtLeast(10)).WillRepeatedly(Return(11));
+
+  // call and wait
+  ASSERT_TRUE(start(pose, pose, 0));
+
+  // wait for the patience to elapse and check result
+  ASSERT_EQ(waitForStateUpdate(boost::chrono::seconds(1)), boost::cv_status::no_timeout);
   ASSERT_EQ(getState(), PAT_EXCEEDED);
 }
 


### PR DESCRIPTION
fix for #287

As described in the issue, if `planner_max_retries` is set to `0` and `makePlan()` fails before the patience is exceeded, the state should be set to `NO_PLAN_FOUND` immediately, and no retries should occur (just like in the case where `planner_patience` is set to 0).

I also added a test for this fix (and they fail without the fix), and took the opportunity to add a few other cases that didn't have tests yet.