### PR TITLE
Fix angle oscillation

### DIFF
--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -122,6 +122,9 @@ void ControllerAction::runImpl(GoalHandle &goal_handle, AbstractControllerExecut
   double oscillation_distance;
   private_nh.param("oscillation_distance", oscillation_distance, 0.03);
 
+  double oscillation_angle;
+  private_nh.param("oscillation_angle", oscillation_angle, M_PI);
+
   mbf_msgs::ExePathResult result;
   mbf_msgs::ExePathFeedback feedback;
 
@@ -276,7 +279,8 @@ void ControllerAction::runImpl(GoalHandle &goal_handle, AbstractControllerExecut
         if (!oscillation_timeout.isZero())
         {
           // check if oscillating
-          if (mbf_utility::distance(robot_pose_, oscillation_pose) >= oscillation_distance)
+          if (mbf_utility::distance(robot_pose_, oscillation_pose) >= oscillation_distance ||
+              mbf_utility::angle(robot_pose_, oscillation_pose) >= oscillation_angle)
           {
             last_oscillation_reset = ros::Time::now();
             oscillation_pose = robot_pose_;


### PR DESCRIPTION
# Description
If the robot is too slow to execute a spin-in-place, oscillation will be triggered.
However, that is not an actual oscillation, since the robot is spinning to goal.

# Testing
Behavior before (`oscillation_angle == 𝝿`):

https://github.com/magazino/move_base_flex/assets/6097267/51b326b5-1b17-41ee-aeaf-0fc8e555dd83

Behavior after (`oscillation_angle == 0.1`):

https://github.com/magazino/move_base_flex/assets/6097267/13f40a9c-cd51-44f5-a29e-a0c52a8d23b7

