### PR TITLE
initialize last_oscillation_pose_

### DIFF
--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -150,6 +150,7 @@ void MoveBaseAction::start(GoalHandle &goal_handle)
     return;
   }
   goal_pose_ = goal.target_pose;
+  last_oscillation_pose_ = robot_pose_;
 
   // wait for server connections
   if (!action_client_get_path_.waitForServer(connection_timeout) ||


### PR DESCRIPTION
this PR fix the issue that `last_oscillation_pose_` is not initialized.
this PR change to initialize the robot pose when `started`