### PR TITLE
Fix 3 related issues on move_base action recovering

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
@@ -121,6 +121,8 @@ class MoveBaseAction
     move_base_result.final_pose = robot_pose_;
   }
 
+  mbf_msgs::MoveBaseResult move_base_result_;
+
   mbf_msgs::ExePathGoal exe_path_goal_;
   mbf_msgs::GetPathGoal get_path_goal_;
   mbf_msgs::RecoveryGoal recovery_goal_;


### PR DESCRIPTION
- `move_base` action get's stuck if recovery behavior patience is exceeded
- If a recovery behavior fails, calling the next immediatly breaks simple action client
- If the last recovery behavior fails, we return that as move_base error instead of the error that triggered recovering

I was debugging the first, but realized the 2 other on the process

The solution for the first is to treat patience exceeded the same way as behavior failure. Then I realized the other 2 errors.
The solution for the 2nd is [rather hackish](https://github.com/magazino/move_base_flex/compare/js/fix_move_base_action?expand=1#diff-6b8a12259c3d11b5f68c080c8a6d7a690aecea38015c66366f1d559b16bd4acbR481-R482), but a proper solution would require to implement the move_base action, for which I don't have time. In any case the previous code was incorrect.