### PR TITLE
Fix multiple retries despite controller_max_retries=0

### DIFF
--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -411,8 +411,8 @@ void AbstractControllerExecution::run()
           else
           {
             setState(NO_LOCAL_CMD); // useful for server feedback
-            // we keep on moving if we have retries left or if the user has granted us some patience.
-            moving_ = max_retries_ || !patience_.isZero();
+            // keep trying if we have > 0 or -1 (infinite) retries
+            moving_ = max_retries_;
           }
           // could not compute a valid velocity command -> stop moving the robot
           publishZeroVelocity(); // command the robot to stop; we still feedback command calculated by the plugin


### PR DESCRIPTION
As discussed [here](https://github.com/magazino/move_base_flex/pull/288#pullrequestreview-840016005), this PR replicates the current planner behavior when max_retries is zero, namely call controller only once.
This is also the behavior documented on [the wiki](http://wiki.ros.org/move_base_flex#:~:text=to%20be%20oscillating-,Note%20about%20max_retries%20and%20patience%20interaction%3A,-All%20possible%20combinations)