### PR TITLE
skip tf lookup if target frame matches input frame

### DIFF
--- a/mbf_utility/src/navigation_utility.cpp
+++ b/mbf_utility/src/navigation_utility.cpp
@@ -101,6 +101,12 @@ bool transformPose(const TF &tf,
     return false;
   }
 
+  if (target_frame == in.header.frame_id)
+  {
+    out = in;
+    return true;
+  }
+
   std::string error_msg;
 
 #ifdef USE_OLD_TF


### PR DESCRIPTION
When comparing the `get_path/goal/goal/target_pose` and `get_path/result/result/path/poses[-1]` (both in the same coordinate frame `map`), I noticed that the poses were slightly different sometimes (in orientation). I traced it down to being caused by `transformPose` "transforming" the pose from `map` to `map`; skipping the transformation for matching frames and just returning the input pose fixed the above issue. 