### PR TITLE
Add parameter force_stop_on_retry that avoids zero vel commands on recoverable errors

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -343,6 +343,10 @@ namespace mbf_abstract_nav
     //! whether move base flex should force the robot to stop on canceling navigation.
     bool force_stop_on_cancel_;
 
+    //! whether move base flex should force the robot to stop while retrying controller calls
+    //! (that is, until patience is exceeded or retries are exhausted).
+    bool force_stop_on_retry_;
+
     //! distance tolerance to the given goal pose
     double dist_tolerance_;
 


### PR DESCRIPTION
This allows gracefully slowing down while retrying calls to the controller.
Note that this will apply only as long as 
- we have not exhausted available controller retries 
- we have not exhausted patience time

When either condition doesn't hold, we send zero velocity commands, as with current implementation

Default value is true, meaning current behavior