### PR TITLE
fix wrong (initial) global planner path cost

### DIFF
--- a/mbf_abstract_nav/src/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_planner_execution.cpp
@@ -251,7 +251,7 @@ void AbstractPlannerExecution::run()
     {
       // call the planner
       std::vector<geometry_msgs::PoseStamped> plan;
-      double cost;
+      double cost = 0.0;
 
       // lock goal start mutex
       goal_start_mtx_.lock();


### PR DESCRIPTION
There is this piece of code that sets a plan's cost in case the `planner_->makePlan` doesn't set the cost:

https://github.com/magazino/move_base_flex/blob/9ccecd1426790a8ab66f8394a94f951946f14fc0/mbf_abstract_nav/src/abstract_planner_execution.cpp#L304-L307

This however only works properly if `cost` is initialized to `0`