### PR TITLE
Fix replanning shutdown

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
@@ -166,6 +166,7 @@ class MoveBaseAction
 
   //! Replanning thread, running permanently
   boost::thread replanning_thread_;
+  bool replanning_thread_shutdown_{ false };
 
   //! true, if recovery behavior for the MoveBase action is enabled.
   bool recovery_enabled_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
@@ -166,7 +166,7 @@ class MoveBaseAction
 
   //! Replanning thread, running permanently
   boost::thread replanning_thread_;
-  bool replanning_thread_shutdown_{ false };
+  bool replanning_thread_shutdown_;
 
   //! true, if recovery behavior for the MoveBase action is enabled.
   bool recovery_enabled_;

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -57,6 +57,7 @@ MoveBaseAction::MoveBaseAction(const std::string& name, const mbf_utility::Robot
   , action_client_recovery_(private_nh_, "recovery")
   , oscillation_timeout_(0)
   , oscillation_distance_(0)
+  , replanning_thread_shutdown_(false)
   , recovery_enabled_(true)
   , behaviors_(behaviors)
   , action_state_(NONE)

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -69,7 +69,11 @@ MoveBaseAction::MoveBaseAction(const std::string& name, const mbf_utility::Robot
 MoveBaseAction::~MoveBaseAction()
 {
   action_state_ = NONE;
-  replanning_thread_.join();
+  replanning_thread_shutdown_ = true;
+  if (replanning_thread_.joinable())
+  {
+    replanning_thread_.join();
+  }
 }
 
 void MoveBaseAction::reconfigure(
@@ -528,7 +532,7 @@ void MoveBaseAction::replanningThread()
   ros::Duration update_period(0.005);
   ros::Time last_replan_time(0.0);
 
-  while (ros::ok())
+  while (ros::ok() && !replanning_thread_shutdown_)
   {
     if (!action_client_get_path_.getState().isDone())
     {


### PR DESCRIPTION
# Description 
Thread `join` hangs forever if one uses the class as an object (not the ROS node), because `ros::ok()` is always true. 
Example, if one try to use it for tests, the test hangs forever and it fails in timeout.