### PR TITLE
Fix some of the remaining mbf abstract nav todos

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -105,7 +105,7 @@ public:
   AbstractActionBase(
       const rclcpp::Node::SharedPtr& node,
       const std::string &name,
-      const mbf_utility::RobotInformation &robot_info
+      const mbf_utility::RobotInformation::ConstPtr &robot_info
   ) : node_(node), name_(name), robot_info_(robot_info){}
 
   virtual ~AbstractActionBase()
@@ -231,7 +231,7 @@ public:
 protected:
   rclcpp::Node::SharedPtr node_;
   const std::string name_;
-  const mbf_utility::RobotInformation &robot_info_;
+  mbf_utility::RobotInformation::ConstPtr robot_info_;
 
   boost::thread_group threads_;
   ConcurrencyMap concurrency_slots_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -94,7 +94,7 @@ namespace mbf_abstract_nav
      */
     AbstractControllerExecution(const std::string& name,
                                 const mbf_abstract_core::AbstractController::Ptr& controller_ptr,
-                                const mbf_utility::RobotInformation& robot_info,
+                                const mbf_utility::RobotInformation::ConstPtr& robot_info,
                                 const rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr& vel_pub,
                                 const rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr& goal_pub,
                                 const rclcpp::Node::SharedPtr& node_handle);

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_execution_base.h
@@ -58,7 +58,7 @@ namespace mbf_abstract_nav
 class AbstractExecutionBase
 {
  public:
-   AbstractExecutionBase(const std::string& name, const mbf_utility::RobotInformation& robot_info, const rclcpp::Node::SharedPtr& node);
+   AbstractExecutionBase(const std::string& name, const mbf_utility::RobotInformation::ConstPtr& robot_info, const rclcpp::Node::SharedPtr& node);
 
    virtual ~AbstractExecutionBase();
 
@@ -139,7 +139,7 @@ protected:
   std::string name_;
 
   //! Reference to the current robot state
-  const mbf_utility::RobotInformation& robot_info_;
+  mbf_utility::RobotInformation::ConstPtr robot_info_;
 
   //! Pointer to node in which the execution runs in. E.g. for getting the right logger.
   rclcpp::Node::SharedPtr node_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -90,7 +90,7 @@ namespace mbf_abstract_nav
      * @param config Initial configuration for this execution
      */
     AbstractPlannerExecution(const std::string& name, const mbf_abstract_core::AbstractPlanner::Ptr& planner_ptr,
-                             const mbf_utility::RobotInformation& robot_info,
+                             const mbf_utility::RobotInformation::ConstPtr& robot_info,
                              const rclcpp::Node::SharedPtr& node_handle);
 
     /**

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
@@ -90,7 +90,7 @@ namespace mbf_abstract_nav
      * @param config Initial configuration for this execution
      */
     AbstractRecoveryExecution(const std::string& name, const mbf_abstract_core::AbstractRecovery::Ptr& recovery_ptr,
-                              const mbf_utility::RobotInformation& robot_info,
+                              const mbf_utility::RobotInformation::ConstPtr& robot_info,
                               const rclcpp::Node::SharedPtr& node_handle);
 
     /**

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -43,6 +43,8 @@
 
 #include <rclcpp_action/server.hpp>
 
+#include <mutex>
+
 #include <mbf_msgs/action/exe_path.hpp>
 #include <mbf_utility/robot_information.h>
 
@@ -59,7 +61,6 @@ class ControllerAction :
 
   typedef std::shared_ptr<ControllerAction> Ptr;
 
-    
   ControllerAction(const rclcpp::Node::SharedPtr &node, const std::string &name,
                    const mbf_utility::RobotInformation &robot_info);
 
@@ -92,7 +93,7 @@ protected:
         uint32_t outcome, const std::string &message,
         mbf_msgs::action::ExePath::Result &result);
 
-  boost::mutex goal_mtx_; ///< lock goal handle for updating it while running
+  std::mutex goal_mtx_; ///< lock goal handle for updating it while running
   geometry_msgs::msg::PoseStamped robot_pose_; ///< Current robot pose
   geometry_msgs::msg::PoseStamped goal_pose_;  ///< Current goal pose
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -62,7 +62,7 @@ class ControllerAction :
   typedef std::shared_ptr<ControllerAction> Ptr;
 
   ControllerAction(const rclcpp::Node::SharedPtr &node, const std::string &name,
-                   const mbf_utility::RobotInformation &robot_info);
+                   const mbf_utility::RobotInformation::ConstPtr &robot_info);
 
   /**
    * @brief Start controller action.

--- a/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
@@ -69,7 +69,7 @@ class MoveBaseAction
   typedef rclcpp_action::ServerGoalHandle<mbf_msgs::action::MoveBase> GoalHandle;
 
   MoveBaseAction(const rclcpp::Node::SharedPtr &node, const std::string &name,
-                 const mbf_utility::RobotInformation &robot_info,
+                 const mbf_utility::RobotInformation::ConstPtr &robot_info,
                  const std::vector<std::string> &controllers);
 
   ~MoveBaseAction();
@@ -141,7 +141,7 @@ class MoveBaseAction
   std::string name_;
 
   //! current robot state
-  const mbf_utility::RobotInformation &robot_info_;
+  mbf_utility::RobotInformation::ConstPtr robot_info_;
 
   //! current robot pose; updated with exe_path action feedback
   geometry_msgs::msg::PoseStamped robot_pose_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
@@ -65,7 +65,7 @@ class PlannerAction : public AbstractActionBase<mbf_msgs::action::GetPath, Abstr
   PlannerAction(
       const rclcpp::Node::SharedPtr& node,
       const std::string &name,
-      const mbf_utility::RobotInformation &robot_info
+      const mbf_utility::RobotInformation::ConstPtr &robot_info
   );
 
   void runImpl(GoalHandle &goal_handle, AbstractPlannerExecution &execution);

--- a/mbf_abstract_nav/include/mbf_abstract_nav/recovery_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/recovery_action.h
@@ -56,7 +56,7 @@ class RecoveryAction : public AbstractActionBase<mbf_msgs::action::Recovery, Abs
 
   typedef std::shared_ptr<RecoveryAction> Ptr;
 
-  RecoveryAction(const rclcpp::Node::SharedPtr& node, const std::string &name, const mbf_utility::RobotInformation &robot_info);
+  RecoveryAction(const rclcpp::Node::SharedPtr& node, const std::string &name, const mbf_utility::RobotInformation::ConstPtr &robot_info);
 
   void runImpl(GoalHandle &goal_handle, AbstractRecoveryExecution &execution);
 

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -557,10 +557,10 @@ bool AbstractControllerExecution::cancel()
           }
           if (!loop_rate_->sleep())
           {
-            // TODO: find ROS2 equivalent or port for r.cycletime()
-            // ROS_WARN_THROTTLE(1.0, "Calculation needs too much time to stay in the moving frequency! (%.4fs >
-            // %.4fs)",
-            //                   loop_rate_.cycleTime().toSec(), loop_rate_.expectedCycleTime().toSec());
+            // TODO: missing loop_rate_->cycletime ROS2 equivalent for conveniently outputting the duration of the loop-to-blame.
+            RCLCPP_WARN_THROTTLE( node_->get_logger(), *node_->get_clock(), 1000, 
+              "Calculation needs too much time to stay in the moving frequency! ( took longer than %.4fs)",
+              std::chrono::duration<float>(loop_rate_->period()).count());
           }
           // Simulate boost::this_thread::interruption_point()
           {

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -52,7 +52,7 @@ const double AbstractControllerExecution::DEFAULT_CONTROLLER_FREQUENCY = 100.0; 
 
 AbstractControllerExecution::AbstractControllerExecution(
     const std::string& name, const mbf_abstract_core::AbstractController::Ptr& controller_ptr,
-    const mbf_utility::RobotInformation& robot_info,
+    const mbf_utility::RobotInformation::ConstPtr& robot_info,
     const rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr& vel_pub,
     const rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr& goal_pub,
     const rclcpp::Node::SharedPtr& node_handle)
@@ -241,7 +241,7 @@ bool AbstractControllerExecution::checkCmdVelIgnored(const geometry_msgs::msg::T
     return false;
   }
 
-  const bool robot_stopped = robot_info_.isRobotStopped(1e-3, 1e-3);
+  const bool robot_stopped = robot_info_->isRobotStopped(1e-3, 1e-3);
 
   // compute linear and angular velocity magnitude
   const double cmd_linear = std::hypot(cmd_vel.linear.x, cmd_vel.linear.y);
@@ -443,7 +443,7 @@ bool AbstractControllerExecution::cancel()
         }
 
         // compute robot pose and store it in robot_pose_
-        if (!robot_info_.getRobotPose(robot_pose_))
+        if (!robot_info_->getRobotPose(robot_pose_))
         {
           message_ = "Could not get the robot pose";
           outcome_ = mbf_msgs::action::ExePath::Result::TF_ERROR;
@@ -480,7 +480,7 @@ bool AbstractControllerExecution::cancel()
           // call plugin to compute the next velocity command
           geometry_msgs::msg::TwistStamped cmd_vel_stamped;
           geometry_msgs::msg::TwistStamped robot_velocity;
-          robot_info_.getRobotVelocity(robot_velocity);
+          robot_info_->getRobotVelocity(robot_velocity);
           outcome_ = computeVelocityCmd(robot_pose_, robot_velocity, cmd_vel_stamped, message_ = "");
 
           if (outcome_ < 10)

--- a/mbf_abstract_nav/src/abstract_execution_base.cpp
+++ b/mbf_abstract_nav/src/abstract_execution_base.cpp
@@ -40,7 +40,7 @@
 
 namespace mbf_abstract_nav
 {
-AbstractExecutionBase::AbstractExecutionBase(const std::string& name, const mbf_utility::RobotInformation& robot_info, const rclcpp::Node::SharedPtr& node)
+AbstractExecutionBase::AbstractExecutionBase(const std::string& name, const mbf_utility::RobotInformation::ConstPtr& robot_info, const rclcpp::Node::SharedPtr& node)
   : should_exit_(false), outcome_(255), cancel_(false), name_(name), robot_info_(robot_info), node_(node)
 { }
 

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -71,10 +71,10 @@ AbstractNavigationServer::AbstractNavigationServer(const TFPtr &tf_listener_ptr,
   robot_info_ = std::make_shared<mbf_utility::RobotInformation>(node, tf_listener_ptr, global_frame_, robot_frame_,
                                                                 rclcpp::Duration::from_seconds(tf_timeout_s),
                                                                 node_->get_parameter("odom_topic").as_string());
-  controller_action_ = std::make_shared<ControllerAction>(node, name_action_exe_path, *robot_info_); // TODO const ref to where robot_info_ ptr points is maybe not so nice
-  planner_action_ = std::make_shared<PlannerAction>(node, name_action_get_path, *robot_info_);
-  recovery_action_ = std::make_shared<RecoveryAction>(node, name_action_recovery, *robot_info_);
-  move_base_action_ = std::make_shared<MoveBaseAction>(node, name_action_move_base, *robot_info_, recovery_plugin_manager_.getLoadedNames());
+  controller_action_ = std::make_shared<ControllerAction>(node, name_action_exe_path, robot_info_);
+  planner_action_ = std::make_shared<PlannerAction>(node, name_action_get_path, robot_info_);
+  recovery_action_ = std::make_shared<RecoveryAction>(node, name_action_recovery, robot_info_);
+  move_base_action_ = std::make_shared<MoveBaseAction>(node, name_action_move_base, robot_info_, recovery_plugin_manager_.getLoadedNames());
   goal_pub_ = node_->create_publisher<geometry_msgs::msg::PoseStamped>("current_goal", 1);
 
   // init cmd_vel publisher for the robot velocity
@@ -307,14 +307,14 @@ mbf_abstract_nav::AbstractPlannerExecution::Ptr AbstractNavigationServer::newPla
     const mbf_abstract_core::AbstractPlanner::Ptr &plugin_ptr)
 {
   return std::make_shared<mbf_abstract_nav::AbstractPlannerExecution>(plugin_name, plugin_ptr,
-                                                                      *robot_info_, node_);//, last_config_); TODO reintroduce last_config feature?
+                                                                      robot_info_, node_);//, last_config_); TODO reintroduce last_config feature?
 }
 
 mbf_abstract_nav::AbstractControllerExecution::Ptr AbstractNavigationServer::newControllerExecution(
     const std::string &plugin_name,
     const mbf_abstract_core::AbstractController::Ptr &plugin_ptr)
 {
-  return std::make_shared<mbf_abstract_nav::AbstractControllerExecution>(plugin_name, plugin_ptr, *robot_info_,
+  return std::make_shared<mbf_abstract_nav::AbstractControllerExecution>(plugin_name, plugin_ptr, robot_info_,
                                                                          vel_pub_, goal_pub_, node_); // last_config_); TODO reintroduce last_config feature?
 }
 
@@ -323,7 +323,7 @@ mbf_abstract_nav::AbstractRecoveryExecution::Ptr AbstractNavigationServer::newRe
     const mbf_abstract_core::AbstractRecovery::Ptr &plugin_ptr)
 {
   return std::make_shared<mbf_abstract_nav::AbstractRecoveryExecution>(plugin_name, plugin_ptr,
-                                                                       *robot_info_, node_); // last_config_); TODO reintroduce last_config feature?
+                                                                       robot_info_, node_); // last_config_); TODO reintroduce last_config feature?
 }
 
 // TODO add restore_defaults functionality again

--- a/mbf_abstract_nav/src/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_planner_execution.cpp
@@ -45,7 +45,7 @@ namespace mbf_abstract_nav
 
 AbstractPlannerExecution::AbstractPlannerExecution(const std::string& name,
                                                    const mbf_abstract_core::AbstractPlanner::Ptr& planner_ptr,
-                                                   const mbf_utility::RobotInformation& robot_info,
+                                                   const mbf_utility::RobotInformation::ConstPtr& robot_info,
                                                    const rclcpp::Node::SharedPtr& node_handle)
   : AbstractExecutionBase(name, robot_info, node_handle)
   , planner_(planner_ptr)

--- a/mbf_abstract_nav/src/abstract_recovery_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_recovery_execution.cpp
@@ -47,7 +47,7 @@ namespace mbf_abstract_nav
 
 AbstractRecoveryExecution::AbstractRecoveryExecution(const std::string& name,
                                                      const mbf_abstract_core::AbstractRecovery::Ptr& recovery_ptr,
-                                                     const mbf_utility::RobotInformation& robot_info,
+                                                     const mbf_utility::RobotInformation::ConstPtr& robot_info,
                                                      const rclcpp::Node::SharedPtr& node_handle)
   : AbstractExecutionBase(name, robot_info, node_handle),
     behavior_(recovery_ptr),

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -90,7 +90,7 @@ void ControllerAction::start(
   std::map<uint8_t, ConcurrencySlot>::iterator slot_it = concurrency_slots_.find(slot);
   if(slot_it != concurrency_slots_.end() && slot_it->second.in_use)
   {
-    boost::lock_guard<boost::mutex> goal_guard(goal_mtx_);
+    std::lock_guard<std::mutex> goal_guard(goal_mtx_);
     if ((slot_it->second.execution->getName() == goal_handle->get_goal()->controller ||
          goal_handle->get_goal()->controller.empty()) &&
          slot_it->second.goal_handle->is_active())

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -48,7 +48,7 @@ namespace mbf_abstract_nav
 ControllerAction::ControllerAction(
     const rclcpp::Node::SharedPtr &node,
     const std::string &action_name,
-    const mbf_utility::RobotInformation &robot_info)
+    const mbf_utility::RobotInformation::ConstPtr &robot_info)
     : AbstractActionBase(node, action_name, robot_info)
 {
   rcl_interfaces::msg::ParameterDescriptor oscillation_timeout_description;
@@ -187,7 +187,7 @@ void ControllerAction::runImpl(GoalHandle &goal_handle, AbstractControllerExecut
   {
     // goal_handle could change between the loop cycles due to adapting the plan
     // with a new goal received for the same concurrency slot
-    if (!robot_info_.getRobotPose(robot_pose_))
+    if (!robot_info_->getRobotPose(robot_pose_))
     {
       controller_active = false;
       fillExePathResult(mbf_msgs::action::ExePath::Result::TF_ERROR, "Could not get the robot pose!", *result);

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -69,7 +69,7 @@ std::string resultCodeToString(rclcpp_action::ResultCode result_code)
 using namespace std::placeholders;
 
 MoveBaseAction::MoveBaseAction(const rclcpp::Node::SharedPtr &node, const std::string& name,
-                               const mbf_utility::RobotInformation& robot_info, const std::vector<std::string>& behaviors)
+                               const mbf_utility::RobotInformation::ConstPtr& robot_info, const std::vector<std::string>& behaviors)
   : name_(name)
   , robot_info_(robot_info)
   , node_(node)
@@ -188,7 +188,7 @@ void MoveBaseAction::start(std::shared_ptr<GoalHandle> goal_handle)
   current_recovery_behavior_ = recovery_behaviors_.begin();
 
   // get the current robot pose only at the beginning, as exe_path will keep updating it as we move
-  if (!robot_info_.getRobotPose(robot_pose_))
+  if (!robot_info_->getRobotPose(robot_pose_))
   {
     RCLCPP_ERROR_STREAM(rclcpp::get_logger("move_base"), "Could not get the current robot pose!");
     move_base_result->message = "Could not get the current robot pose!";

--- a/mbf_abstract_nav/src/planner_action.cpp
+++ b/mbf_abstract_nav/src/planner_action.cpp
@@ -48,7 +48,7 @@ namespace mbf_abstract_nav
 PlannerAction::PlannerAction(
     const rclcpp::Node::SharedPtr& node,
     const std::string &name,
-    const mbf_utility::RobotInformation &robot_info)
+    const mbf_utility::RobotInformation::ConstPtr &robot_info)
   : AbstractActionBase(node, name, robot_info)
 {
   // informative topics: current navigation goal
@@ -62,7 +62,7 @@ void PlannerAction::runImpl(GoalHandle &goal_handle, AbstractPlannerExecution &e
   mbf_msgs::action::GetPath::Result::SharedPtr result = std::make_shared<mbf_msgs::action::GetPath::Result>();
   geometry_msgs::msg::PoseStamped start_pose;
 
-  result->path.header.frame_id = robot_info_.getGlobalFrame();
+  result->path.header.frame_id = robot_info_->getGlobalFrame();
 
   double tolerance = goal.tolerance;
   bool use_start_pose = goal.use_start_pose;
@@ -79,7 +79,7 @@ void PlannerAction::runImpl(GoalHandle &goal_handle, AbstractPlannerExecution &e
   else
   {
     // get the current robot pose
-    if (!robot_info_.getRobotPose(start_pose))
+    if (!robot_info_->getRobotPose(start_pose))
     {
       result->outcome = mbf_msgs::action::GetPath::Result::TF_ERROR;
       result->message = "Could not get the current robot pose!";
@@ -267,12 +267,12 @@ bool PlannerAction::transformPlanToGlobalFrame(const std::vector<geometry_msgs::
   for (iter = plan.begin(); iter != plan.end(); ++iter)
   {
     geometry_msgs::msg::PoseStamped global_pose;
-    tf_success = mbf_utility::transformPose(node_, robot_info_.getTransformListener(), robot_info_.getGlobalFrame(),
-                                            robot_info_.getTfTimeout(), *iter, global_pose);
+    tf_success = mbf_utility::transformPose(node_, robot_info_->getTransformListener(), robot_info_->getGlobalFrame(),
+                                            robot_info_->getTfTimeout(), *iter, global_pose);
     if (!tf_success)
     {
       RCLCPP_ERROR_STREAM(rclcpp::get_logger(name_), "Can not transform pose from the \"" << iter->header.frame_id << "\" frame into the \""
-                                                     << robot_info_.getGlobalFrame() << "\" frame !");
+                                                     << robot_info_->getGlobalFrame() << "\" frame !");
       return false;
     }
     global_plan.push_back(global_pose);

--- a/mbf_abstract_nav/src/recovery_action.cpp
+++ b/mbf_abstract_nav/src/recovery_action.cpp
@@ -45,7 +45,7 @@
 namespace mbf_abstract_nav
 {
 
-RecoveryAction::RecoveryAction(const rclcpp::Node::SharedPtr& node, const std::string &name, const mbf_utility::RobotInformation &robot_info)
+RecoveryAction::RecoveryAction(const rclcpp::Node::SharedPtr& node, const std::string &name, const mbf_utility::RobotInformation::ConstPtr &robot_info)
   : AbstractActionBase(node, name, robot_info){}
 
 void RecoveryAction::runImpl(GoalHandle &goal_handle, AbstractRecoveryExecution &execution)

--- a/mbf_abstract_nav/test/abstract_action_base.cpp
+++ b/mbf_abstract_nav/test/abstract_action_base.cpp
@@ -14,7 +14,7 @@ using namespace mbf_abstract_nav;
 struct MockedExecution : public AbstractExecutionBase {
   typedef boost::shared_ptr<MockedExecution> Ptr;
 
-  MockedExecution(const mbf_utility::RobotInformation& ri, const rclcpp::Node::SharedPtr& node) : AbstractExecutionBase("mocked_execution", ri, node) {}
+  MockedExecution(const mbf_utility::RobotInformation::ConstPtr& ri, const rclcpp::Node::SharedPtr& node) : AbstractExecutionBase("mocked_execution", ri, node) {}
 
   MOCK_METHOD0(cancel, bool());
 
@@ -29,17 +29,17 @@ struct AbstractActionBaseFixture
     : public AbstractActionBase<mbf_msgs::action::GetPath, MockedExecution>,
       public Test {
   // required members for the c'tor
-  std::string test_name;
+  std::string test_name_;
   rclcpp::Node::SharedPtr node_;
   TFPtr tf_;
-  mbf_utility::RobotInformation ri;
+  mbf_utility::RobotInformation::ConstPtr ri_;
 
   AbstractActionBaseFixture()
-      : test_name("action_base"),
+      : test_name_("action_base"),
         node_(std::make_shared<rclcpp::Node>("test_node")),
         tf_(new TF(node_->get_clock())),
-        ri(node_, tf_, "global_frame", "local_frame", rclcpp::Duration(0,0)),
-        AbstractActionBase(node_, test_name, ri)
+        ri_(new mbf_utility::RobotInformation(node_, tf_, "global_frame", "local_frame", rclcpp::Duration(0,0))),
+        AbstractActionBase(node_, test_name_, ri_)
   {
   }
 
@@ -49,7 +49,7 @@ struct AbstractActionBaseFixture
 TEST_F(AbstractActionBaseFixture, thread_stop)
 {
   unsigned char slot = 1;
-  concurrency_slots_[slot].execution.reset(new MockedExecution(AbstractActionBaseFixture::ri, node_));
+  concurrency_slots_[slot].execution.reset(new MockedExecution(ri_, node_));
   concurrency_slots_[slot].thread_ptr =
       threads_.create_thread(boost::bind(&AbstractActionBaseFixture::run, this,
                                          boost::ref(concurrency_slots_[slot])));
@@ -61,7 +61,7 @@ TEST_F(AbstractActionBaseFixture, cancelAll)
 {
   // spawn a bunch of threads
   for (unsigned char slot = 0; slot != 10; ++slot) {
-    concurrency_slots_[slot].execution.reset(new MockedExecution(AbstractActionBaseFixture::ri, node_));
+    concurrency_slots_[slot].execution.reset(new MockedExecution(ri_, node_));
     // set the expectation
     EXPECT_CALL(*concurrency_slots_[slot].execution, cancel())
         .WillRepeatedly(Return(true));

--- a/mbf_abstract_nav/test/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_controller_execution.cpp
@@ -76,7 +76,6 @@ struct AbstractControllerExecutionFixture : public Test, public AbstractControll
     join();
 
     // re-init global objects, otherwise we get crashes due to multiple declaration of params
-    // TODO we should rid ourselves of global objects
     init_global_objects();
   }
 

--- a/mbf_abstract_nav/test/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_controller_execution.cpp
@@ -61,7 +61,7 @@ struct AbstractControllerExecutionFixture : public Test, public AbstractControll
 {
   AbstractControllerExecutionFixture()
     : AbstractControllerExecution("a name", AbstractController::Ptr(new AbstractControllerMock()),
-                                  *ROBOT_INFO, VEL_PUB, GOAL_PUB, NODE)
+                                  ROBOT_INFO, VEL_PUB, GOAL_PUB, NODE)
   {
   }
 

--- a/mbf_abstract_nav/test/abstract_execution_base.cpp
+++ b/mbf_abstract_nav/test/abstract_execution_base.cpp
@@ -10,7 +10,7 @@ using namespace mbf_abstract_nav;
 // it basically runs until we cancel it.
 struct DummyExecutionBase : public AbstractExecutionBase
 {
-  DummyExecutionBase(const std::string& _name, const mbf_utility::RobotInformation& ri, const rclcpp::Node::SharedPtr& node)
+  DummyExecutionBase(const std::string& _name, const mbf_utility::RobotInformation::ConstPtr& ri, const rclcpp::Node::SharedPtr& node)
     : AbstractExecutionBase(_name, ri, node)
   {
   }
@@ -45,12 +45,12 @@ struct AbstractExecutionFixture : public Test
 {
   rclcpp::Node::SharedPtr node_;
   TFPtr tf_;
-  mbf_utility::RobotInformation ri_;
+  mbf_utility::RobotInformation::ConstPtr ri_;
   DummyExecutionBase impl_;
   AbstractExecutionFixture() :
     node_(std::make_shared<rclcpp::Node>("test")), 
     tf_(new TF(node_->get_clock())),
-    ri_(node_, tf_, "global_frame", "local_frame", rclcpp::Duration::from_seconds(0), ""), 
+    ri_(new mbf_utility::RobotInformation(node_, tf_, "global_frame", "local_frame", rclcpp::Duration::from_seconds(0), "")), 
     impl_("foo", ri_, node_)
   {
   }

--- a/mbf_abstract_nav/test/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_planner_execution.cpp
@@ -57,7 +57,6 @@ struct AbstractPlannerExecutionFixture : public Test, public AbstractPlannerExec
     join();
 
     // re-init global objects, otherwise we get crashes due to multiple declaration of params
-    // TODO we should rid ourselves of global objects
     init_global_objects();
   }
 };

--- a/mbf_abstract_nav/test/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_planner_execution.cpp
@@ -28,7 +28,7 @@ using testing::Test;
 
 TFPtr TF_PTR;
 rclcpp::Node::SharedPtr NODE;
-mbf_utility::RobotInformation::Ptr ROBOT_INFO_PTR;
+mbf_utility::RobotInformation::ConstPtr ROBOT_INFO_PTR;
 
 void init_global_objects()
 {
@@ -47,7 +47,7 @@ struct AbstractPlannerExecutionFixture : public Test, public AbstractPlannerExec
 
   AbstractPlannerExecutionFixture()
     : AbstractPlannerExecution("foo", AbstractPlanner::Ptr{ new AbstractPlannerMock() },
-                               *ROBOT_INFO_PTR, NODE)
+                               ROBOT_INFO_PTR, NODE)
   {
   }
 

--- a/mbf_abstract_nav/test/planner_action.cpp
+++ b/mbf_abstract_nav/test/planner_action.cpp
@@ -56,7 +56,7 @@ struct PlannerActionFixture : public Test
     , planner_(new MockPlanner())
     , global_frame_("global_frame")
     , local_frame_("local_frame")
-    , robot_info_(node_, tf_, global_frame_, local_frame_, rclcpp::Duration::from_seconds(0.0))
+    , robot_info_(new mbf_utility::RobotInformation(node_, tf_, global_frame_, local_frame_, rclcpp::Duration::from_seconds(0.0)))
     , planner_execution_(new AbstractPlannerExecution("plugin", planner_, robot_info_, node_))
     , planner_action_(node_, "action_name", robot_info_)
     , action_server_(rclcpp_action::create_server<mbf_msgs::action::GetPath>(
@@ -115,7 +115,7 @@ struct PlannerActionFixture : public Test
   std::shared_ptr<MockPlanner> planner_; ///< the mocked planner
   std::string global_frame_;
   std::string local_frame_;
-  mbf_utility::RobotInformation robot_info_;
+  mbf_utility::RobotInformation::ConstPtr robot_info_;
   AbstractPlannerExecution::Ptr planner_execution_;
   PlannerAction planner_action_;
   std::shared_ptr<rclcpp_action::Server<mbf_msgs::action::GetPath>> action_server_;

--- a/mbf_utility/include/mbf_utility/robot_information.h
+++ b/mbf_utility/include/mbf_utility/robot_information.h
@@ -57,6 +57,7 @@ class RobotInformation
  public:
 
   typedef std::shared_ptr<RobotInformation> Ptr;
+  typedef std::shared_ptr<const RobotInformation> ConstPtr;
 
   RobotInformation(
       const rclcpp::Node::SharedPtr& node,


### PR DESCRIPTION
This PR will fix some of the ToDos we added during the initial ROS2 migration. In contrast to how I named the branch, the PR does not yet remove all ToDos. This is to get more easily digestible PRs and there were more ToDos than I anticipated... :D

Changes:
* Some easy replacements from boost to std
* Change `const &T` member to be `shared_ptr<const T>`
  * I think having const references to class members is a code smell. This particular instance (`T=RobotInformation`) didn't cause any issues during the tests. Some other cases (already fixed) already caused segfaults or similar crashes during the unit tests. Generally, I think it's better style to use a shared ptr here and the overhead is minimal (reference counting) (your opinions?).
  * Note that this changes the interface for all subclasses, which is quite a pain... But as we need to change the interface anyways for ROS2, it's a got moment to change this.