### PR TITLE
ControllerAction: use dynamic params on oscillation detection

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -198,8 +198,7 @@ public:
     slot.in_use = false;
   }
 
-  virtual void reconfigureAll(
-      mbf_abstract_nav::MoveBaseFlexConfig &config, uint32_t level)
+  virtual void reconfigure(mbf_abstract_nav::MoveBaseFlexConfig& config, uint32_t level)
   {
     boost::lock_guard<boost::mutex> guard(slot_map_mtx_);
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
@@ -106,7 +106,7 @@ class AbstractExecutionBase
    virtual void postRun(){};
 
    /**
-    * @brief Optional implementaiton-specific configuration function.
+    * @brief Optional implementation-specific configuration function.
     */
    virtual void reconfigure(MoveBaseFlexConfig& _cfg)
    {

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -90,7 +90,7 @@ protected:
   //! Publish the current goal pose (the last pose of the path we are following)
   ros::Publisher goal_pub_;
 
-  //! timeout after a oscillation is detected
+  //! timeout after an oscillation is detected
   ros::Duration oscillation_timeout_;
 
   //! minimal move distance to not detect an oscillation

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -59,6 +59,8 @@ public:
 
   ControllerAction(const std::string& name, const mbf_utility::RobotInformation& robot_info);
 
+  void reconfigure(mbf_abstract_nav::MoveBaseFlexConfig& config, uint32_t level) override;
+
   /**
    * @brief Start controller action.
    * Override abstract action version to allow updating current plan without stopping execution.
@@ -87,6 +89,15 @@ protected:
 
   //! Publish the current goal pose (the last pose of the path we are following)
   ros::Publisher goal_pub_;
+
+  //! timeout after a oscillation is detected
+  ros::Duration oscillation_timeout_;
+
+  //! minimal move distance to not detect an oscillation
+  double oscillation_distance_;
+
+  //! minimal rotation to not detect an oscillation
+  double oscillation_angle_;
 };
 }  // namespace mbf_abstract_nav
 

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -363,9 +363,9 @@ void AbstractNavigationServer::reconfigure(
     // if someone sets restore defaults on the parameter server, prevent looping
     config.restore_defaults = false;
   }
-  planner_action_.reconfigureAll(config, level);
-  controller_action_.reconfigureAll(config, level);
-  recovery_action_.reconfigureAll(config, level);
+  planner_action_.reconfigure(config, level);
+  controller_action_.reconfigure(config, level);
+  recovery_action_.reconfigure(config, level);
   move_base_action_.reconfigure(config, level);
 
   last_config_ = config;


### PR DESCRIPTION
Same as MoveBaseAction does

I have renamed AbstractActionBase::reconfigureAll as AbstractActionBase::reconfigure, so any action that needs dynamic parameters can just override it (as ControllerAction does now)