### PR TITLE
rviz_mbf_plugins: Select planners and controllers from dropdown menu

### DIFF
--- a/rviz_mbf_plugins/include/rviz_mbf_plugins/mbf_goal_actions_panel.hpp
+++ b/rviz_mbf_plugins/include/rviz_mbf_plugins/mbf_goal_actions_panel.hpp
@@ -42,15 +42,22 @@
 #include <mbf_msgs/action/get_path.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/parameter_client.hpp>
+
 #include <rviz_common/panel.hpp>
+#include <rviz_common/properties/editable_enum_property.hpp>
 #include <rviz_common/properties/ros_topic_property.hpp>
+#include <rviz_common/properties/ros_action_property.hpp>
 #include <rviz_common/properties/property_tree_model.hpp>
 #include <rviz_common/properties/property_tree_widget.hpp>
-#include <rviz_common/properties/string_property.hpp>
 
 #include <QLabel>
 #include <QGroupBox>
 #include <QVBoxLayout>
+
+#include <memory>
+#include <optional>
+#include <future>
 
 namespace rviz_mbf_plugins
 {
@@ -89,8 +96,8 @@ protected:
 
 private Q_SLOTS:
   void updateGoalInputSubscription();
-  void updateGetPathServiceClient();
-  void updateExePathServiceClient();
+  void updateGetPathActionClient();
+  void updateExePathActionClient();
 
 protected:
   rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr goal_pose_subscription_;
@@ -119,13 +126,16 @@ protected:
   ////////////////
   QVBoxLayout * ui_layout_;
 
-  rviz_common::properties::PropertyTreeWidget * properity_tree_widget_;
-  rviz_common::properties::PropertyTreeModel *  properity_tree_model_;
-  rviz_common::properties::RosTopicProperty *   goal_input_topic_;
-  rviz_common::properties::RosTopicProperty *   get_path_action_server_path_;
-  rviz_common::properties::StringProperty *     planner_name_property_;
-  rviz_common::properties::RosTopicProperty *   exe_path_action_server_path_;
-  rviz_common::properties::StringProperty *     controller_name_property_;
+  rviz_common::properties::PropertyTreeWidget*    properity_tree_widget_;
+  rviz_common::properties::PropertyTreeModel*     properity_tree_model_;
+  rviz_common::properties::RosTopicProperty*      goal_input_topic_;
+  rviz_common::properties::RosActionProperty*     get_path_action_server_path_;
+  rviz_common::properties::EditableEnumProperty*  planner_name_property_;
+  rviz_common::properties::RosActionProperty*     exe_path_action_server_path_;
+  rviz_common::properties::EditableEnumProperty*  controller_name_property_;
+
+  std::shared_ptr<rclcpp::AsyncParametersClient>  planner_parameter_client_;
+  std::shared_ptr<rclcpp::AsyncParametersClient>  controller_parameter_client_;
 
   QGroupBox * goal_input_ui_box_;
   QVBoxLayout * goal_input_ui_layout_;

--- a/rviz_mbf_plugins/include/rviz_mbf_plugins/mbf_goal_actions_panel.hpp
+++ b/rviz_mbf_plugins/include/rviz_mbf_plugins/mbf_goal_actions_panel.hpp
@@ -46,6 +46,7 @@
 #include <rviz_common/properties/ros_topic_property.hpp>
 #include <rviz_common/properties/property_tree_model.hpp>
 #include <rviz_common/properties/property_tree_widget.hpp>
+#include <rviz_common/properties/string_property.hpp>
 
 #include <QLabel>
 #include <QGroupBox>
@@ -119,10 +120,12 @@ protected:
   QVBoxLayout * ui_layout_;
 
   rviz_common::properties::PropertyTreeWidget * properity_tree_widget_;
-  rviz_common::properties::PropertyTreeModel * properity_tree_model_;
-  rviz_common::properties::RosTopicProperty * goal_input_topic_;
-  rviz_common::properties::RosTopicProperty * get_path_action_server_path_;
-  rviz_common::properties::RosTopicProperty * exe_path_action_server_path_;
+  rviz_common::properties::PropertyTreeModel *  properity_tree_model_;
+  rviz_common::properties::RosTopicProperty *   goal_input_topic_;
+  rviz_common::properties::RosTopicProperty *   get_path_action_server_path_;
+  rviz_common::properties::StringProperty *     planner_name_property_;
+  rviz_common::properties::RosTopicProperty *   exe_path_action_server_path_;
+  rviz_common::properties::StringProperty *     controller_name_property_;
 
   QGroupBox * goal_input_ui_box_;
   QVBoxLayout * goal_input_ui_layout_;

--- a/rviz_mbf_plugins/src/mbf_goal_actions_panel.cpp
+++ b/rviz_mbf_plugins/src/mbf_goal_actions_panel.cpp
@@ -195,27 +195,6 @@ void MbfGoalActionsPanel::updateGoalInputSubscription()
   }
 }
 
-/** helper function to split a topic string by slashes */
-std::vector<std::string> split_topic(std::string topic)
-{
-  std::vector<std::string> ret;
-
-  std::string delimiter = "/";
-  size_t pos = 0;
-  while ((pos = topic.find(delimiter)) != std::string::npos) {
-    std::string token = topic.substr(0, pos);
-    if (!token.empty()) {
-      ret.push_back(token);
-    }
-    topic.erase(0, pos + delimiter.length());
-  }
-  if (!topic.empty()) {
-    ret.push_back(topic);
-  }
-
-  return ret;
-}
-
 std::string node_name_guess(const std::string& topic)
 {
   // this just guesses the node name and returns it.
@@ -230,7 +209,6 @@ std::string node_name_guess(const std::string& topic)
   } else {
     return "";
   }
-
 }
 
 void MbfGoalActionsPanel::updateGetPathActionClient()

--- a/rviz_mbf_plugins/src/mbf_goal_actions_panel.cpp
+++ b/rviz_mbf_plugins/src/mbf_goal_actions_panel.cpp
@@ -86,25 +86,25 @@ void MbfGoalActionsPanel::constructPropertiesWidget()
     SLOT(updateGoalInputSubscription()), this);
   properity_tree_model_->getRoot()->addChild(goal_input_topic_);
   
-  get_path_action_server_path_ = new rviz_common::properties::RosTopicProperty(
-    "Planner Action", default_action_server_path, "",
+  get_path_action_server_path_ = new rviz_common::properties::RosActionProperty(
+    "Planner Action", default_action_server_path, "mbf_msgs/action/GetPath",
     "ROS path to move base flex get_path action server",
     nullptr,
-    SLOT(updateGetPathServiceClient()), this);
+    SLOT(updateGetPathActionClient()), this);
   properity_tree_model_->getRoot()->addChild(get_path_action_server_path_);
 
-  planner_name_property_ = new rviz_common::properties::StringProperty(
+  planner_name_property_ = new rviz_common::properties::EditableEnumProperty(
     "Planner Name", "", "Key name of planner to use (must defined in config), e.g. 'GridBased' or 'mesh_planner'");
   properity_tree_model_->getRoot()->addChild(planner_name_property_);
 
-  exe_path_action_server_path_ = new rviz_common::properties::RosTopicProperty(
-    "Controller Action", default_action_server_path, "",
+  exe_path_action_server_path_ = new rviz_common::properties::RosActionProperty(
+    "Controller Action", default_action_server_path, "mbf_msgs/action/ExePath",
     "ROS path to move base flex exe_path action server",
     nullptr,
-    SLOT(updateExePathServiceClient()), this);
+    SLOT(updateExePathActionClient()), this);
   properity_tree_model_->getRoot()->addChild(exe_path_action_server_path_);
 
-  controller_name_property_ = new rviz_common::properties::StringProperty(
+  controller_name_property_ = new rviz_common::properties::EditableEnumProperty(
     "Controller Name", "", "Key name of planner to use (must defined in config), e.g. 'mppi' or 'mesh_controller'");
   properity_tree_model_->getRoot()->addChild(controller_name_property_);
 
@@ -195,11 +195,49 @@ void MbfGoalActionsPanel::updateGoalInputSubscription()
   }
 }
 
-void MbfGoalActionsPanel::updateGetPathServiceClient()
+/** helper function to split a topic string by slashes */
+std::vector<std::string> split_topic(std::string topic)
+{
+  std::vector<std::string> ret;
+
+  std::string delimiter = "/";
+  size_t pos = 0;
+  while ((pos = topic.find(delimiter)) != std::string::npos) {
+    std::string token = topic.substr(0, pos);
+    if (!token.empty()) {
+      ret.push_back(token);
+    }
+    topic.erase(0, pos + delimiter.length());
+  }
+  if (!topic.empty()) {
+    ret.push_back(topic);
+  }
+
+  return ret;
+}
+
+std::string node_name_guess(const std::string& topic)
+{
+  // this just guesses the node name and returns it.
+  // split topic by first slashes from right. return first part as node name
+
+  std::string delimiter = "/";
+
+  size_t pos = topic.rfind(delimiter);
+
+  if (pos != std::string::npos) {
+    return topic.substr(0, pos);
+  } else {
+    return "";
+  }
+
+}
+
+void MbfGoalActionsPanel::updateGetPathActionClient()
 {
   auto node = getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
 
-  const std::string selected_server = get_path_action_server_path_->getTopic().toStdString();
+  const std::string selected_server = get_path_action_server_path_->getAction().toStdString();
 
   if (selected_server != default_action_server_path) {
     action_client_get_path_ = rclcpp_action::create_client<mbf_msgs::action::GetPath>(
@@ -211,13 +249,42 @@ void MbfGoalActionsPanel::updateGetPathServiceClient()
       get_path_action_server_status_->setText("connecting");
     }
   }
+
+  // fetch planners via parameters: 
+  // string list: [node_name_of_action_server].planners
+  planner_name_property_->clearOptions();
+
+  // TODO(amock): this is a bit hacky. We extract the node name from the action server topic
+  // - but if the topic was remapped we get a problem. Currently I dont know an efficient (!) solution to that problem
+  std::string node_name = node_name_guess(selected_server);
+
+  RCLCPP_INFO_STREAM(node->get_logger(), "Guessed node name for planner list: " << node_name);
+
+  planner_parameter_client_ = std::make_shared<rclcpp::AsyncParametersClient>(node, node_name);
+
+  planner_parameter_client_->get_parameters({"planners"},
+    [this, node, selected_server](std::shared_future<std::vector<rclcpp::Parameter>> future) {
+      auto parameters = future.get();
+      if(!parameters.empty())
+      {
+        const std::vector<std::string> planners = parameters[0].as_string_array();
+        for(const std::string& planner : planners)
+        {
+          planner_name_property_->addOptionStd(planner);
+        }
+        RCLCPP_INFO_STREAM(node->get_logger(), "Received planner list with " << planners.size() << " entries for planner action " << selected_server);
+      } else {
+        this->get_path_action_goal_status_->setText(QString("No planner found!"));
+        RCLCPP_WARN_STREAM(node->get_logger(), "No planner found for planner action " << selected_server);
+      }
+    });
 }
 
-void MbfGoalActionsPanel::updateExePathServiceClient()
+void MbfGoalActionsPanel::updateExePathActionClient()
 {
   auto node = getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
 
-  const std::string selected_server = exe_path_action_server_path_->getTopic().toStdString();
+  const std::string selected_server = exe_path_action_server_path_->getAction().toStdString();
   if (selected_server != default_action_server_path) {
     action_client_exe_path_ = rclcpp_action::create_client<mbf_msgs::action::ExePath>(
       node, selected_server);
@@ -227,6 +294,35 @@ void MbfGoalActionsPanel::updateExePathServiceClient()
       exe_path_action_server_status_->setText("connecting");
     }
   }
+
+  // fetch controllers via parameters: 
+  // string list: [node_name_of_action_server].controllers
+  controller_name_property_->clearOptions();
+
+  // TODO(amock): this is a bit hacky. We extract the node name from the action server topic
+  // - but if the topic was remapped we get a problem. Currently I dont know an efficient (!) solution to that problem
+  std::string node_name = node_name_guess(selected_server);
+
+  RCLCPP_INFO_STREAM(node->get_logger(), "Guessed node name for controller list: " << node_name);
+
+  controller_parameter_client_ = std::make_shared<rclcpp::AsyncParametersClient>(node, node_name);
+
+  controller_parameter_client_->get_parameters({"controllers"},
+    [this, node, selected_server](std::shared_future<std::vector<rclcpp::Parameter>> future) {
+      auto parameters = future.get();
+      if(!parameters.empty())
+      {
+        const std::vector<std::string> controllers = parameters[0].as_string_array();
+        for(const std::string& controller : controllers)
+        {
+          controller_name_property_->addOptionStd(controller);
+        }
+        RCLCPP_INFO_STREAM(node->get_logger(), "Received controller list with " << controllers.size() << " entries for controller action " << selected_server);
+      } else {
+        this->exe_path_action_goal_status_->setText(QString("No controller found!"));
+        RCLCPP_WARN_STREAM(node->get_logger(), "No controller found for controller action " << selected_server);
+      }
+    });
 }
 
 void MbfGoalActionsPanel::onInitialize()

--- a/rviz_mbf_plugins/src/mbf_goal_actions_panel.cpp
+++ b/rviz_mbf_plugins/src/mbf_goal_actions_panel.cpp
@@ -85,18 +85,28 @@ void MbfGoalActionsPanel::constructPropertiesWidget()
     nullptr,
     SLOT(updateGoalInputSubscription()), this);
   properity_tree_model_->getRoot()->addChild(goal_input_topic_);
+  
   get_path_action_server_path_ = new rviz_common::properties::RosTopicProperty(
-    "Get Path", default_action_server_path, "",
+    "Planner Action", default_action_server_path, "",
     "ROS path to move base flex get_path action server",
     nullptr,
     SLOT(updateGetPathServiceClient()), this);
   properity_tree_model_->getRoot()->addChild(get_path_action_server_path_);
+
+  planner_name_property_ = new rviz_common::properties::StringProperty(
+    "Planner Name", "", "Key name of planner to use (must defined in config), e.g. 'GridBased' or 'mesh_planner'");
+  properity_tree_model_->getRoot()->addChild(planner_name_property_);
+
   exe_path_action_server_path_ = new rviz_common::properties::RosTopicProperty(
-    "Exe Path", default_action_server_path, "",
+    "Controller Action", default_action_server_path, "",
     "ROS path to move base flex exe_path action server",
     nullptr,
     SLOT(updateExePathServiceClient()), this);
   properity_tree_model_->getRoot()->addChild(exe_path_action_server_path_);
+
+  controller_name_property_ = new rviz_common::properties::StringProperty(
+    "Controller Name", "", "Key name of planner to use (must defined in config), e.g. 'mppi' or 'mesh_controller'");
+  properity_tree_model_->getRoot()->addChild(controller_name_property_);
 
   properity_tree_widget_ = new rviz_common::properties::PropertyTreeWidget();
   properity_tree_widget_->setModel(properity_tree_model_);
@@ -235,6 +245,7 @@ void MbfGoalActionsPanel::newMeshGoalCallback(const geometry_msgs::msg::PoseStam
   current_goal_ = msg;
   mbf_msgs::action::GetPath::Goal goal;
   goal.target_pose = msg;
+  goal.planner = planner_name_property_->getStdString();
   goal.use_start_pose = false; // planner shall use the current robot pose
   if (goal_handle_get_path_) {
     // planner is currently active, cancel first
@@ -282,6 +293,7 @@ void MbfGoalActionsPanel::getPathResultCallback(
           wrapped_result.result->cost));
 
       exe_path_goal.path = wrapped_result.result->path;
+      exe_path_goal.controller = controller_name_property_->getStdString();
 
       if (goal_handle_exe_path_) {
         // path execution is currently active, cancel first
@@ -371,6 +383,7 @@ void MbfGoalActionsPanel::exePathResultCallback(
           goal_retry_cnt_ += 1;
           mbf_msgs::action::GetPath::Goal goal;
           goal.target_pose = current_goal_;
+          goal.planner = planner_name_property_->getStdString();
           // Overwrite the timestamp to prevent tf extrapolation errors in the planners
           goal.target_pose.header.set__stamp(getDisplayContext()->getClock()->now());
           goal.use_start_pose = false;


### PR DESCRIPTION
For the RViz MBFActionPanel, I added functionality to select controllers and planners via a dropdown list. The list is filled through a parameter service call to the MBF instance.

One issue remains: the node name is currently inferred by splitting the action topic. This approach breaks if the action is remapped. However, this is acceptable for now, as the panel is primarily intended as a debugging/development tool.

Minor fix: ROSTopicProperty -> ROSActionProperty for all the actions