### PR TITLE
Remove boost from mbf_abstract_nav

### DIFF
--- a/mbf_abstract_nav/CMakeLists.txt
+++ b/mbf_abstract_nav/CMakeLists.txt
@@ -17,9 +17,6 @@ foreach(dep IN LISTS dependencies)
   find_package(${dep} REQUIRED)
 endforeach()
 
-# TODO remove dep to boost, use std lib instead
-find_package(Boost COMPONENTS thread chrono REQUIRED)
-
 include_directories(
   include
 )
@@ -59,7 +56,7 @@ if(BUILD_TESTING)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
-  target_link_libraries(${MBF_ABSTRACT_SERVER_LIB}_gtest ${MBF_ABSTRACT_SERVER_LIB} ${Boost_LIBRARIES})
+  target_link_libraries(${MBF_ABSTRACT_SERVER_LIB}_gtest ${MBF_ABSTRACT_SERVER_LIB})
 
   find_package(ament_cmake_gmock REQUIRED)
   ament_add_gmock(abstract_action_base_test test/abstract_action_base.cpp)
@@ -67,22 +64,22 @@ if(BUILD_TESTING)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
-  target_link_libraries(abstract_action_base_test ${MBF_ABSTRACT_SERVER_LIB} ${Boost_LIBRARIES})
+  target_link_libraries(abstract_action_base_test ${MBF_ABSTRACT_SERVER_LIB})
 
   ament_add_gmock(abstract_controller_execution_test test/abstract_controller_execution.cpp)
   target_include_directories(abstract_controller_execution_test PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
-  target_link_libraries(abstract_controller_execution_test ${MBF_ABSTRACT_SERVER_LIB} ${Boost_LIBRARIES})
+  target_link_libraries(abstract_controller_execution_test ${MBF_ABSTRACT_SERVER_LIB})
 
   ament_add_gmock(abstract_planner_execution_test
     test/abstract_planner_execution.cpp)
-  target_link_libraries(abstract_planner_execution_test ${MBF_ABSTRACT_SERVER_LIB} ${Boost_LIBRARIES})
+  target_link_libraries(abstract_planner_execution_test ${MBF_ABSTRACT_SERVER_LIB})
 
   ament_add_gmock(planner_action_test
     test/planner_action.cpp)
-  target_link_libraries(planner_action_test ${MBF_ABSTRACT_SERVER_LIB} ${Boost_LIBRARIES})
+  target_link_libraries(planner_action_test ${MBF_ABSTRACT_SERVER_LIB})
 endif()
 
 ament_export_include_directories(include) 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
@@ -44,7 +44,6 @@
 #include <string>
 
 #include <memory>
-#include <boost/thread/recursive_mutex.hpp>
 
 #include <rclcpp_action/server.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -310,7 +309,7 @@ const std::string name_action_move_base = "move_base";
     ActionServerMoveBase::SharedPtr action_server_move_base_ptr_;
 
     //! configuration mutex for derived classes and other threads.
-    boost::mutex configuration_mutex_;
+    //std::mutex configuration_mutex_;
 
     ////! last configuration save
     //mbf_abstract_nav::MoveBaseFlexConfig last_config_;

--- a/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
@@ -40,10 +40,11 @@
 #ifndef MBF_ABSTRACT_NAV__MOVE_BASE_ACTION_H_
 #define MBF_ABSTRACT_NAV__MOVE_BASE_ACTION_H_
 
+#include <thread>
+
 #include <rclcpp/duration.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
-#include <boost/thread.hpp> // TODO std thread?
 
 #include <mbf_msgs/action/move_base.hpp>
 #include <mbf_msgs/action/get_path.hpp>
@@ -167,7 +168,7 @@ class MoveBaseAction
   rclcpp::Duration replanning_period_;
 
   //! Replanning thread, running permanently
-  boost::thread replanning_thread_;
+  std::thread replanning_thread_;
   bool replanning_thread_shutdown_;
 
   //! true, if recovery behavior for the MoveBase action is enabled.

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -45,19 +45,21 @@
 namespace mbf_abstract_nav
 {
 
+using namespace std::placeholders;
+
 AbstractNavigationServer::AbstractNavigationServer(const TFPtr &tf_listener_ptr, const rclcpp::Node::SharedPtr& node)
     : tf_listener_ptr_(tf_listener_ptr), node_(node),
       planner_plugin_manager_("planners",
-          std::bind(&AbstractNavigationServer::loadPlannerPlugin, this, std::placeholders::_1),
-          std::bind(&AbstractNavigationServer::initializePlannerPlugin, this, std::placeholders::_1, std::placeholders::_2),
+          std::bind(&AbstractNavigationServer::loadPlannerPlugin, this, _1),
+          std::bind(&AbstractNavigationServer::initializePlannerPlugin, this, _1, _2),
           node),
       controller_plugin_manager_("controllers",
-          std::bind(&AbstractNavigationServer::loadControllerPlugin, this, std::placeholders::_1),
-          std::bind(&AbstractNavigationServer::initializeControllerPlugin, this, std::placeholders::_1, std::placeholders::_2),
+          std::bind(&AbstractNavigationServer::loadControllerPlugin, this, _1),
+          std::bind(&AbstractNavigationServer::initializeControllerPlugin, this, _1, _2),
           node),
       recovery_plugin_manager_("recovery_behaviors",
-          std::bind(&AbstractNavigationServer::loadRecoveryPlugin, this, std::placeholders::_1),
-          std::bind(&AbstractNavigationServer::initializeRecoveryPlugin, this, std::placeholders::_1, std::placeholders::_2),
+          std::bind(&AbstractNavigationServer::loadRecoveryPlugin, this, _1),
+          std::bind(&AbstractNavigationServer::initializeRecoveryPlugin, this, _1, _2),
           node)
 {
   node_->declare_parameter<double>("tf_timeout", 3.0);
@@ -83,30 +85,30 @@ AbstractNavigationServer::AbstractNavigationServer(const TFPtr &tf_listener_ptr,
   action_server_get_path_ptr_ = rclcpp_action::create_server<mbf_msgs::action::GetPath>(
     node_,
     name_action_get_path,
-    std::bind(&mbf_abstract_nav::AbstractNavigationServer::handleGoalGetPath, this, std::placeholders::_1, std::placeholders::_2),
-    std::bind(&mbf_abstract_nav::AbstractNavigationServer::cancelActionGetPath, this, std::placeholders::_1),
-    std::bind(&mbf_abstract_nav::AbstractNavigationServer::callActionGetPath, this, std::placeholders::_1));
+    std::bind(&mbf_abstract_nav::AbstractNavigationServer::handleGoalGetPath, this, _1, _2),
+    std::bind(&mbf_abstract_nav::AbstractNavigationServer::cancelActionGetPath, this, _1),
+    std::bind(&mbf_abstract_nav::AbstractNavigationServer::callActionGetPath, this, _1));
 
   action_server_exe_path_ptr_ = rclcpp_action::create_server<mbf_msgs::action::ExePath>(
     node_,
     name_action_exe_path,
-    std::bind(&mbf_abstract_nav::AbstractNavigationServer::handleGoalExePath, this, std::placeholders::_1, std::placeholders::_2),
-    std::bind(&mbf_abstract_nav::AbstractNavigationServer::cancelActionExePath, this, std::placeholders::_1),
-    std::bind(&mbf_abstract_nav::AbstractNavigationServer::callActionExePath, this, std::placeholders::_1));
+    std::bind(&mbf_abstract_nav::AbstractNavigationServer::handleGoalExePath, this, _1, _2),
+    std::bind(&mbf_abstract_nav::AbstractNavigationServer::cancelActionExePath, this, _1),
+    std::bind(&mbf_abstract_nav::AbstractNavigationServer::callActionExePath, this, _1));
 
   action_server_recovery_ptr_ = rclcpp_action::create_server<mbf_msgs::action::Recovery>(
     node_,
     name_action_recovery,
-    std::bind(&mbf_abstract_nav::AbstractNavigationServer::handleGoalRecovery, this, std::placeholders::_1, std::placeholders::_2),
-    std::bind(&mbf_abstract_nav::AbstractNavigationServer::cancelActionRecovery, this, std::placeholders::_1),
-    std::bind(&mbf_abstract_nav::AbstractNavigationServer::callActionRecovery, this, std::placeholders::_1));
+    std::bind(&mbf_abstract_nav::AbstractNavigationServer::handleGoalRecovery, this, _1, _2),
+    std::bind(&mbf_abstract_nav::AbstractNavigationServer::cancelActionRecovery, this, _1),
+    std::bind(&mbf_abstract_nav::AbstractNavigationServer::callActionRecovery, this, _1));
 
   action_server_move_base_ptr_ = rclcpp_action::create_server<mbf_msgs::action::MoveBase>(
     node_,
     name_action_move_base,
-    std::bind(&mbf_abstract_nav::AbstractNavigationServer::handleGoalMoveBase, this, std::placeholders::_1, std::placeholders::_2),
-    std::bind(&mbf_abstract_nav::AbstractNavigationServer::cancelActionMoveBase, this, std::placeholders::_1),
-    std::bind(&mbf_abstract_nav::AbstractNavigationServer::callActionMoveBase, this, std::placeholders::_1));
+    std::bind(&mbf_abstract_nav::AbstractNavigationServer::handleGoalMoveBase, this, _1, _2),
+    std::bind(&mbf_abstract_nav::AbstractNavigationServer::cancelActionMoveBase, this, _1),
+    std::bind(&mbf_abstract_nav::AbstractNavigationServer::callActionMoveBase, this, _1));
 
   // XXX note that we don't start a dynamic reconfigure server, to avoid colliding with the one possibly created by
   // the base class. If none, it should call startDynamicReconfigureServer method to start the one defined here for

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -330,7 +330,7 @@ mbf_abstract_nav::AbstractRecoveryExecution::Ptr AbstractNavigationServer::newRe
 // void AbstractNavigationServer::reconfigure(
 //   mbf_abstract_nav::MoveBaseFlexConfig &config, uint32_t level)
 // {
-//   boost::lock_guard<boost::mutex> guard(configuration_mutex_);
+//   std::lock_guard<std::mutex> guard(configuration_mutex_);
 // 
 //   // Make sure we have the original configuration the first time we're called, so we can restore it if needed
 //   if (!setup_reconfigure_)

--- a/mbf_abstract_nav/src/abstract_recovery_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_recovery_execution.cpp
@@ -38,8 +38,6 @@
  *
  */
 
-#include <boost/exception/diagnostic_information.hpp>
-
 #include <mbf_abstract_nav/abstract_recovery_execution.h>
 
 namespace mbf_abstract_nav

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -87,7 +87,7 @@ void ControllerAction::start(
 
   bool update_plan = false;
   slot_map_mtx_.lock();
-  std::map<uint8_t, ConcurrencySlot>::iterator slot_it = concurrency_slots_.find(slot);
+  ConcurrencyMap::iterator slot_it = concurrency_slots_.find(slot);
   if(slot_it != concurrency_slots_.end() && slot_it->second.in_use)
   {
     std::lock_guard<std::mutex> goal_guard(goal_mtx_);

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -82,7 +82,7 @@ MoveBaseAction::MoveBaseAction(const rclcpp::Node::SharedPtr &node, const std::s
   , recovery_trigger_(NONE)
   , dist_to_goal_(std::numeric_limits<double>::infinity())
   , replanning_period_(0, 0)
-  , replanning_thread_(boost::bind(&MoveBaseAction::replanningThread, this))
+  , replanning_thread_(std::bind(&MoveBaseAction::replanningThread, this))
 { 
   // TODO check, if parameterizable values get instantly set via reconfigure callback; otherwise, get param here. (Note that the params are declared in controller_action.)
   action_client_exe_path_ = rclcpp_action::create_client<ExePath>(node_, "exe_path");

--- a/mbf_abstract_nav/test/abstract_action_base.cpp
+++ b/mbf_abstract_nav/test/abstract_action_base.cpp
@@ -1,3 +1,6 @@
+#include <memory>
+#include <functional>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -12,7 +15,7 @@ using namespace mbf_abstract_nav;
 
 // mocked version of an execution
 struct MockedExecution : public AbstractExecutionBase {
-  typedef boost::shared_ptr<MockedExecution> Ptr;
+  typedef std::shared_ptr<MockedExecution> Ptr;
 
   MockedExecution(const mbf_utility::RobotInformation::ConstPtr& ri, const rclcpp::Node::SharedPtr& node) : AbstractExecutionBase("mocked_execution", ri, node) {}
 
@@ -50,9 +53,8 @@ TEST_F(AbstractActionBaseFixture, thread_stop)
 {
   unsigned char slot = 1;
   concurrency_slots_[slot].execution.reset(new MockedExecution(ri_, node_));
-  concurrency_slots_[slot].thread_ptr =
-      threads_.create_thread(boost::bind(&AbstractActionBaseFixture::run, this,
-                                         boost::ref(concurrency_slots_[slot])));
+  concurrency_slots_[slot].thread_ptr = new std::thread(
+    std::bind(&AbstractActionBaseFixture::run, this, std::ref(concurrency_slots_[slot])));
 }
 
 using testing::Return;
@@ -68,9 +70,8 @@ TEST_F(AbstractActionBaseFixture, cancelAll)
 
     // set the in_use flag --> this should turn to false
     concurrency_slots_[slot].in_use = true;
-    concurrency_slots_[slot].thread_ptr = threads_.create_thread(
-        boost::bind(&AbstractActionBaseFixture::run, this,
-                    boost::ref(concurrency_slots_[slot])));
+    concurrency_slots_[slot].thread_ptr = new std::thread(
+        std::bind(&AbstractActionBaseFixture::run, this, std::ref(concurrency_slots_[slot])));
   }
 
   // cancel all of slots

--- a/mbf_abstract_nav/test/planner_action.cpp
+++ b/mbf_abstract_nav/test/planner_action.cpp
@@ -36,6 +36,8 @@ using mbf_abstract_nav::AbstractPlannerExecution;
 using mbf_msgs::action::GetPath;
 using ServerGoalHandlePtr = std::shared_ptr<rclcpp_action::ServerGoalHandle<GetPath>>;
 
+using namespace std::placeholders;
+
 using testing::_;
 using testing::DoAll;
 using testing::Eq;
@@ -61,9 +63,9 @@ struct PlannerActionFixture : public Test
     , planner_action_(node_, "action_name", robot_info_)
     , action_server_(rclcpp_action::create_server<mbf_msgs::action::GetPath>(
         node_, "planner_action_test_server", 
-        std::bind(&PlannerActionFixture::acceptGoal, this, std::placeholders::_1, std::placeholders::_2),
-        std::bind(&PlannerActionFixture::cancelAction, this, std::placeholders::_1),
-        std::bind(&PlannerActionFixture::callAction, this, std::placeholders::_1)))
+        std::bind(&PlannerActionFixture::acceptGoal, this, _1, _2),
+        std::bind(&PlannerActionFixture::cancelAction, this, _1),
+        std::bind(&PlannerActionFixture::callAction, this, _1)))
     , action_client_(rclcpp_action::create_client<mbf_msgs::action::GetPath>(node_, "planner_action_test_server"))
   {
     tf_->setUsingDedicatedThread(true);


### PR DESCRIPTION
This PR removes all remaining dependencies to boost from mbf_abstract_nav. Use usages of boost before the migration were:
* boost bind
* boost shared ptrs
* boost thread, mutex, thread_group, condition_variables

The package now uses stdlib for these functionalities instead. In some cases, this improves interoperability with ROS2, since it uses stdlib for function bindings and smart pointers. The threading stuff could have remained on boost in principle, but having one dependency less is a good thing. Especially since it is not tracked by the ros pkg ecosystem and all the functionality we need is part of stdlib in C++17.

Changes in this PR:
* Remove boost dep on pkg level
* Do some easy drop-in replacement boost->std
* Refactor out `boost::thread_group`, use `thread_ptr` in `ConcurrencyMap` instead. <-- focus on these changes maybe, though we actually have a few tests for that yay!