### PR TITLE
Missing quotation mark in ROS_ERROR_STREAM log

### DIFF
--- a/mbf_utility/src/robot_information.cpp
+++ b/mbf_utility/src/robot_information.cpp
@@ -61,7 +61,7 @@ bool RobotInformation::getRobotPose(geometry_msgs::PoseStamped &robot_pose) cons
   if (!tf_success)
   {
     ROS_ERROR_STREAM("Can not get the robot pose in the global frame. - robot frame: \""
-                         << robot_frame_ << "\"   global frame: \"" << global_frame_);
+                         << robot_frame_ << "\"   global frame: \"" << global_frame_ << "\"");
     return false;
   }
   return true;


### PR DESCRIPTION
Hi,
I've been recently using _move_base_flex_ and got the following error:

```text
Can not get the robot pose in the global frame. - robot frame: "base_link"   global frame: "map
```

At first glance I thought I messed something with frame names, because there's no closing quotation mark at the end of global frame name. (It turned out it was related with time synchronization between AMR and Host PC :laughing: ). I suggest you should add missing quotation mark, because this log can be misleading :wink:  

Regards,
Jan :robot: 