### PR TITLE
accept tf_timeout < 0 to ignore timeout

### DIFF
--- a/mbf_utility/src/navigation_utility.cpp
+++ b/mbf_utility/src/navigation_utility.cpp
@@ -67,7 +67,7 @@ bool getRobotPose(const TF &tf,
                                timeout,
                                local_pose,
                                robot_pose);
-  if (success && ros::Time::now() - robot_pose.header.stamp > timeout)
+  if (success && timeout.toSec() > 0 && ros::Time::now() - robot_pose.header.stamp > timeout)
   {
     ROS_WARN("Most recent robot pose is %gs old (tolerance %gs)",
              (ros::Time::now() - robot_pose.header.stamp).toSec(), timeout.toSec());


### PR DESCRIPTION
this PR change to accept `tf_timeout` param `-1` to ignore `transformation` timeout check.
this is useful when we use `tf_static_transformer` for debugging.