### PR TITLE
Implement service to force update the costmaps

### DIFF
--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
@@ -218,7 +218,7 @@ private:
   bool callServiceCheckPathCost(mbf_msgs::CheckPath::Request& request, mbf_msgs::CheckPath::Response& response);
 
   /**
-   * @brief Callback method for the make_plan service
+   * @brief Callback method for the clear_costmaps service
    * @param request Empty request object.
    * @param response Empty response object.
    * @return true, if the service completed successfully, false otherwise
@@ -232,6 +232,14 @@ private:
    * @return true, if the service completed successfully, false otherwise
    */
   bool callServiceFindValidPose(mbf_msgs::FindValidPose::Request& request, mbf_msgs::FindValidPose::Response& response);
+
+  /**
+   * @brief Callback method for the force_update_costmaps service
+   * @param request Empty request object.
+   * @param response Empty response object.
+   * @return true, if the service completed successfully, false otherwise
+   */
+  bool callForceUpdateCostmaps(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
 
   /**
    * @brief Reconfiguration method called by dynamic reconfigure.
@@ -285,6 +293,9 @@ private:
 
   //! Service Server for the find_valid_pose service
   ros::ServiceServer find_valid_pose_srv_;
+
+  //! Service Server for the force_update_costmap service
+  ros::ServiceServer force_update_costmaps_srv_;
 
   static constexpr double ANGLE_INCREMENT = 5.0 * M_PI / 180.0;  // 5 degrees
 };

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
@@ -234,12 +234,12 @@ private:
   bool callServiceFindValidPose(mbf_msgs::FindValidPose::Request& request, mbf_msgs::FindValidPose::Response& response);
 
   /**
-   * @brief Callback method for the force_update_costmaps service
+   * @brief Callback method for the update_costmaps service
    * @param request Empty request object.
    * @param response Empty response object.
    * @return true, if the service completed successfully, false otherwise
    */
-  bool callForceUpdateCostmaps(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
+  bool callServiceUpdateCostmaps(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
 
   /**
    * @brief Reconfiguration method called by dynamic reconfigure.
@@ -294,8 +294,8 @@ private:
   //! Service Server for the find_valid_pose service
   ros::ServiceServer find_valid_pose_srv_;
 
-  //! Service Server for the force_update_costmap service
-  ros::ServiceServer force_update_costmaps_srv_;
+  //! Service Server for the update_costmap service
+  ros::ServiceServer update_costmaps_srv_;
 
   static constexpr double ANGLE_INCREMENT = 5.0 * M_PI / 180.0;  // 5 degrees
 };

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -175,13 +175,12 @@ CostmapNavigationServer::CostmapNavigationServer(const TFPtr& tf_listener_ptr)
       private_nh_.advertiseService("check_pose_cost", &CostmapNavigationServer::callServiceCheckPoseCost, this);
   check_path_cost_srv_ =
       private_nh_.advertiseService("check_path_cost", &CostmapNavigationServer::callServiceCheckPathCost, this);
-  clear_costmaps_srv_ =
-      private_nh_.advertiseService("clear_costmaps", &CostmapNavigationServer::callServiceClearCostmaps, this);
   find_valid_pose_srv_ =
       private_nh_.advertiseService("find_valid_pose", &CostmapNavigationServer::callServiceFindValidPose, this);
-
-  force_update_costmaps_srv_ =
-      private_nh_.advertiseService("force_update_costmaps", &CostmapNavigationServer::callForceUpdateCostmaps, this);
+  update_costmaps_srv_ =
+      private_nh_.advertiseService("update_costmaps", &CostmapNavigationServer::callServiceUpdateCostmaps, this);
+  clear_costmaps_srv_ =
+      private_nh_.advertiseService("clear_costmaps", &CostmapNavigationServer::callServiceClearCostmaps, this);
 
   // dynamic reconfigure server for mbf_costmap_nav configuration; also include abstract server parameters
   dsrv_costmap_ = boost::make_shared<dynamic_reconfigure::Server<mbf_costmap_nav::MoveBaseFlexConfig> >(private_nh_);
@@ -821,10 +820,10 @@ bool CostmapNavigationServer::callServiceClearCostmaps(std_srvs::Empty::Request&
   return true;
 }
 
-bool CostmapNavigationServer::callForceUpdateCostmaps(std_srvs::Empty::Request& request,
-                                                      std_srvs::Empty::Response& response)
+bool CostmapNavigationServer::callServiceUpdateCostmaps(std_srvs::Empty::Request& request,
+                                                        std_srvs::Empty::Response& response)
 {
-  // force update both costmaps
+  // update both costmaps
   for (auto costmap : { local_costmap_ptr_, global_costmap_ptr_ })
   {
     costmap->checkActivate();

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -180,6 +180,9 @@ CostmapNavigationServer::CostmapNavigationServer(const TFPtr& tf_listener_ptr)
   find_valid_pose_srv_ =
       private_nh_.advertiseService("find_valid_pose", &CostmapNavigationServer::callServiceFindValidPose, this);
 
+  force_update_costmaps_srv_ =
+      private_nh_.advertiseService("force_update_costmaps", &CostmapNavigationServer::callForceUpdateCostmaps, this);
+
   // dynamic reconfigure server for mbf_costmap_nav configuration; also include abstract server parameters
   dsrv_costmap_ = boost::make_shared<dynamic_reconfigure::Server<mbf_costmap_nav::MoveBaseFlexConfig> >(private_nh_);
   dsrv_costmap_->setCallback(boost::bind(&CostmapNavigationServer::reconfigure, this, _1, _2));
@@ -815,6 +818,20 @@ bool CostmapNavigationServer::callServiceClearCostmaps(std_srvs::Empty::Request&
   // clear both costmaps
   local_costmap_ptr_->clear();
   global_costmap_ptr_->clear();
+  return true;
+}
+
+bool CostmapNavigationServer::callForceUpdateCostmaps(std_srvs::Empty::Request& request,
+                                                      std_srvs::Empty::Response& response)
+{
+  // force update both costmaps
+  for (auto costmap : { local_costmap_ptr_, global_costmap_ptr_ })
+  {
+    costmap->checkActivate();
+    costmap->updateMap();
+    costmap->checkDeactivate();
+  }
+
   return true;
 }
 


### PR DESCRIPTION
## Description

Added a new service `force_update_costmaps` to force an update to happen NOW.

**Bonus:** fixed description of `clear_costmaps` service -- I guess it was a mistake from copy-pasting.

## Testing

```bash
> rosservice call /move_base_flex/force_update_costmaps "{}"
```

## Demo

Note that in the video I set the update frequency to 0, so in order for rviz to reflect the change I need to re-toggle the subscribers.
But you can see how the footprint immediately updates to the new position.

https://github.com/magazino/move_base_flex/assets/15384781/1bbfb213-78ad-4349-a14c-78823f1f96e6