### PR TITLE
fix: main thread is blocked when canceling an execution

### DIFF
--- a/mbf_costmap_nav/src/mbf_costmap_nav/footprint_helper.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/footprint_helper.cpp
@@ -314,7 +314,7 @@ std::vector<Cell> FootprintHelper::getFootprintCells(double x, double y, double 
       return clearAndReturn(footprint_cells);
     }
 
-    getLineCells(x0, x1, y0, y1, footprint_cells);
+    supercover(x0, x1, y0, y1, footprint_cells);
   }
 
   //we need to close the loop, so we also have to raytrace from the last pt to first pt
@@ -329,7 +329,7 @@ std::vector<Cell> FootprintHelper::getFootprintCells(double x, double y, double 
     return clearAndReturn(footprint_cells);
   }
 
-  getLineCells(x0, x1, y0, y1, footprint_cells);
+  supercover(x0, x1, y0, y1, footprint_cells);
 
   if(fill) {
     getFillCells(footprint_cells);


### PR DESCRIPTION
[Issue](https://github.com/naturerobots/move_base_flex/issues/323)
Before, the join was called in the main thread. So when cancel is running, it will block other callbacks like odom callback from running. When cancel is running, the controller relies on odom callback to check if the robot is stopped and then it returns cancel. But as odom is not updated, the cancel keeps running.

After this change, it moves the block that runs cancel and updates the slot in a function and this function is called in a separate thread. So it does not block the main thread. I tested this by sending a goal with a different controller when cancel from one controller is running, and it seems to work. The next goal is executed after the first one is cancelled and the callbacks keep running in parallel.