### PR TITLE
change plugin loader to load simple_core plugins

### DIFF
--- a/mbf_simple_nav/src/simple_navigation_server.cpp
+++ b/mbf_simple_nav/src/simple_navigation_server.cpp
@@ -46,9 +46,9 @@ namespace mbf_simple_nav
 
 SimpleNavigationServer::SimpleNavigationServer(const TFPtr &tf_listener_ptr) :
     mbf_abstract_nav::AbstractNavigationServer(tf_listener_ptr),
-    planner_plugin_loader_("mbf_abstract_core", "mbf_abstract_core::AbstractPlanner"),
-    controller_plugin_loader_("mbf_abstract_core", "mbf_abstract_core::AbstractController"),
-    recovery_plugin_loader_("mbf_abstract_core", "mbf_abstract_core::AbstractRecovery")
+  , planner_plugin_loader_("mbf_simple_core", "mbf_simple_core::SimplePlanner")
+  , controller_plugin_loader_("mbf_simple_core", "mbf_simple_core::SimpleController")
+  , recovery_plugin_loader_("mbf_simple_core", "mbf_simple_core::SimpleRecovery")
 {
   // initialize all plugins
   initializeServerComponents();


### PR DESCRIPTION
This change is needed to load simple_core plugins.
Otherwise abstract_core plugins are loaded, which results in an incorrect start of mbf.