### PR TITLE
Fix race condition between finishing and updating a goal

### DIFF
--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -69,9 +69,11 @@ void ControllerAction::start(
   if(slot_it != concurrency_slots_.end() && slot_it->second.in_use)
   {
     boost::lock_guard<boost::mutex> goal_guard(goal_mtx_);
-    if(slot_it->second.execution->getName() == goal_handle.getGoal()->controller ||
-       goal_handle.getGoal()->controller.empty())
+    if ((slot_it->second.execution->getName() == goal_handle.getGoal()->controller ||
+         goal_handle.getGoal()->controller.empty()) &&
+        slot_it->second.goal_handle.getGoalStatus().status == actionlib_msgs::GoalStatus::ACTIVE)
     {
+      ROS_DEBUG_STREAM_NAMED(name_, "Updating running controller goal of slot " << static_cast<int>(slot));
       update_plan = true;
       // Goal requests to run the same controller on the same concurrency slot already in use:
       // we update the goal handle and pass the new plan and tolerances from the action to the


### PR DESCRIPTION
AbstractActionBase sets slot.in_use to false after having left runImpl.
This means that a check based on slot.in_use might still see a thread as
running despite the goal got assigned a terminal state.
Hence, we also check that the goal is still active to consume an update.

Fix #295