### PR TITLE
Handle infeasible global planner result when periodically replanning

### DIFF
--- a/mbf_abstract_nav/cfg/MoveBaseFlex.cfg
+++ b/mbf_abstract_nav/cfg/MoveBaseFlex.cfg
@@ -9,5 +9,6 @@ gen = ParameterGenerator()
 
 add_mbf_abstract_nav_params(gen)
 
+gen.add("stop_when_replan_fails", bool_t, 0, "Will cancel current goal when replanning fails", False)
 gen.add("restore_defaults", bool_t, 0, "Restore to the original configuration", False)
 exit(gen.generate(PACKAGE, "move_base_flex_node", "MoveBaseFlex"))

--- a/mbf_abstract_nav/cfg/MoveBaseFlex.cfg
+++ b/mbf_abstract_nav/cfg/MoveBaseFlex.cfg
@@ -9,6 +9,5 @@ gen = ParameterGenerator()
 
 add_mbf_abstract_nav_params(gen)
 
-gen.add("stop_when_replan_fails", bool_t, 0, "Will cancel current goal when replanning fails", False)
 gen.add("restore_defaults", bool_t, 0, "Restore to the original configuration", False)
 exit(gen.generate(PACKAGE, "move_base_flex_node", "MoveBaseFlex"))

--- a/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
@@ -170,6 +170,9 @@ class MoveBaseAction
   //! true, if recovery behavior for the MoveBase action is enabled.
   bool recovery_enabled_;
 
+  //! binds callback to handle replanning action which cancels current goal upon failure
+  bool stop_when_replan_fails_;
+
   std::vector<std::string> recovery_behaviors_;
 
   std::vector<std::string>::iterator current_recovery_behavior_;

--- a/mbf_abstract_nav/src/mbf_abstract_nav/__init__.py
+++ b/mbf_abstract_nav/src/mbf_abstract_nav/__init__.py
@@ -21,6 +21,8 @@ def add_mbf_abstract_nav_params(gen):
             "How long the planner will wait in seconds in an attempt to find a valid plan before giving up", 5.0, 0, 100)
     gen.add("planner_max_retries", int_t, 0,
             "How many times we will recall the planner in an attempt to find a valid plan before giving up", -1, -1, 1000)
+    gen.add("stop_when_replan_fails", bool_t, 0,
+            "Will cancel current goal when replanning fails", False)
 
     gen.add("controller_frequency", double_t, 0,
             "The rate in Hz at which to run the control loop and send velocity commands to the base", 20, 0, 100)

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -560,7 +560,7 @@ void MoveBaseAction::replanningThread()
     else if (ros::Time::now() - last_replan_time >= replanning_period_)
     {
       ROS_DEBUG_STREAM_NAMED("move_base", "Next replanning cycle, using the \"get_path\" action!");
-      action_client_get_path_.sendGoal(get_path_goal_);
+      action_client_get_path_.sendGoal(get_path_goal_, boost::bind(&MoveBaseAction::actionGetPathDone, this, _1, _2));
       last_replan_time = ros::Time::now();
     }
   }

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -82,6 +82,7 @@ void MoveBaseAction::reconfigure(
   oscillation_timeout_ = ros::Duration(config.oscillation_timeout);
   oscillation_distance_ = config.oscillation_distance;
   recovery_enabled_ = config.recovery_enabled;
+  stop_when_replan_fails_ = config.stop_when_replan_fails;
 }
 
 void MoveBaseAction::cancel()
@@ -560,7 +561,14 @@ void MoveBaseAction::replanningThread()
     else if (ros::Time::now() - last_replan_time >= replanning_period_)
     {
       ROS_DEBUG_STREAM_NAMED("move_base", "Next replanning cycle, using the \"get_path\" action!");
-      action_client_get_path_.sendGoal(get_path_goal_, boost::bind(&MoveBaseAction::actionGetPathDone, this, _1, _2));
+      if (stop_when_replan_fails_)
+      {
+        action_client_get_path_.sendGoal(get_path_goal_, boost::bind(&MoveBaseAction::actionGetPathDone, this, _1, _2));
+      }
+      else
+      {
+        action_client_get_path_.sendGoal(get_path_goal_);
+      }
       last_replan_time = ros::Time::now();
     }
   }

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -79,10 +79,10 @@ void MoveBaseAction::reconfigure(
     replanning_period_.fromSec(1.0 / config.planner_frequency);
   else
     replanning_period_.fromSec(0.0);
+  stop_when_replan_fails_ = config.stop_when_replan_fails;
   oscillation_timeout_ = ros::Duration(config.oscillation_timeout);
   oscillation_distance_ = config.oscillation_distance;
   recovery_enabled_ = config.recovery_enabled;
-  stop_when_replan_fails_ = config.stop_when_replan_fails;
 }
 
 void MoveBaseAction::cancel()

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -459,6 +459,7 @@ void CostmapNavigationServer::reconfigure(mbf_costmap_nav::MoveBaseFlexConfig &c
   abstract_config.planner_frequency = config.planner_frequency;
   abstract_config.planner_patience = config.planner_patience;
   abstract_config.planner_max_retries = config.planner_max_retries;
+  abstract_config.stop_when_replan_fails = config.stop_when_replan_fails;
   abstract_config.controller_frequency = config.controller_frequency;
   abstract_config.controller_patience = config.controller_patience;
   abstract_config.controller_max_retries = config.controller_max_retries;


### PR DESCRIPTION
While a goal is active, and a new goal is given, say through rviz, and this new goal is infeasible, then mbf aborts the active goal (good behavior).
While a goal is active, and through the `planner_frequency > 0` this goal is replanned and no feasible path is found, nothing happens (bad behavior). There will be no active global path, and the local planner will continue on its old path.

I connected the replanning goal call with the same callback as the "manual" goal call. so that the current goal will be canceled if no feasible path is found upon replanning.