### PR TITLE
Jenkins: move_base_flex meta package depends on ament_cmake build tool

### DIFF
--- a/move_base_flex/package.xml
+++ b/move_base_flex/package.xml
@@ -15,6 +15,8 @@
   <url>http://github.com/naturerobots/move_base_flex</url>
   <author email="sebastian.puetz@naturerobots.com">Sebastian Pütz</author>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
   <exec_depend>mbf_abstract_core</exec_depend>
   <exec_depend>mbf_abstract_nav</exec_depend>
   <exec_depend>mbf_msgs</exec_depend>


### PR DESCRIPTION
Hopefully fixes #372 