### PR TITLE
Modernize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,32 @@
-This is the active ROS2 branch of this repository. If your are looking for the ROS1 version, checkout the [noetic](https://github.com/naturerobots/move_base_flex/tree/noetic) or [master](https://github.com/naturerobots/move_base_flex/tree/master) branches.
-
 [![Jazzy CI](https://github.com/naturerobots/move_base_flex/actions/workflows/jazzy.yaml/badge.svg)](https://github.com/naturerobots/move_base_flex/actions/workflows/jazzy.yaml)
 [![Humble CI](https://github.com/naturerobots/move_base_flex/actions/workflows/humble.yaml/badge.svg)](https://github.com/naturerobots/move_base_flex/actions/workflows/humble.yaml)
 
-# Move Base Flex: A Highly Flexible Navigation Framework:
+# Move Base Flex: A Highly Flexible Navigation Framework
 
-This repository contains Move Base Flex (MBF), a backwards-compatible replacement for move_base. MBF can use existing plugins for move_base, and provides an enhanced version of the same ROS interface. It exposes action servers for planning, controlling and recovering, providing detailed information of the current state and the plugin's feedback. An external executive logic can use MBF and its actions to perform smart and flexible navigation strategies. For example, at [Magazino](https://www.magazino.eu/?lang=en) we have successfully deployed MBF at customer facilities to control TORU robots in highly dynamical environments. Furthermore, MBF enables the use of other map representations, e.g. meshes. The core features are:
- 
-* Fully backwards-compatible with current ROS navigation.
-* Actions for the submodules planning, controlling and recovering, and services to query the costmaps are provided. This interface allows external executives, e.g. SMACH, or Behavior Trees, to run highly flexible and complex navigation strategies.
-* Comprehensive result and feedback information on all actions, including error codes and messages from the loaded plugins. For users still relying on a unique navigation interface, we have extended move_base action with detailed result and feedback information (though we still provide the current one).
-* Separation between an abstract navigation framework and concrete implementations, allowing faster development of new applications, e.g. 3D navigation.
-* Load multiple planners and controllers, selectable at runtime by setting one of the loaded plugin names in the action goal. 
-* Concurrency: Parallel planning, recovering, controlling by selecting different concurrency slots when defining the action goal. Only different plugins instances can run in parallel.
+**Move Base Flex (MBF)** is a **modular, map-agnostic navigation framework** for ROS that provides **well-defined interfaces and action servers** for **path planning**, **control**, and **recovery behaviors**.
+Rather than being a complete navigation stack, MBF serves as an **interface layer** that enables developers to design and integrate their own navigation systems using arbitrary map representations and custom plugin implementations.
 
-Please see also the [Move Base Flex Documentation and Tutorials](https://wiki.ros.org/move_base_flex) in the ROS wiki. And [this repository](https://github.com/Rayman/turtlebot3_mbf) contains a working minimal configuration for a turtlebot 3.
+## Key Features
 
-## Announcements & News
-### 16.10.2024 First ROS2 Version of Move Base Flex
-The first working ROS2 version of Move Base Flex has been published.
-It targets the ROS2 distro `humble` and includes most components you know from ROS1:
-- mbf_abstract_core & mbf_abstract_nav
-- mbf_simple_core & mbf_simple_nav (for navigation components that need no map representation)
-- mbf_utility
-- mbf_msgs
+* **Map-Agnostic Interface Design**
+  
+  MBF's interfaces are independent of any particular map representation (e.g., 2D costmaps, [meshes](https://github.com/naturerobots/mesh_navigation), or voxel grids), enabling seamless integration, scientific comparison, and context-aware selection of both navigation implementations and map types.
 
-The ROS2 version comes with an additional package that helps with integration tests:
-- mbf_test_utility (only a test dependency)
+* **Modular Action-Based Architecture**
+  
+  Separate action servers for *path planning*, *control*, and *recovery* enable external [deliberation software](https://github.com/ros-wg-delib/awesome-ros-deliberation) (e.g., Behavior Trees, SMACH, or custom logic) to coordinate complex navigation strategies.
 
-These two packages not migrated:
-- mbf_costmap_core & mbf_costmap_nav (for navigation components that utilize a 2D costmap). Nav2, which hosts the 2D costmap equivalent to the one from ROS1, and ROS1's move_base are quite different, so interfaces do not easily fit anymore. This makes migration hard. PRs are welcome for this. However, we might integrate another 2D grid map planning module soon.
+* **Extensible Plugin Framework**
+  
+  Multiple planners, controllers, and recovery behaviors can be loaded simultaneously, selected at runtime, or executed in parallel using different concurrency slots.
 
-Note that [mesh_navigation](https://github.com/naturerobots/mesh_navigation) is also available for ROS2, now. It provides navigation components that utilize 3D mesh maps.
+* **Rich Feedback and Diagnostics**
+  
+  All actions expose detailed feedback, results, and error codes, providing transparent runtime information for better debugging and system supervision.
+
+* **Clear Separation of Interfaces and Implementations**
+  
+  MBF's design facilitates reuse, experimentation, and the rapid development of new navigation approaches independent of any particular mapping or planning framework.
 
 ## Concepts & Architecture
 
@@ -39,6 +34,20 @@ We have created Move Base Flex for a larger target group besides the standard de
 
 MBF architecture:
 ![MBF architecture](doc/images/move_base_flex.png)
+
+## History
+
+MBF was originally developed for **ROS 1** by [Magazino](https://www.magazino.eu/en/) (see [noetic](https://github.com/naturerobots/move_base_flex/tree/noetic) or [master](https://github.com/naturerobots/move_base_flex/tree/master) branch) as a **backwards-compatible replacement for `move_base`**, providing a more flexible and transparent architecture when no modular alternative was available.
+It has been successfully deployed in production environments, for example at **[Magazino](https://www.magazino.eu/?lang=en)**, to control **TORU robots** operating in dynamic warehouse scenarios.
+
+Compared to `move_base`, MBF introduced:
+
+* Separate action servers for path planning, control, and recovery
+* Detailed feedback and error reporting
+* Runtime selection of multiple plugin implementations
+* Map-agnostic interface definitions
+
+With the advent of **ROS 2** and newer navigation frameworks such as **Nav2**, MBF continues to serve as a **lightweight, interface-oriented foundation** for research, prototyping, and customized navigation systems.
 
 ## Future Work
 MBF is an ongoing project. Some of the improvements that we have planned for the near future are:
@@ -59,3 +68,11 @@ Move Base Flex was initially developed at Magazino.
 
 ### [<img width="25" height="25" src="doc/images/logos/nature_robots_icon.jpg"> Nature Robots](https://naturerobots.com/)
 The latest version (ROS2) is developed and maintained by Nature Robots.
+
+## Further Resources
+
+* [Move Base Flex Documentation and Tutorials](https://wiki.ros.org/move_base_flex)
+* [Example TurtleBot3 Configuration](https://github.com/Rayman/turtlebot3_mbf)
+* [MBF Deliberation Examples](https://github.com/amock/mbf_deliberation)
+* [MBF Tutorials](https://github.com/naturerobots/mbf_tutorials)
+* [Mesh Navigation](https://github.com/naturerobots/mesh_navigation)

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Rather than being a complete navigation stack, MBF serves as an **interface laye
 
 ## Concepts & Architecture
 
-We have created Move Base Flex for a larger target group besides the standard developers and users of move_base and 2D navigation based on costmaps, as well as addressed move_base's limitations. Since robot navigation can be separated into planning and controlling in many cases, even for outdoor scenarios without the benefits of flat terrain, we designed MBF based on abstract planner-, controller- and recovery behavior-execution classes. To accomplish this goal, we created abstract base classes for the nav core BaseLocalPlanner, BaseGlobalPlanner and RecoveryBehavior plugin interfaces, extending the API to provide a richer and more expressive interface without breaking the current move_base plugin API. The new abstract interfaces allow plugins to return valuable information in each execution cycle, e.g. why a valid plan or a velocity command could not be computed. This information is then passed to the external executive logic through MBF planning, navigation or recovering actions’ feedback and result. The planner, controller and recovery behavior execution is implemented in the abstract execution classes without binding the software implementation to 2D costmaps. In our framework, MoveBase is just a particular implementation of a navigation system: its execution classes implement the abstract ones, bind the system to the costmaps. Thereby, the system can easily be used for other approaches, e.g. navigation on meshes or 3D occupancy grid maps. However, we provide a SimpleNavigationServer class without a binding to costmaps.
+Since robot navigation can be separated into planning and controlling in many cases, even for outdoor scenarios without the benefits of flat terrain, we designed MBF based on abstract planner-, controller- and recovery behavior-execution classes. To accomplish this goal, we created abstract base classes for the nav core BaseLocalPlanner, BaseGlobalPlanner and RecoveryBehavior plugin interfaces, extending the API to provide a rich and expressive interface. The abstract interfaces allow plugins to return valuable information in each execution cycle, e.g. why a valid plan or a velocity command could not be computed. This information is then passed to the external executive logic through MBF planning, navigation or recovering actions’ feedback and result. The planner, controller and recovery behavior execution is implemented in the abstract execution classes without binding the software implementation to 2D costmaps. In our framework, SimpleNav (or MeshNav) is just a particular implementation of a navigation system: its execution classes implement the abstract ones, bind the system to the costmaps. Thereby, the system can easily be used for other approaches, e.g. navigation on meshes or 3D occupancy grid maps. However, we provide a SimpleNavigationServer class without a binding to costmaps.
 
-MBF architecture:
+**MBF architecture:**
 ![MBF architecture](doc/images/move_base_flex.png)
 
 ## History
@@ -69,10 +69,33 @@ Move Base Flex was initially developed at Magazino.
 ### [<img width="25" height="25" src="doc/images/logos/nature_robots_icon.jpg"> Nature Robots](https://naturerobots.com/)
 The latest version (ROS2) is developed and maintained by Nature Robots.
 
+Here’s a clearer and more polished rephrasing of your section — concise but professional:
+
 ## Further Resources
 
-* [Move Base Flex Documentation and Tutorials](https://wiki.ros.org/move_base_flex)
-* [Example TurtleBot3 Configuration](https://github.com/Rayman/turtlebot3_mbf)
-* [MBF Deliberation Examples](https://github.com/amock/mbf_deliberation)
-* [MBF Tutorials](https://github.com/naturerobots/mbf_tutorials)
-* [Mesh Navigation](https://github.com/naturerobots/mesh_navigation)
+* [**Mesh Navigation**](https://github.com/naturerobots/mesh_navigation)
+  
+  Provides 3D navigation on **mesh surfaces**, implementing the **MBF interfaces** provided by this repository.
+
+* [**MBF Deliberation Examples**](https://github.com/amock/mbf_deliberation)
+  
+  Demonstrates how to invoke MBF actions using popular deliberation frameworks such as BehaviorTree.CPP and SMACH. These examples work independently of the chosen map representation.
+
+
+## Announcements & News
+
+### 16.10.2024 First ROS2 Version of Move Base Flex
+The first working ROS2 version of Move Base Flex has been published.
+It targets the ROS2 distro `humble` and includes most components you know from ROS1:
+- mbf_abstract_core & mbf_abstract_nav
+- mbf_simple_core & mbf_simple_nav (for navigation components that need no map representation)
+- mbf_utility
+- mbf_msgs
+
+The ROS2 version comes with an additional package that helps with integration tests:
+- mbf_test_utility (only a test dependency)
+
+These two packages not migrated:
+- mbf_costmap_core & mbf_costmap_nav (for navigation components that utilize a 2D costmap). Nav2, which hosts the 2D costmap equivalent to the one from ROS1, and ROS1's move_base are quite different, so interfaces do not easily fit anymore. This makes migration hard. PRs are welcome for this. However, we might integrate another 2D grid map planning module soon.
+
+Note that [mesh_navigation](https://github.com/naturerobots/mesh_navigation) is also available for ROS2, now. It provides navigation components that utilize 3D mesh maps.

--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ Move Base Flex was initially developed at Magazino.
 ### [<img width="25" height="25" src="doc/images/logos/nature_robots_icon.jpg"> Nature Robots](https://naturerobots.com/)
 The latest version (ROS2) is developed and maintained by Nature Robots.
 
-Here’s a clearer and more polished rephrasing of your section — concise but professional:
-
 ## Further Resources
 
 * [**Mesh Navigation**](https://github.com/naturerobots/mesh_navigation)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 # Move Base Flex: A Highly Flexible Navigation Framework
 
 Move Base Flex (MBF) is a modular, map-agnostic navigation framework for ROS that provides well-defined interfaces and action servers for path planning, control, and recovery behaviors.
-Rather than being a complete navigation stack, MBF serves as an interface layer that enables developers to design and integrate their own navigation systems using arbitrary map representations and custom plugin implementations.
-
-## Key Features
+Rather than being a complete navigation stack, MBF serves as an interface layer that enables developers to design and integrate their own navigation systems using arbitrary map representations and custom plugin implementations. Key features are:
 
 * **Map-Agnostic Interface Design**
   

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 # Move Base Flex: A Highly Flexible Navigation Framework
 
-**Move Base Flex (MBF)** is a **modular, map-agnostic navigation framework** for ROS that provides **well-defined interfaces and action servers** for **path planning**, **control**, and **recovery behaviors**.
-Rather than being a complete navigation stack, MBF serves as an **interface layer** that enables developers to design and integrate their own navigation systems using arbitrary map representations and custom plugin implementations.
+Move Base Flex (MBF) is a modular, map-agnostic navigation framework for ROS that provides well-defined interfaces and action servers for path planning, control, and recovery behaviors.
+Rather than being a complete navigation stack, MBF serves as an interface layer that enables developers to design and integrate their own navigation systems using arbitrary map representations and custom plugin implementations.
 
 ## Key Features
 
@@ -37,8 +37,8 @@ Since robot navigation can be separated into planning and controlling in many ca
 
 ## History
 
-MBF was originally developed for **ROS 1** by [Magazino](https://www.magazino.eu/en/) (see [noetic](https://github.com/naturerobots/move_base_flex/tree/noetic) or [master](https://github.com/naturerobots/move_base_flex/tree/master) branch) as a **backwards-compatible replacement for `move_base`**, providing a more flexible and transparent architecture when no modular alternative was available.
-It has been successfully deployed in production environments, for example at **[Magazino](https://www.magazino.eu/?lang=en)**, to control **TORU robots** operating in dynamic warehouse scenarios.
+MBF was originally developed for ROS 1 by [Magazino](https://www.magazino.eu/en/) (see [noetic](https://github.com/naturerobots/move_base_flex/tree/noetic) or [master](https://github.com/naturerobots/move_base_flex/tree/master) branch) as a backwards-compatible replacement for `move_base`, providing a more flexible and transparent architecture when no modular alternative was available.
+It has been successfully deployed in production environments, for example at [Magazino](https://www.magazino.eu/?lang=en), to control TORU robots operating in dynamic warehouse scenarios.
 
 Compared to `move_base`, MBF introduced:
 
@@ -47,7 +47,7 @@ Compared to `move_base`, MBF introduced:
 * Runtime selection of multiple plugin implementations
 * Map-agnostic interface definitions
 
-With the advent of **ROS 2** and newer navigation frameworks such as **Nav2**, MBF continues to serve as a **lightweight, interface-oriented foundation** for research, prototyping, and customized navigation systems.
+With the advent of ROS 2 and newer navigation frameworks such as Nav2, MBF continues to serve as a lightweight, interface-oriented foundation for research, prototyping, and customized navigation systems.
 
 ## Future Work
 MBF is an ongoing project. Some of the improvements that we have planned for the near future are:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The latest version (ROS2) is developed and maintained by Nature Robots.
 
 * [**Mesh Navigation**](https://github.com/naturerobots/mesh_navigation)
   
-  Provides 3D navigation on **mesh surfaces**, implementing the **MBF interfaces** provided by this repository.
+  Provides 3D navigation on mesh surfaces, implementing the MBF interfaces provided by this repository.
 
 * [**MBF Deliberation Examples**](https://github.com/amock/mbf_deliberation)
   

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 
 # Move Base Flex: A Highly Flexible Navigation Framework
 
-Move Base Flex (MBF) is a modular, map-agnostic navigation framework for ROS that provides well-defined interfaces and action servers for path planning, control, and recovery behaviors.
-Rather than being a complete navigation stack, MBF serves as an interface layer that enables developers to design and integrate their own navigation systems using arbitrary map representations and custom plugin implementations. Key features are:
+Move Base Flex (MBF) is a modular and map-agnostic navigation framework for ROS that provides well-defined interfaces and action servers for path planning, control, and recovery behaviors. Rather than being a complete navigation stack, MBF serves as an adaptable interface layer that enables developers to design and integrate their own navigation systems using arbitrary map representations and custom plugin implementations. Key features are:
 
 * **Map-Agnostic Interface Design**
   


### PR DESCRIPTION
I believe some parts of the README for the ROS 2 version of MBF feel a bit outdated. For instance, many newer ROS users are likely unfamiliar with the original move_base. I've therefore revised the README to better highlight MBF's current purpose and core features, focusing on its role and key design aspects rather than its historical context.

What do you think? I'm open to any feedback or ideas for improvement.