### PR TITLE
Update running controller goal also when we are preempting it

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -143,7 +143,7 @@ public:
         // if there is already a plugin running on the same slot, cancel it
         slot_it->second.execution->cancel();
 
-        // TODO + WARNING: this will block the main thread for an arbitrary time during which we won't execute callbacks
+        // WARNING: this will block the main thread for an arbitrary time during which we won't execute callbacks
         if (slot_it->second.thread_ptr->joinable()) {
           slot_it->second.thread_ptr->join();
         }

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -81,9 +81,10 @@ void ControllerAction::start(
   if(slot_it != concurrency_slots_.end() && slot_it->second.in_use)
   {
     boost::lock_guard<boost::mutex> goal_guard(goal_mtx_);
+    const auto slot_status = slot_it->second.goal_handle.getGoalStatus().status;
     if ((slot_it->second.execution->getName() == goal_handle.getGoal()->controller ||
          goal_handle.getGoal()->controller.empty()) &&
-        slot_it->second.goal_handle.getGoalStatus().status == actionlib_msgs::GoalStatus::ACTIVE)
+        (slot_status == actionlib_msgs::GoalStatus::ACTIVE || slot_status == actionlib_msgs::GoalStatus::PREEMPTING))
     {
       ROS_DEBUG_STREAM_NAMED(name_, "Updating running controller goal of slot " << static_cast<int>(slot));
       update_plan = true;


### PR DESCRIPTION
This PR partially addresses issue #323, for the case of preempting a controller execution with the same controller.
The problem is still there if the old and new goals have different controller.

I re-state here the problem and the solution
1. force_stop_on_cancel is set to false (we let the controller to smoothly stop when canceled)
2. goal running
3. we cancel it;  the controller slows down gently
4. before stopping, a new controller goal arrives
5. we [cancel the previous execution and join the thread](https://github.com/magazino/move_base_flex/blob/master/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp#L144-L149), waiting for the robot to stop
6. we keep calling the canceled controller to get slowing down speeds
7. BUT as we have blocked the main thread, the velocity we pass to it (provided by /odom topic) won't change
8. If the controller happens to relay on this velocity to control it's slowing down and stopping, we can deadlock

So instead of canceling and joining, with this PR, things change from point 5

5. we reuse the same slot and change the path of the current execution
6. it's not canceled anymore, so it executes the new path