### PR TITLE
[fix] move_base_action: always sleep regardless of replanning

### DIFF
--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -526,7 +526,7 @@ bool MoveBaseAction::replanningActive() const
 void MoveBaseAction::replanningThread()
 {
   ros::Duration update_period(0.005);
-  ros::Rate update_rate(200);
+  ros::Rate update_rate(1.0/update_period.toSec());
   ros::Time last_replan_time(0.0);
 
   while (ros::ok())

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -526,6 +526,7 @@ bool MoveBaseAction::replanningActive() const
 void MoveBaseAction::replanningThread()
 {
   ros::Duration update_period(0.005);
+  ros::Rate update_rate(200);
   ros::Time last_replan_time(0.0);
 
   while (ros::ok())
@@ -553,16 +554,13 @@ void MoveBaseAction::replanningThread()
       }
       // else keep waiting for planning to complete (we already waited update_period in waitForResult)
     }
-    else if (!replanningActive())
-    {
-      update_period.sleep();
-    }
-    else if (ros::Time::now() - last_replan_time >= replanning_period_)
+    else if (replanningActive() && ros::Time::now() - last_replan_time >= replanning_period_)
     {
       ROS_DEBUG_STREAM_NAMED("move_base", "Next replanning cycle, using the \"get_path\" action!");
       action_client_get_path_.sendGoal(get_path_goal_);
       last_replan_time = ros::Time::now();
     }
+    update_rate.sleep();
   }
 }
 


### PR DESCRIPTION
when `planner_frequency > 0` the replanning thread would never sleep and thus cause CPU load of 100%.
This fix makes sure there is always an `update_period.sleep()` in the loop.

This reduces the load of mbf_costmap_navigation to 8% in my case, without any different behavior.