### PR TITLE
Fix service zero tolerance numerical issue

### DIFF
--- a/mbf_costmap_nav/CMakeLists.txt
+++ b/mbf_costmap_nav/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 find_package(catkin REQUIRED
   COMPONENTS
+  angles
   costmap_2d
   dynamic_reconfigure
   geometry_msgs
@@ -37,6 +38,7 @@ catkin_package(
   CATKIN_DEPENDS
   actionlib
   actionlib_msgs
+  angles
   costmap_2d
   dynamic_reconfigure
   geometry_msgs

--- a/mbf_costmap_nav/include/mbf_costmap_nav/free_pose_search.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/free_pose_search.h
@@ -61,11 +61,11 @@ namespace mbf_costmap_nav
 
 struct SearchConfig
 {
-  double angle_increment{ 5 * M_PI / 180 };  // 5 degrees
-  double angle_tolerance{ M_PI_2 };          // 90 degrees
-  double linear_tolerance{ 1.0 };            // 1 meter
-  bool use_padded_fp{ true };                // Padded footprint by default
-  double safety_dist{ 0.1 };                 // 10 cm
+  double angle_max_step_size{ 5 * M_PI / 180 };  // 5 degrees
+  double angle_tolerance{ M_PI_2 };              // 90 degrees
+  double linear_tolerance{ 1.0 };                // 1 meter
+  bool use_padded_fp{ true };                    // Padded footprint by default
+  double safety_dist{ 0.1 };                     // 10 cm
   geometry_msgs::Pose2D goal;
 };
 

--- a/mbf_costmap_nav/package.xml
+++ b/mbf_costmap_nav/package.xml
@@ -16,6 +16,7 @@
 
     <depend>actionlib</depend>
     <depend>actionlib_msgs</depend>
+    <depend>angles</depend>
     <depend>costmap_2d</depend>
     <depend>dynamic_reconfigure</depend>
     <depend>geometry_msgs</depend>

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -48,6 +48,7 @@
 #include <nav_core_wrapper/wrapper_local_planner.h>
 #include <nav_core_wrapper/wrapper_recovery_behavior.h>
 #include <xmlrpcpp/XmlRpc.h>
+#include <angles/angles.h>
 
 #include "mbf_costmap_nav/footprint_helper.h"
 #include "mbf_costmap_nav/costmap_navigation_server.h"
@@ -885,7 +886,12 @@ bool CostmapNavigationServer::callServiceFindValidPose(mbf_msgs::FindValidPose::
   response.pose.pose.position.x = sol.pose.x;
   response.pose.pose.position.y = sol.pose.y;
   response.pose.pose.position.z = 0;
-  response.pose.pose.orientation = tf::createQuaternionMsgFromYaw(sol.pose.theta);
+
+  // if the difference between solution angle and requested angle is less than ANGLE_INCREMENT,
+  // use the requested one to avoid numerical issues
+  response.pose.pose.orientation = angles::shortest_angular_distance(goal.theta, sol.pose.theta) < ANGLE_INCREMENT ?
+                                       request.pose.pose.orientation :
+                                       tf::createQuaternionMsgFromYaw(sol.pose.theta);
   response.pose.header.frame_id = costmap_frame;
   response.pose.header.stamp = ros::Time::now();
   response.state = sol.search_state.state;

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -887,12 +887,10 @@ bool CostmapNavigationServer::callServiceFindValidPose(mbf_msgs::FindValidPose::
   response.pose.pose.position.y = sol.pose.y;
   response.pose.pose.position.z = 0;
 
-  // if the difference between solution angle and requested angle is less than ANGLE_INCREMENT,
-  // use the requested one to avoid violating a very small angle_tolerance (e.g. 0)
+  // if solution angle and requested angle are the same (after conversion),
+  // use the requested (quaternion) one to avoid violating a very small angle_tolerance (e.g. 0)
   response.pose.pose.orientation =
-      std::abs(angles::shortest_angular_distance(goal.theta, sol.pose.theta)) < ANGLE_INCREMENT ?
-          request.pose.pose.orientation :
-          tf::createQuaternionMsgFromYaw(sol.pose.theta);
+      goal.theta == sol.pose.theta ? request.pose.pose.orientation : tf::createQuaternionMsgFromYaw(sol.pose.theta);
 
   const double linear_dist = std::hypot(goal.x - sol.pose.x, goal.y - sol.pose.y);
   const double angular_dist =


### PR DESCRIPTION
# Description

In the `callServiceFindValidPose` service we use `tf` utility functions to convert `quarternion` to `yaw` back and forth: `tf::getYaw` and `tf::createQuaternionMsgFromYaw` because of the `FreePoseSearch` class interfaces.

This can lead to numerical issues. For example, when the starting angle for the search is the solution, the original angle (service request) can be slightly different from the output (service response) because of the conversions.

Adding a check to fix the numerical issue: if the difference from input to output is less than the `ANGLE_INCREMENT`, we use the input angle without conversions.