### PR TITLE
Create 2 topics for current goal: controller and planner

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -85,7 +85,6 @@ namespace mbf_abstract_nav
      * @param controller_ptr Pointer to the controller plugin
      * @param robot_info Current robot state
      * @param vel_pub Velocity publisher
-     * @param goal_pub Current goal publisher
      * @param config Initial configuration for this execution
      */
     AbstractControllerExecution(
@@ -93,7 +92,6 @@ namespace mbf_abstract_nav
         const mbf_abstract_core::AbstractController::Ptr &controller_ptr,
         const mbf_utility::RobotInformation &robot_info,
         const ros::Publisher &vel_pub,
-        const ros::Publisher &goal_pub,
         const MoveBaseFlexConfig &config);
 
     /**
@@ -329,9 +327,6 @@ namespace mbf_abstract_nav
 
     //! publisher for the current velocity command
     ros::Publisher vel_pub_;
-
-    //! publisher for the current goal
-    ros::Publisher current_goal_pub_;
 
     //! the current controller state
     AbstractControllerExecution::ControllerState state_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
@@ -342,9 +342,6 @@ typedef boost::shared_ptr<dynamic_reconfigure::Server<mbf_abstract_nav::MoveBase
     //! cmd_vel publisher for all controller execution objects
     ros::Publisher vel_pub_;
 
-    //! current_goal publisher for all controller execution objects
-    ros::Publisher goal_pub_;
-
     //! current robot state
     mbf_utility::RobotInformation robot_info_;
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -52,15 +52,12 @@
 namespace mbf_abstract_nav
 {
 
-class ControllerAction :
-    public AbstractActionBase<mbf_msgs::ExePathAction, AbstractControllerExecution>
+class ControllerAction : public AbstractActionBase<mbf_msgs::ExePathAction, AbstractControllerExecution>
 {
- public:
-
+public:
   typedef boost::shared_ptr<ControllerAction> Ptr;
 
-  ControllerAction(const std::string &name,
-                   const mbf_utility::RobotInformation &robot_info);
+  ControllerAction(const std::string& name, const mbf_utility::RobotInformation& robot_info);
 
   /**
    * @brief Start controller action.
@@ -68,18 +65,13 @@ class ControllerAction :
    * @param goal_handle Reference to the goal handle received on action execution callback.
    * @param execution_ptr Pointer to the execution descriptor.
    */
-  void start(
-      GoalHandle &goal_handle,
-      typename AbstractControllerExecution::Ptr execution_ptr
-  );
+  void start(GoalHandle& goal_handle, typename AbstractControllerExecution::Ptr execution_ptr);
 
-  void runImpl(GoalHandle &goal_handle, AbstractControllerExecution& execution);
+  void runImpl(GoalHandle& goal_handle, AbstractControllerExecution& execution);
 
 protected:
-  void publishExePathFeedback(
-          GoalHandle &goal_handle,
-          uint32_t outcome, const std::string &message,
-          const geometry_msgs::TwistStamped &current_twist);
+  void publishExePathFeedback(GoalHandle& goal_handle, uint32_t outcome, const std::string& message,
+                              const geometry_msgs::TwistStamped& current_twist);
 
   /**
    * @brief Utility method to fill the ExePath action result in a single line
@@ -87,19 +79,15 @@ protected:
    * @param message ExePath action message
    * @param result The action result to fill
    */
-  void fillExePathResult(
-        uint32_t outcome, const std::string &message,
-        mbf_msgs::ExePathResult &result);
+  void fillExePathResult(uint32_t outcome, const std::string& message, mbf_msgs::ExePathResult& result);
 
-  boost::mutex goal_mtx_; ///< lock goal handle for updating it while running
-  geometry_msgs::PoseStamped robot_pose_; ///< Current robot pose
-  geometry_msgs::PoseStamped goal_pose_;  ///< Current goal pose
+  boost::mutex goal_mtx_;                  ///< lock goal handle for updating it while running
+  geometry_msgs::PoseStamped robot_pose_;  ///< Current robot pose
+  geometry_msgs::PoseStamped goal_pose_;   ///< Current goal pose
 
   //! Publish the current goal pose (the last pose of the path we are following)
   ros::Publisher goal_pub_;
 };
-}
+}  // namespace mbf_abstract_nav
 
-
-
-#endif //MBF_ABSTRACT_NAV__CONTROLLER_ACTION_H_
+#endif  // MBF_ABSTRACT_NAV__CONTROLLER_ACTION_H_

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -95,6 +95,8 @@ protected:
   geometry_msgs::PoseStamped robot_pose_; ///< Current robot pose
   geometry_msgs::PoseStamped goal_pose_;  ///< Current goal pose
 
+  //! Publish the current goal pose (the last pose of the path we are following)
+  ros::Publisher goal_pub_;
 };
 }
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
@@ -80,7 +80,7 @@ class PlannerAction : public AbstractActionBase<mbf_msgs::GetPathAction, Abstrac
  private:
 
   //! Publisher to publish the current goal pose, which is used for path planning
-  ros::Publisher current_goal_pub_;
+  ros::Publisher goal_pub_;
 
   //! Path sequence counter
   unsigned int path_seq_count_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
@@ -49,36 +49,29 @@
 #include "mbf_abstract_nav/abstract_action_base.hpp"
 #include "mbf_abstract_nav/abstract_planner_execution.h"
 
-
-namespace mbf_abstract_nav{
-
+namespace mbf_abstract_nav
+{
 
 class PlannerAction : public AbstractActionBase<mbf_msgs::GetPathAction, AbstractPlannerExecution>
 {
- public:
-
+public:
   typedef boost::shared_ptr<PlannerAction> Ptr;
 
-  PlannerAction(
-      const std::string &name,
-      const mbf_utility::RobotInformation &robot_info
-  );
+  PlannerAction(const std::string& name, const mbf_utility::RobotInformation& robot_info);
 
-  void runImpl(GoalHandle &goal_handle, AbstractPlannerExecution &execution);
+  void runImpl(GoalHandle& goal_handle, AbstractPlannerExecution& execution);
 
- protected:
-
+protected:
   /**
    * @brief Transforms a plan to the global frame (global_frame_) coord system.
    * @param plan Input plan to be transformed.
    * @param global_plan Output plan, which is then transformed to the global frame.
    * @return true, if the transformation succeeded, false otherwise
    */
-   bool transformPlanToGlobalFrame(const std::vector<geometry_msgs::PoseStamped>& plan,
-                                   std::vector<geometry_msgs::PoseStamped>& global_plan);
+  bool transformPlanToGlobalFrame(const std::vector<geometry_msgs::PoseStamped>& plan,
+                                  std::vector<geometry_msgs::PoseStamped>& global_plan);
 
- private:
-
+private:
   //! Publisher to publish the current goal pose, which is used for path planning
   ros::Publisher goal_pub_;
 
@@ -86,6 +79,6 @@ class PlannerAction : public AbstractActionBase<mbf_msgs::GetPathAction, Abstrac
   unsigned int path_seq_count_;
 };
 
-} /* mbf_abstract_nav */
+}  // namespace mbf_abstract_nav
 
 #endif /* MBF_ABSTRACT_NAV__PLANNER_ACTION_H_ */

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -48,17 +48,17 @@ namespace mbf_abstract_nav
 const double AbstractControllerExecution::DEFAULT_CONTROLLER_FREQUENCY = 100.0; // 100 Hz
 
 AbstractControllerExecution::AbstractControllerExecution(
-    const std::string &name,
-    const mbf_abstract_core::AbstractController::Ptr &controller_ptr,
-    const mbf_utility::RobotInformation &robot_info,
-    const ros::Publisher &vel_pub,
-    const MoveBaseFlexConfig &config) :
-  AbstractExecutionBase(name, robot_info),
-    controller_(controller_ptr),
-    state_(INITIALIZED), moving_(false), max_retries_(0), patience_(0), vel_pub_(vel_pub),
-    loop_rate_(DEFAULT_CONTROLLER_FREQUENCY)
+    const std::string& name, const mbf_abstract_core::AbstractController::Ptr& controller_ptr,
+    const mbf_utility::RobotInformation& robot_info, const ros::Publisher& vel_pub, const MoveBaseFlexConfig& config)
+  : AbstractExecutionBase(name, robot_info)
+  , controller_(controller_ptr)
+  , state_(INITIALIZED)
+  , moving_(false)
+  , max_retries_(0)
+  , patience_(0)
+  , vel_pub_(vel_pub)
+  , loop_rate_(DEFAULT_CONTROLLER_FREQUENCY)
 {
-  ros::NodeHandle nh;
   ros::NodeHandle private_nh("~");
 
   // non-dynamically reconfigurable parameters

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -52,11 +52,10 @@ AbstractControllerExecution::AbstractControllerExecution(
     const mbf_abstract_core::AbstractController::Ptr &controller_ptr,
     const mbf_utility::RobotInformation &robot_info,
     const ros::Publisher &vel_pub,
-    const ros::Publisher &goal_pub,
     const MoveBaseFlexConfig &config) :
   AbstractExecutionBase(name, robot_info),
     controller_(controller_ptr),
-    state_(INITIALIZED), moving_(false), max_retries_(0), patience_(0), vel_pub_(vel_pub), current_goal_pub_(goal_pub),
+    state_(INITIALIZED), moving_(false), max_retries_(0), patience_(0), vel_pub_(vel_pub),
     loop_rate_(DEFAULT_CONTROLLER_FREQUENCY)
 {
   ros::NodeHandle nh;
@@ -375,7 +374,6 @@ void AbstractControllerExecution::run()
           condition_.notify_all();
           return;
         }
-        current_goal_pub_.publish(plan.back());
       }
 
       // compute robot pose and store it in robot_pose_

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -66,12 +66,8 @@ AbstractNavigationServer::AbstractNavigationServer(const TFPtr &tf_listener_ptr)
       recovery_action_(name_action_recovery, robot_info_),
       move_base_action_(name_action_move_base, robot_info_, recovery_plugin_manager_.getLoadedNames())
 {
-  ros::NodeHandle nh;
-
-  goal_pub_ = nh.advertise<geometry_msgs::PoseStamped>("current_goal", 1);
-
   // init cmd_vel publisher for the robot velocity
-  vel_pub_ = nh.advertise<geometry_msgs::Twist>("cmd_vel", 1);
+  vel_pub_ = ros::NodeHandle().advertise<geometry_msgs::Twist>("cmd_vel", 1);
 
   action_server_get_path_ptr_ = ActionServerGetPathPtr(
     new ActionServerGetPath(
@@ -323,7 +319,7 @@ mbf_abstract_nav::AbstractControllerExecution::Ptr AbstractNavigationServer::new
     const mbf_abstract_core::AbstractController::Ptr &plugin_ptr)
 {
   return boost::make_shared<mbf_abstract_nav::AbstractControllerExecution>(plugin_name, plugin_ptr, robot_info_,
-                                                                           vel_pub_, goal_pub_, last_config_);
+                                                                           vel_pub_, last_config_);
 }
 
 mbf_abstract_nav::AbstractRecoveryExecution::Ptr AbstractNavigationServer::newRecoveryExecution(

--- a/mbf_abstract_nav/src/planner_action.cpp
+++ b/mbf_abstract_nav/src/planner_action.cpp
@@ -50,9 +50,9 @@ PlannerAction::PlannerAction(
     const mbf_utility::RobotInformation &robot_info)
   : AbstractActionBase(name, robot_info), path_seq_count_(0)
 {
-  ros::NodeHandle private_nh("~");
   // informative topics: current navigation goal
-  current_goal_pub_ = private_nh.advertise<geometry_msgs::PoseStamped>("current_goal", 1);
+  ros::NodeHandle private_nh("~");
+  goal_pub_ = private_nh.advertise<geometry_msgs::PoseStamped>("planner_goal", 1);
 }
 
 void PlannerAction::runImpl(GoalHandle &goal_handle, AbstractPlannerExecution &execution)
@@ -67,7 +67,7 @@ void PlannerAction::runImpl(GoalHandle &goal_handle, AbstractPlannerExecution &e
 
   double tolerance = goal.tolerance;
   bool use_start_pose = goal.use_start_pose;
-  current_goal_pub_.publish(goal.target_pose);
+  goal_pub_.publish(goal.target_pose);
 
   bool planner_active = true;
 

--- a/mbf_abstract_nav/test/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_controller_execution.cpp
@@ -41,7 +41,7 @@ struct AbstractControllerMock : public AbstractController
   MOCK_METHOD0(cancel, bool());
 };
 
-ros::Publisher VEL_PUB, GOAL_PUB;
+ros::Publisher VEL_PUB;
 TFPtr TF_PTR;
 mbf_utility::RobotInformation::Ptr ROBOT_INFO_PTR;
 
@@ -50,7 +50,7 @@ struct AbstractControllerExecutionFixture : public Test, public AbstractControll
 {
   AbstractControllerExecutionFixture()
     : AbstractControllerExecution("a name", AbstractController::Ptr(new AbstractControllerMock()), *ROBOT_INFO_PTR,
-                                  VEL_PUB, GOAL_PUB, MoveBaseFlexConfig{})
+                                  VEL_PUB, MoveBaseFlexConfig{})
   {
   }
 
@@ -298,7 +298,6 @@ int main(int argc, char** argv)
   ros::NodeHandle nh;
   // setup the pubs as global objects
   VEL_PUB = nh.advertise<Twist>("vel", 1);
-  GOAL_PUB = nh.advertise<PoseStamped>("pose", 1);
 
   // setup the tf-publisher and robot info as a global objects
   TF_PTR.reset(new TF());

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
@@ -67,7 +67,6 @@ public:
    * @param controller_ptr Shared pointer to the plugin to use.
    * @param robot_info Current robot state
    * @param vel_pub Velocity commands publisher.
-   * @param goal_pub Goal pose publisher (just vor visualization).
    * @param costmap_ptr Shared pointer to the local costmap.
    * @param config Current server configuration (dynamic).
    */
@@ -76,7 +75,6 @@ public:
       const mbf_costmap_core::CostmapController::Ptr &controller_ptr,
       const mbf_utility::RobotInformation &robot_info,
       const ros::Publisher &vel_pub,
-      const ros::Publisher &goal_pub,
       const CostmapWrapper::Ptr &costmap_ptr,
       const MoveBaseFlexConfig &config);
 

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
@@ -47,10 +47,9 @@ CostmapControllerExecution::CostmapControllerExecution(
     const mbf_costmap_core::CostmapController::Ptr &controller_ptr,
     const mbf_utility::RobotInformation &robot_info,
     const ros::Publisher &vel_pub,
-    const ros::Publisher &goal_pub,
     const CostmapWrapper::Ptr &costmap_ptr,
     const MoveBaseFlexConfig &config)
-      : AbstractControllerExecution(controller_name, controller_ptr, robot_info, vel_pub, goal_pub, toAbstract(config)),
+      : AbstractControllerExecution(controller_name, controller_ptr, robot_info, vel_pub, toAbstract(config)),
         costmap_ptr_(costmap_ptr)
 {
   ros::NodeHandle private_nh("~");

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
@@ -42,15 +42,14 @@
 namespace mbf_costmap_nav
 {
 
-CostmapControllerExecution::CostmapControllerExecution(
-    const std::string &controller_name,
-    const mbf_costmap_core::CostmapController::Ptr &controller_ptr,
-    const mbf_utility::RobotInformation &robot_info,
-    const ros::Publisher &vel_pub,
-    const CostmapWrapper::Ptr &costmap_ptr,
-    const MoveBaseFlexConfig &config)
-      : AbstractControllerExecution(controller_name, controller_ptr, robot_info, vel_pub, toAbstract(config)),
-        costmap_ptr_(costmap_ptr)
+CostmapControllerExecution::CostmapControllerExecution(const std::string& controller_name,
+                                                       const mbf_costmap_core::CostmapController::Ptr& controller_ptr,
+                                                       const mbf_utility::RobotInformation& robot_info,
+                                                       const ros::Publisher& vel_pub,
+                                                       const CostmapWrapper::Ptr& costmap_ptr,
+                                                       const MoveBaseFlexConfig& config)
+  : AbstractControllerExecution(controller_name, controller_ptr, robot_info, vel_pub, toAbstract(config))
+  , costmap_ptr_(costmap_ptr)
 {
   ros::NodeHandle private_nh("~");
   private_nh.param("controller_lock_costmap", lock_costmap_, true);

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -236,7 +236,7 @@ mbf_abstract_nav::AbstractControllerExecution::Ptr CostmapNavigationServer::newC
       findWithDefault(controller_name_to_costmap_ptr_, plugin_name, local_costmap_ptr_);
   return boost::make_shared<mbf_costmap_nav::CostmapControllerExecution>(
       plugin_name, boost::static_pointer_cast<mbf_costmap_core::CostmapController>(plugin_ptr), robot_info_, vel_pub_,
-      goal_pub_, costmap_ptr, last_config_);
+      costmap_ptr, last_config_);
 }
 
 mbf_abstract_nav::AbstractRecoveryExecution::Ptr CostmapNavigationServer::newRecoveryExecution(


### PR DESCRIPTION
Also, I cannot see why the controller's topic is created in the abstract_navigation_server and passed all along, so I move to the controller_action (same as planner).

I did the clang formatting required to pass CI in a 2nd commit, to make reviewing easier 