### PR TITLE
More post migration todo fixes

### DIFF
--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -563,12 +563,11 @@ void MoveBaseAction::replanningThread()
   while (rclcpp::ok() && !replanning_thread_shutdown_)
   {
     const auto get_path_goal_handle = get_path_goal_handle_.get();
-    if (get_path_goal_handle->get_status() == rclcpp_action::GoalStatus::STATUS_ACCEPTED || get_path_goal_handle->get_status() == rclcpp_action::GoalStatus::STATUS_EXECUTING) // ->getState().isDone() : if PENDING or ACTIVE TODO rm comment
+    if (get_path_goal_handle->get_status() == rclcpp_action::GoalStatus::STATUS_ACCEPTED || get_path_goal_handle->get_status() == rclcpp_action::GoalStatus::STATUS_EXECUTING)
     {
       const auto get_path_result_future = action_client_get_path_->async_get_result(get_path_goal_handle);
       if (get_path_result_future.wait_for(update_preiod) == std::future_status::ready)
       {
-        //actionlib::SimpleClientGoalState state = action_client_get_path_.getState();
         const auto get_path_result = get_path_result_future.get();
         if (get_path_result.code == rclcpp_action::ResultCode::SUCCEEDED && replanningActive())
         {

--- a/mbf_abstract_nav/src/recovery_action.cpp
+++ b/mbf_abstract_nav/src/recovery_action.cpp
@@ -89,7 +89,7 @@ void RecoveryAction::runImpl(GoalHandle &goal_handle, AbstractRecoveryExecution 
           execution.cancel();
         }
 
-        //RCLCPP_DEBUG_STREAM_THROTTLE(rclcpp::get_logger(name_), clock, 3seconds , "Recovering with: " << goal.behavior); // TODO no node -> no clock? :(
+        RCLCPP_DEBUG_STREAM_THROTTLE(rclcpp::get_logger(name_), *node_->get_clock(), 3000 , "Recovering with: " << goal.behavior);
         break;
 
       case AbstractRecoveryExecution::CANCELED:

--- a/mbf_abstract_nav/test/abstract_action_base.cpp
+++ b/mbf_abstract_nav/test/abstract_action_base.cpp
@@ -19,9 +19,6 @@ struct MockedExecution : public AbstractExecutionBase {
 
   MockedExecution(const mbf_utility::RobotInformation::ConstPtr& ri, const rclcpp::Node::SharedPtr& node) : AbstractExecutionBase("mocked_execution", ri, node) {}
 
-
-protected:
-  MOCK_METHOD0(run, void());
   MOCK_METHOD(bool, cancel, (), (override));
 };
 

--- a/mbf_abstract_nav/test/abstract_action_base.cpp
+++ b/mbf_abstract_nav/test/abstract_action_base.cpp
@@ -22,6 +22,7 @@ struct MockedExecution : public AbstractExecutionBase {
   MOCK_METHOD(bool, cancel, (), (override));
 };
 
+using testing::Return;
 using testing::Test;
 
 // fixture with access to the AbstractActionBase's internals
@@ -47,16 +48,6 @@ struct AbstractActionBaseFixture
       std::this_thread::sleep_for(std::chrono::milliseconds(50)); // runs in action thread(s)
   }
 };
-
-TEST_F(AbstractActionBaseFixture, thread_stop)
-{
-  unsigned char slot = 1;
-  concurrency_slots_[slot].execution.reset(new MockedExecution(ri_, node_));
-  concurrency_slots_[slot].thread_ptr = new std::thread(
-    std::bind(&AbstractActionBaseFixture::run, this, std::ref(concurrency_slots_[slot])));
-}
-
-using testing::Return;
 
 TEST_F(AbstractActionBaseFixture, cancelAll)
 {

--- a/mbf_abstract_nav/test/abstract_action_base.cpp
+++ b/mbf_abstract_nav/test/abstract_action_base.cpp
@@ -43,7 +43,9 @@ struct AbstractActionBaseFixture
   {
   }
 
-  void runImpl(GoalHandle &goal_handle, MockedExecution &execution) {}
+  void runImpl(GoalHandle &goal_handle, MockedExecution &execution) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50)); // runs in action thread(s)
+  }
 };
 
 TEST_F(AbstractActionBaseFixture, thread_stop)
@@ -62,8 +64,7 @@ TEST_F(AbstractActionBaseFixture, cancelAll)
   for (unsigned char slot = 0; slot != 10; ++slot) {
     concurrency_slots_[slot].execution.reset(new MockedExecution(ri_, node_));
     // set the expectation
-    EXPECT_CALL(*concurrency_slots_[slot].execution, cancel())
-        .WillRepeatedly(Return(true));
+    EXPECT_CALL(*concurrency_slots_[slot].execution, cancel()).WillRepeatedly(Return(true));
 
     // set the in_use flag --> this should turn to false
     concurrency_slots_[slot].in_use = true;

--- a/mbf_abstract_nav/test/abstract_action_base.cpp
+++ b/mbf_abstract_nav/test/abstract_action_base.cpp
@@ -19,10 +19,10 @@ struct MockedExecution : public AbstractExecutionBase {
 
   MockedExecution(const mbf_utility::RobotInformation::ConstPtr& ri, const rclcpp::Node::SharedPtr& node) : AbstractExecutionBase("mocked_execution", ri, node) {}
 
-  MOCK_METHOD0(cancel, bool());
 
 protected:
   MOCK_METHOD0(run, void());
+  MOCK_METHOD(bool, cancel, (), (override));
 };
 
 using testing::Test;


### PR DESCRIPTION
This PR fixes the flaky test by deleting the test that came before it. I hope... I ran `$ while [ "$?" = "0" ]; do ./mbf_abstract_nav/abstract_action_base_test; done` for half an hour without failures. Usually, the running the command yields a failed test run in under a minute.
Sadly, I don't understand why the changes fix the flaky test, but I am tired of staring at the code. So... Let's get back to it if becomes necessary.

The deleted test did not test anything - it is missing `EXPECT_*` or `ASSERT_*` statements.

Otherwise, this PR cleans up a few ToDos. Other ToDos still remain, they are mostly about action goal handle state flow. But I think I will shift my focus to `mesh_navigation` next. We'll find out more about whether the state flow is flawed when we can run some real tests...