### PR TITLE
Add plugin-specific error ranges, so we don't return "unknown error"

### DIFF
--- a/mbf_msgs/action/ExePath.action
+++ b/mbf_msgs/action/ExePath.action
@@ -41,7 +41,10 @@ uint8 STOPPED           = 118  # The controller execution has been stopped rigor
 
 uint8 ERROR_RANGE_START = 100
 uint8 ERROR_RANGE_END   = 149
-# 121..149 are reserved as plugin specific errors
+
+# 121..149 are reserved as plugin specific errors:
+uint8 PLUGIN_ERROR_RANGE_START = 121
+uint8 PLUGIN_ERROR_RANGE_END   = 149
 
 uint32 outcome
 string message

--- a/mbf_msgs/action/GetPath.action
+++ b/mbf_msgs/action/GetPath.action
@@ -42,7 +42,10 @@ uint8 STOPPED           = 63  # The planner execution has been stopped rigorousl
 
 uint8 ERROR_RANGE_START = 50
 uint8 ERROR_RANGE_END   = 99
-# 71..99 are reserved as plugin specific errors
+
+# 71..99 are reserved as plugin specific errors:
+uint8 PLUGIN_ERROR_RANGE_START = 71
+uint8 PLUGIN_ERROR_RANGE_END   = 99
 
 uint32 outcome
 string message

--- a/mbf_msgs/action/MoveBase.action
+++ b/mbf_msgs/action/MoveBase.action
@@ -15,27 +15,27 @@ string[] recovery_behaviors
 ---
 
 # Predefined success codes:
-uint8 SUCCESS          = 0
+uint8 SUCCESS           = 0
 
 # Predefined general error codes:
-uint8 FAILURE          = 10
-uint8 CANCELED         = 11
-uint8 COLLISION        = 12
-uint8 OSCILLATION      = 13
-uint8 START_BLOCKED    = 14
-uint8 GOAL_BLOCKED     = 15
-uint8 TF_ERROR         = 16
-uint8 INTERNAL_ERROR   = 17
+uint8 FAILURE           = 10
+uint8 CANCELED          = 11
+uint8 COLLISION         = 12
+uint8 OSCILLATION       = 13
+uint8 START_BLOCKED     = 14
+uint8 GOAL_BLOCKED      = 15
+uint8 TF_ERROR          = 16
+uint8 INTERNAL_ERROR    = 17
 
 uint8 ERROR_RANGE_START = 10
 uint8 ERROR_RANGE_END   = 49
 # 21..49 are reserved for future general error codes
 
 # Planning/controlling failures:
-uint8 PLAN_FAILURE     = 50
+uint8 PLAN_FAILURE      = 50
 # 51..99 are reserved as planner specific errors
 
-uint8 CTRL_FAILURE     = 100
+uint8 CTRL_FAILURE      = 100
 # 101..149 are reserved as controller specific errors
 
 uint32 outcome

--- a/mbf_msgs/action/Recovery.action
+++ b/mbf_msgs/action/Recovery.action
@@ -23,7 +23,10 @@ uint8 IMPASSABLE        = 158  # Further execution would lead to a collision
 
 uint8 ERROR_RANGE_START = 150
 uint8 ERROR_RANGE_END   = 199
-# 171..199 are reserved as plugin specific errors
+
+# 171..199 are reserved as plugin specific errors:
+uint8 PLUGIN_ERROR_RANGE_START = 171
+uint8 PLUGIN_ERROR_RANGE_END   = 199
 
 uint32 outcome
 string message

--- a/mbf_utility/src/navigation_utility.cpp
+++ b/mbf_utility/src/navigation_utility.cpp
@@ -211,65 +211,122 @@ double angle(const geometry_msgs::PoseStamped &pose1, const geometry_msgs::PoseS
 
 std::string outcome2str(unsigned int outcome)
 {
-  switch (outcome)
-  {
-    case mbf_msgs::MoveBaseResult::SUCCESS:         return "Success";
-    case mbf_msgs::MoveBaseResult::FAILURE:         return "Failure";
-    case mbf_msgs::MoveBaseResult::CANCELED:        return "Canceled";
-    case mbf_msgs::MoveBaseResult::COLLISION:       return "Collision";
-    case mbf_msgs::MoveBaseResult::OSCILLATION:     return "Oscillation";
-    case mbf_msgs::MoveBaseResult::START_BLOCKED:   return "Start blocked";
-    case mbf_msgs::MoveBaseResult::GOAL_BLOCKED:    return "Goal blocked";
-    case mbf_msgs::MoveBaseResult::TF_ERROR:        return "TF Error";
-    case mbf_msgs::MoveBaseResult::INTERNAL_ERROR:  return "Internal Error";
+  if (outcome == mbf_msgs::MoveBaseResult::SUCCESS)
+    return "Success";
+  if (outcome == mbf_msgs::MoveBaseResult::FAILURE)
+    return "Failure";
+  if (outcome == mbf_msgs::MoveBaseResult::CANCELED)
+    return "Canceled";
+  if (outcome == mbf_msgs::MoveBaseResult::COLLISION)
+    return "Collision";
+  if (outcome == mbf_msgs::MoveBaseResult::OSCILLATION)
+    return "Oscillation";
+  if (outcome == mbf_msgs::MoveBaseResult::START_BLOCKED)
+    return "Start blocked";
+  if (outcome == mbf_msgs::MoveBaseResult::GOAL_BLOCKED)
+    return "Goal blocked";
+  if (outcome == mbf_msgs::MoveBaseResult::TF_ERROR)
+    return "TF Error";
+  if (outcome == mbf_msgs::MoveBaseResult::INTERNAL_ERROR)
+    return "Internal Error";
 
-    case mbf_msgs::GetPathResult::FAILURE:          return "Failure";
-    case mbf_msgs::GetPathResult::CANCELED:         return "Canceled";
-    case mbf_msgs::GetPathResult::INVALID_START:    return "Invalid start";
-    case mbf_msgs::GetPathResult::INVALID_GOAL:     return "Invalid goal";
-    case mbf_msgs::GetPathResult::NO_PATH_FOUND:    return "No path found";
-    case mbf_msgs::GetPathResult::PAT_EXCEEDED:     return "Patience exceeded";
-    case mbf_msgs::GetPathResult::EMPTY_PATH:       return "Empty Path";
-    case mbf_msgs::GetPathResult::TF_ERROR:         return "TF Error";
-    case mbf_msgs::GetPathResult::NOT_INITIALIZED:  return "Not initialized";
-    case mbf_msgs::GetPathResult::INVALID_PLUGIN:   return "Invalid Plugin";
-    case mbf_msgs::GetPathResult::INTERNAL_ERROR:   return "Internal Error";
-    case mbf_msgs::GetPathResult::OUT_OF_MAP:       return "Out of map";
-    case mbf_msgs::GetPathResult::MAP_ERROR:        return "Map error";
-    case mbf_msgs::GetPathResult::STOPPED:          return "Stopped";
+  if (outcome == mbf_msgs::GetPathResult::FAILURE)
+    return "Failure";
+  if (outcome == mbf_msgs::GetPathResult::CANCELED)
+    return "Canceled";
+  if (outcome == mbf_msgs::GetPathResult::INVALID_START)
+    return "Invalid start";
+  if (outcome == mbf_msgs::GetPathResult::INVALID_GOAL)
+    return "Invalid goal";
+  if (outcome == mbf_msgs::GetPathResult::NO_PATH_FOUND)
+    return "No path found";
+  if (outcome == mbf_msgs::GetPathResult::PAT_EXCEEDED)
+    return "Patience exceeded";
+  if (outcome == mbf_msgs::GetPathResult::EMPTY_PATH)
+    return "Empty Path";
+  if (outcome == mbf_msgs::GetPathResult::TF_ERROR)
+    return "TF Error";
+  if (outcome == mbf_msgs::GetPathResult::NOT_INITIALIZED)
+    return "Not initialized";
+  if (outcome == mbf_msgs::GetPathResult::INVALID_PLUGIN)
+    return "Invalid Plugin";
+  if (outcome == mbf_msgs::GetPathResult::INTERNAL_ERROR)
+    return "Internal Error";
+  if (outcome == mbf_msgs::GetPathResult::OUT_OF_MAP)
+    return "Out of map";
+  if (outcome == mbf_msgs::GetPathResult::MAP_ERROR)
+    return "Map error";
+  if (outcome == mbf_msgs::GetPathResult::STOPPED)
+    return "Stopped";
+  if (outcome >= mbf_msgs::GetPathResult::PLUGIN_ERROR_RANGE_START &&
+      outcome <= mbf_msgs::GetPathResult::PLUGIN_ERROR_RANGE_END)
+    return "Plugin-specific planner error";
 
-    case mbf_msgs::ExePathResult::FAILURE:          return "Failure";
-    case mbf_msgs::ExePathResult::CANCELED:         return "Canceled";
-    case mbf_msgs::ExePathResult::NO_VALID_CMD:     return "No valid command";
-    case mbf_msgs::ExePathResult::PAT_EXCEEDED:     return "Patience exceeded";
-    case mbf_msgs::ExePathResult::COLLISION:        return "Collision";
-    case mbf_msgs::ExePathResult::OSCILLATION:      return "Oscillation";
-    case mbf_msgs::ExePathResult::ROBOT_STUCK:      return "Robot stuck";
-    case mbf_msgs::ExePathResult::MISSED_GOAL:      return "Missed Goal";
-    case mbf_msgs::ExePathResult::MISSED_PATH:      return "Missed Path";
-    case mbf_msgs::ExePathResult::BLOCKED_GOAL:     return "Blocked Goal";
-    case mbf_msgs::ExePathResult::BLOCKED_PATH:     return "Blocked Path";
-    case mbf_msgs::ExePathResult::INVALID_PATH:     return "Invalid Path";
-    case mbf_msgs::ExePathResult::TF_ERROR:         return "TF Error";
-    case mbf_msgs::ExePathResult::NOT_INITIALIZED:  return "Not initialized";
-    case mbf_msgs::ExePathResult::INVALID_PLUGIN:   return "Invalid Plugin";
-    case mbf_msgs::ExePathResult::INTERNAL_ERROR:   return "Internal Error";
-    case mbf_msgs::ExePathResult::OUT_OF_MAP:       return "Out of map";
-    case mbf_msgs::ExePathResult::MAP_ERROR:        return "Map error";
-    case mbf_msgs::ExePathResult::STOPPED:          return "Stopped";
+  if (outcome == mbf_msgs::ExePathResult::FAILURE)
+    return "Failure";
+  if (outcome == mbf_msgs::ExePathResult::CANCELED)
+    return "Canceled";
+  if (outcome == mbf_msgs::ExePathResult::NO_VALID_CMD)
+    return "No valid command";
+  if (outcome == mbf_msgs::ExePathResult::PAT_EXCEEDED)
+    return "Patience exceeded";
+  if (outcome == mbf_msgs::ExePathResult::COLLISION)
+    return "Collision";
+  if (outcome == mbf_msgs::ExePathResult::OSCILLATION)
+    return "Oscillation";
+  if (outcome == mbf_msgs::ExePathResult::ROBOT_STUCK)
+    return "Robot stuck";
+  if (outcome == mbf_msgs::ExePathResult::MISSED_GOAL)
+    return "Missed Goal";
+  if (outcome == mbf_msgs::ExePathResult::MISSED_PATH)
+    return "Missed Path";
+  if (outcome == mbf_msgs::ExePathResult::BLOCKED_GOAL)
+    return "Blocked Goal";
+  if (outcome == mbf_msgs::ExePathResult::BLOCKED_PATH)
+    return "Blocked Path";
+  if (outcome == mbf_msgs::ExePathResult::INVALID_PATH)
+    return "Invalid Path";
+  if (outcome == mbf_msgs::ExePathResult::TF_ERROR)
+    return "TF Error";
+  if (outcome == mbf_msgs::ExePathResult::NOT_INITIALIZED)
+    return "Not initialized";
+  if (outcome == mbf_msgs::ExePathResult::INVALID_PLUGIN)
+    return "Invalid Plugin";
+  if (outcome == mbf_msgs::ExePathResult::INTERNAL_ERROR)
+    return "Internal Error";
+  if (outcome == mbf_msgs::ExePathResult::OUT_OF_MAP)
+    return "Out of map";
+  if (outcome == mbf_msgs::ExePathResult::MAP_ERROR)
+    return "Map error";
+  if (outcome == mbf_msgs::ExePathResult::STOPPED)
+    return "Stopped";
+  if (outcome >= mbf_msgs::ExePathResult::PLUGIN_ERROR_RANGE_START &&
+      outcome <= mbf_msgs::ExePathResult::PLUGIN_ERROR_RANGE_END)
+    return "Plugin-specific controller error";
 
-    case mbf_msgs::RecoveryResult::FAILURE:         return "Failure";
-    case mbf_msgs::RecoveryResult::CANCELED:        return "Canceled";
-    case mbf_msgs::RecoveryResult::PAT_EXCEEDED:    return "Patience exceeded";
-    case mbf_msgs::RecoveryResult::TF_ERROR:        return "TF Error";
-    case mbf_msgs::RecoveryResult::NOT_INITIALIZED: return "Not initialized";
-    case mbf_msgs::RecoveryResult::INVALID_PLUGIN:  return "Invalid Plugin";
-    case mbf_msgs::RecoveryResult::INTERNAL_ERROR:  return "Internal Error";
-    case mbf_msgs::RecoveryResult::IMPASSABLE:      return "Impassable";
-    case mbf_msgs::RecoveryResult::STOPPED:         return "Stopped";
+  if (outcome == mbf_msgs::RecoveryResult::FAILURE)
+    return "Failure";
+  if (outcome == mbf_msgs::RecoveryResult::CANCELED)
+    return "Canceled";
+  if (outcome == mbf_msgs::RecoveryResult::PAT_EXCEEDED)
+    return "Patience exceeded";
+  if (outcome == mbf_msgs::RecoveryResult::TF_ERROR)
+    return "TF Error";
+  if (outcome == mbf_msgs::RecoveryResult::NOT_INITIALIZED)
+    return "Not initialized";
+  if (outcome == mbf_msgs::RecoveryResult::INVALID_PLUGIN)
+    return "Invalid Plugin";
+  if (outcome == mbf_msgs::RecoveryResult::INTERNAL_ERROR)
+    return "Internal Error";
+  if (outcome == mbf_msgs::RecoveryResult::IMPASSABLE)
+    return "Impassable";
+  if (outcome == mbf_msgs::RecoveryResult::STOPPED)
+    return "Stopped";
+  if (outcome >= mbf_msgs::RecoveryResult::PLUGIN_ERROR_RANGE_START &&
+      outcome <= mbf_msgs::RecoveryResult::PLUGIN_ERROR_RANGE_END)
+    return "Plugin-specific recovery error";
 
-    default: return "unknown error code: " + std::to_string(outcome);
-  }
+  return "Unknown error code";
 }
 
 } /* namespace mbf_utility */


### PR DESCRIPTION
Follow up of #304, with ranges for the plugin-specific error codes

rationale: It doesn't make sense to return "unknown error code" for codes reserved for the plugins 