### PR TITLE
Wait for replanning_period also when starting a goal

### DIFF
--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -531,7 +531,7 @@ bool MoveBaseAction::replanningActive() const
 void MoveBaseAction::replanningThread()
 {
   ros::Duration update_period(0.005);
-  ros::Time last_replan_time(0.0);
+  ros::Time last_replan_time = ros::Time::now();
 
   while (ros::ok() && !replanning_thread_shutdown_)
   {
@@ -560,6 +560,7 @@ void MoveBaseAction::replanningThread()
     }
     else if (!replanningActive())
     {
+      last_replan_time = ros::Time::now();
       update_period.sleep();
     }
     else if (ros::Time::now() - last_replan_time >= replanning_period_)


### PR DESCRIPTION
Otherwise we send 2 get_path goals consecutively, because `last_replan_time` gets stuck on the time when we finished the previous goal while the replanning thread is idle