### PR TITLE
fix(mbf_abstract_nav): check for empty path to prevent segfault

### DIFF
--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -63,7 +63,7 @@ void ControllerAction::start(
   if (goal_handle.getGoal()->path.poses.empty())
   {
     mbf_msgs::ExePathResult result;
-    result.message = "Path is empty.";
+    result.message = "Path is empty";
     result.outcome = mbf_msgs::ExePathResult::INVALID_PATH;
     goal_handle.setRejected(result, result.message);
   }

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -60,6 +60,13 @@ void ControllerAction::start(
     goal_handle.setCanceled();
     return;
   }
+  if (goal_handle.getGoal()->path.poses.empty())
+  {
+    mbf_msgs::ExePathResult result;
+    result.message = "Path is empty.";
+    result.outcome = mbf_msgs::ExePathResult::INVALID_PATH;
+    goal_handle.setRejected(result, result.message);
+  }
 
   uint8_t slot = goal_handle.getGoal()->concurrency_slot;
 


### PR DESCRIPTION
Otherwise https://github.com/magazino/move_base_flex/blob/master/mbf_abstract_nav/src/controller_action.cpp#L87 will segfault when the path is empty