### PR TITLE
Fix RobotInformation Tf-Lookup Latency Slows Control Loop Down

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
@@ -368,6 +368,9 @@ protected:
   //! the robot frame, to get the current robot pose in the global_frame_
   std::string robot_frame_;
 
+  //! the odometry frame, in which the robot is moving
+  std::string odom_frame_;
+
   //! the global frame, in which the robot is moving
   std::string global_frame_;
 

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -69,6 +69,7 @@ AbstractNavigationServer::AbstractNavigationServer(
     node)
 {
   node_->declare_parameter<std::string>("global_frame", "map");
+  node_->declare_parameter<std::string>("odom_frame", "odom");
   node_->declare_parameter<std::string>("robot_frame", "base_link");
   node_->declare_parameter<double>("tf_timeout", 3.0);
   node_->declare_parameter<std::string>("odom_topic", "~/odom");
@@ -76,10 +77,11 @@ AbstractNavigationServer::AbstractNavigationServer(
   double tf_timeout_s;
   node_->get_parameter("tf_timeout", tf_timeout_s);
   node_->get_parameter("global_frame", global_frame_);
+  node_->get_parameter("odom_frame", odom_frame_);
   node_->get_parameter("robot_frame", robot_frame_);
 
   robot_info_ = std::make_shared<mbf_utility::RobotInformation>(
-    node, tf_listener_ptr, global_frame_, robot_frame_,
+    node, tf_listener_ptr, global_frame_, odom_frame_, robot_frame_,
     rclcpp::Duration::from_seconds(tf_timeout_s),
     node_->get_parameter("odom_topic").as_string());
   controller_action_ = std::make_shared<ControllerAction>(node, name_action_exe_path, robot_info_);

--- a/mbf_abstract_nav/test/abstract_action_base.cpp
+++ b/mbf_abstract_nav/test/abstract_action_base.cpp
@@ -44,7 +44,7 @@ struct AbstractActionBaseFixture
   {
     node_ = std::shared_ptr<rclcpp::Node>(new rclcpp::Node("test_node"));
     tf_ = std::make_shared<TF>(node_->get_clock());
-    ri_ = std::make_shared<mbf_utility::RobotInformation>(node_, tf_, "global_frame", "local_frame", rclcpp::Duration(0,0));
+    ri_ = std::make_shared<mbf_utility::RobotInformation>(node_, tf_, "global_frame", "odom_frame", "local_frame", rclcpp::Duration(0,0));
   }
 
   void runImpl(const GoalHandlePtr &goal_handle, MockedExecution &execution) {

--- a/mbf_abstract_nav/test/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_controller_execution.cpp
@@ -59,7 +59,7 @@ struct AbstractControllerExecutionFixture : public Test
     goal_pub_ptr_ = node_ptr_->create_publisher<PoseStamped>("pose", 1);
     tf_ptr_ = std::make_shared<TF>(node_ptr_->get_clock());
     tf_ptr_->setUsingDedicatedThread(true);
-    robot_info_ptr_ = std::make_shared<mbf_utility::RobotInformation>(node_ptr_, tf_ptr_, "global_frame",
+    robot_info_ptr_ = std::make_shared<mbf_utility::RobotInformation>(node_ptr_, tf_ptr_, "global_frame", "odom_frame",
                                                                 "robot_frame", rclcpp::Duration::from_seconds(1.0), "");
 
     mock_controller_ptr_ = std::make_shared<AbstractControllerMock>();
@@ -183,8 +183,9 @@ TEST_F(AbstractControllerExecutionFixture, internalError)
 // fixture making us pass computeRobotPose()
 struct ComputeRobotPoseFixture : public AbstractControllerExecutionFixture
 {
-  ComputeRobotPoseFixture () 
+  ComputeRobotPoseFixture ()
   : global_frame_("global_frame")
+  , odom_frame_("odom_frame")
   , robot_frame_("robot_frame")
   {}
 
@@ -192,6 +193,7 @@ struct ComputeRobotPoseFixture : public AbstractControllerExecutionFixture
   {
 
     node_options.append_parameter_override("global_frame", global_frame_)
+                .append_parameter_override("odom_frame", odom_frame_)
                 .append_parameter_override("robot_frame", robot_frame_);
     AbstractControllerExecutionFixture::initRosNode(node_options);
     // setup the transform.
@@ -199,15 +201,24 @@ struct ComputeRobotPoseFixture : public AbstractControllerExecutionFixture
     TransformStamped transform;
     transform.header.stamp = t_now;
     transform.header.frame_id = global_frame_;
-    transform.child_frame_id = robot_frame_;
+    transform.child_frame_id = odom_frame_;
     transform.transform.rotation.w = 1;
-    // add transforms to the buffer such that move base flex can transform between global and robot frame for one second, starting now
+    // add transforms to the buffer such that move base flex can transform between global and odom frame for one second, starting now
+    tf_ptr_->setTransform(transform, "test_tf_authority");
+    transform.header.stamp = t_now + rclcpp::Duration::from_seconds(1.0);
+    tf_ptr_->setTransform(transform, "test_tf_authority");
+
+    // also add transform from odom_frame to robot_frame so getRobotPose() can resolve the full chain
+    transform.header.stamp = t_now;
+    transform.header.frame_id = odom_frame_;
+    transform.child_frame_id = robot_frame_;
     tf_ptr_->setTransform(transform, "test_tf_authority");
     transform.header.stamp = t_now + rclcpp::Duration::from_seconds(1.0);
     tf_ptr_->setTransform(transform, "test_tf_authority");
   }
-protected: 
+protected:
   const std::string global_frame_;
+  const std::string odom_frame_;
   const std::string robot_frame_;
 };
 

--- a/mbf_abstract_nav/test/abstract_execution_base.cpp
+++ b/mbf_abstract_nav/test/abstract_execution_base.cpp
@@ -50,7 +50,7 @@ struct AbstractExecutionFixture : public Test
   AbstractExecutionFixture() :
     node_(std::make_shared<rclcpp::Node>("test")), 
     tf_(new TF(node_->get_clock())),
-    ri_(new mbf_utility::RobotInformation(node_, tf_, "global_frame", "local_frame", rclcpp::Duration::from_seconds(0), "")), 
+    ri_(new mbf_utility::RobotInformation(node_, tf_, "global_frame", "odom_frame", "local_frame", rclcpp::Duration::from_seconds(0), "")),
     impl_("foo", ri_, node_)
   {
   }

--- a/mbf_abstract_nav/test/abstract_plan_refiner_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_plan_refiner_execution.cpp
@@ -45,7 +45,7 @@ struct AbstractPlanRefinerExecutionFixture : public Test
     tf_ptr_ = std::make_shared<TF>(node_ptr_->get_clock());
     tf_ptr_->setUsingDedicatedThread(true);
     robot_info_ptr_ = std::make_shared<mbf_utility::RobotInformation>(
-      node_ptr_, tf_ptr_, "global_frame", "robot_frame", rclcpp::Duration::from_seconds(1.0), "");
+      node_ptr_, tf_ptr_, "global_frame", "odom_frame", "robot_frame", rclcpp::Duration::from_seconds(1.0), "");
 
     mock_refiner_ptr_ = std::make_shared<AbstractPlanRefinerMock>();
     plan_refiner_execution_ptr_ = std::make_unique<AbstractPlanRefinerExecution>(

--- a/mbf_abstract_nav/test/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/test/abstract_planner_execution.cpp
@@ -38,8 +38,8 @@ struct AbstractPlannerExecutionFixture : public Test
     node_ptr_->get_logger().set_level(rclcpp::Logger::Level::Fatal);
     tf_ptr_ = std::make_shared<TF>(node_ptr_->get_clock());
     tf_ptr_->setUsingDedicatedThread(true);
-    robot_info_ptr_ = std::make_shared<mbf_utility::RobotInformation>(node_ptr_, tf_ptr_, "global_frame",
-                                                                "robot_frame", rclcpp::Duration::from_seconds(1.0), "");
+    robot_info_ptr_ = std::make_shared<mbf_utility::RobotInformation>(node_ptr_, tf_ptr_, "global_frame", "odom_frame",
+                                                                 "robot_frame", rclcpp::Duration::from_seconds(1.0), "");
 
     mock_planner_ptr_ = std::make_shared<AbstractPlannerMock>();
     planner_execution_ptr_ = std::make_unique<AbstractPlannerExecution>("foo", mock_planner_ptr_,

--- a/mbf_abstract_nav/test/planner_action.cpp
+++ b/mbf_abstract_nav/test/planner_action.cpp
@@ -57,8 +57,9 @@ struct PlannerActionFixture : public Test
     , tf_(new TF(node_->get_clock()))
     , planner_(new MockPlanner())
     , global_frame_("global_frame")
+    , odom_frame_("odom_frame")
     , local_frame_("local_frame")
-    , robot_info_(new mbf_utility::RobotInformation(node_, tf_, global_frame_, local_frame_, rclcpp::Duration::from_seconds(0.0)))
+    , robot_info_(new mbf_utility::RobotInformation(node_, tf_, global_frame_, odom_frame_, local_frame_, rclcpp::Duration::from_seconds(0.0)))
     , planner_execution_(new AbstractPlannerExecution("plugin", planner_, robot_info_, node_))
     , planner_action_(node_, "action_name", robot_info_)
     , action_server_(rclcpp_action::create_server<mbf_msgs::action::GetPath>(
@@ -116,6 +117,7 @@ struct PlannerActionFixture : public Test
   TFPtr tf_;
   std::shared_ptr<MockPlanner> planner_; ///< the mocked planner
   std::string global_frame_;
+  std::string odom_frame_;
   std::string local_frame_;
   mbf_utility::RobotInformation::ConstPtr robot_info_;
   AbstractPlannerExecution::Ptr planner_execution_;

--- a/mbf_utility/include/mbf_utility/robot_information.h
+++ b/mbf_utility/include/mbf_utility/robot_information.h
@@ -63,12 +63,13 @@ class RobotInformation
       const rclcpp::Node::SharedPtr& node,
       const TFPtr &tf_buffer,
       const std::string &global_frame,
+      const std::string &odom_frame,
       const std::string &robot_frame,
       const rclcpp::Duration &tf_timeout,
       const std::string &odom_topic = "odom");
 
   /**
-   * @brief Computes the current robot pose (robot_frame_) in the global frame (global_frame_).
+   * @brief Computes the latest robot pose estimate (robot_frame_) in the global frame (global_frame_).
    * @param robot_pose Reference to the robot_pose message object to be filled.
    * @return true, if the current robot pose could be computed, false otherwise.
    */
@@ -91,6 +92,8 @@ class RobotInformation
 
   const std::string& getGlobalFrame() const;
 
+  const std::string& getOdomFrame() const;
+
   const std::string& getRobotFrame() const;
 
   const TF& getTransformListener() const;
@@ -103,6 +106,8 @@ class RobotInformation
   const TFPtr tf_buffer_;
 
   const std::string global_frame_;
+
+  const std::string odom_frame_;
 
   const std::string robot_frame_;
 

--- a/mbf_utility/src/robot_information.cpp
+++ b/mbf_utility/src/robot_information.cpp
@@ -37,19 +37,20 @@
  */
 
 #include "mbf_utility/robot_information.h"
-#include "mbf_utility/navigation_utility.h"
 
 #include <rclcpp/rclcpp.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace mbf_utility
 {
 RobotInformation::RobotInformation(const rclcpp::Node::SharedPtr& node,
                                    const TFPtr &tf_buffer,
                                    const std::string &global_frame,
+                                   const std::string &odom_frame,
                                    const std::string &robot_frame,
                                    const rclcpp::Duration &tf_timeout,
                                    const std::string &odom_topic)
- : node_(node), tf_buffer_(tf_buffer), global_frame_(global_frame), robot_frame_(robot_frame), tf_timeout_(tf_timeout),
+ : node_(node), tf_buffer_(tf_buffer), global_frame_(global_frame), odom_frame_(odom_frame), robot_frame_(robot_frame), tf_timeout_(tf_timeout),
    odom_helper_(node_, odom_topic)
 {
 
@@ -58,29 +59,30 @@ RobotInformation::RobotInformation(const rclcpp::Node::SharedPtr& node,
 
 bool RobotInformation::getRobotPose(geometry_msgs::msg::PoseStamped &robot_pose_globalFrame) const
 {
-  const auto t_now = node_->now();
-
   std::string err_string;
-  if (!tf_buffer_->canTransform(robot_frame_, global_frame_, rclcpp::Time(0), tf_timeout_, &err_string))
+  if (!tf_buffer_->canTransform(robot_frame_, odom_frame_, rclcpp::Time(0), tf_timeout_, &err_string))
+  {
+    RCLCPP_ERROR_STREAM(node_->get_logger(), "Failed to get robot pose. Reason: " << err_string);
+    return false;
+  }
+
+  if (!tf_buffer_->canTransform(odom_frame_, global_frame_, rclcpp::Time(0), tf_timeout_, &err_string))
   {
     RCLCPP_ERROR_STREAM(node_->get_logger(), "Failed to get robot pose. Reason: " << err_string);
     return false;
   }
 
   geometry_msgs::msg::PoseStamped robot_pose_robotFrame; // default constructed pose at origin
-  geometry_msgs::msg::PoseStamped robot_pose_odomFrame; // default constructed pose at origin
+  geometry_msgs::msg::PoseStamped robot_pose_odomFrame;
   robot_pose_robotFrame.header.stamp = rclcpp::Time(0);
   robot_pose_robotFrame.header.frame_id = robot_frame_;
   // Latest transform from base -> odom
-  tf_buffer_->transform(robot_pose_robotFrame, robot_pose_odomFrame, "odom");
+  tf_buffer_->transform(robot_pose_robotFrame, robot_pose_odomFrame, odom_frame_);
 
   // Latest transform from odom -> map
   robot_pose_odomFrame.header.stamp = rclcpp::Time(0);
   tf_buffer_->transform(robot_pose_odomFrame, robot_pose_globalFrame, global_frame_);
 
-  const auto t_end = node_->now();
-  //RCLCPP_INFO(node_->get_logger(), "Robot pose query took: %lu ns", (t_end - t_now).nanoseconds());
-  RCLCPP_INFO(node_->get_logger(), "Latest odom: %f", (t_end - robot_pose_globalFrame.header.stamp).seconds() * 1000.0);
   return true;
 }
 

--- a/mbf_utility/src/robot_information.cpp
+++ b/mbf_utility/src/robot_information.cpp
@@ -68,9 +68,16 @@ bool RobotInformation::getRobotPose(geometry_msgs::msg::PoseStamped &robot_pose_
   }
 
   geometry_msgs::msg::PoseStamped robot_pose_robotFrame; // default constructed pose at origin
+  geometry_msgs::msg::PoseStamped robot_pose_odomFrame; // default constructed pose at origin
   robot_pose_robotFrame.header.stamp = rclcpp::Time(0);
   robot_pose_robotFrame.header.frame_id = robot_frame_;
-  tf_buffer_->transform(robot_pose_robotFrame, robot_pose_globalFrame, global_frame_);
+  // Latest transform from base -> odom
+  tf_buffer_->transform(robot_pose_robotFrame, robot_pose_odomFrame, "odom");
+
+  // Latest transform from odom -> map
+  robot_pose_odomFrame.header.stamp = rclcpp::Time(0);
+  tf_buffer_->transform(robot_pose_odomFrame, robot_pose_globalFrame, global_frame_);
+
   const auto t_end = node_->now();
   RCLCPP_INFO(node_->get_logger(), "Robot pose query took: %lu ns", (t_end - t_now).nanoseconds());
   return true;

--- a/mbf_utility/src/robot_information.cpp
+++ b/mbf_utility/src/robot_information.cpp
@@ -68,7 +68,7 @@ bool RobotInformation::getRobotPose(geometry_msgs::msg::PoseStamped &robot_pose_
   }
 
   geometry_msgs::msg::PoseStamped robot_pose_robotFrame; // default constructed pose at origin
-  robot_pose_robotFrame.header.stamp = t_now;
+  robot_pose_robotFrame.header.stamp = rclcpp::Time(0);
   robot_pose_robotFrame.header.frame_id = robot_frame_;
   tf_buffer_->transform(robot_pose_robotFrame, robot_pose_globalFrame, global_frame_);
   const auto t_end = node_->now();

--- a/mbf_utility/src/robot_information.cpp
+++ b/mbf_utility/src/robot_information.cpp
@@ -71,6 +71,8 @@ bool RobotInformation::getRobotPose(geometry_msgs::msg::PoseStamped &robot_pose_
   robot_pose_robotFrame.header.stamp = t_now;
   robot_pose_robotFrame.header.frame_id = robot_frame_;
   tf_buffer_->transform(robot_pose_robotFrame, robot_pose_globalFrame, global_frame_);
+  const auto t_end = node_->now();
+  RCLCPP_INFO(node_->get_logger(), "Robot pose query took: %lu", (t_end - t_now).nanoseconds());
   return true;
 }
 

--- a/mbf_utility/src/robot_information.cpp
+++ b/mbf_utility/src/robot_information.cpp
@@ -79,7 +79,8 @@ bool RobotInformation::getRobotPose(geometry_msgs::msg::PoseStamped &robot_pose_
   tf_buffer_->transform(robot_pose_odomFrame, robot_pose_globalFrame, global_frame_);
 
   const auto t_end = node_->now();
-  RCLCPP_INFO(node_->get_logger(), "Robot pose query took: %lu ns", (t_end - t_now).nanoseconds());
+  //RCLCPP_INFO(node_->get_logger(), "Robot pose query took: %lu ns", (t_end - t_now).nanoseconds());
+  RCLCPP_INFO(node_->get_logger(), "Latest odom: %f", (t_end - robot_pose_globalFrame.header.stamp).seconds() * 1000.0);
   return true;
 }
 

--- a/mbf_utility/src/robot_information.cpp
+++ b/mbf_utility/src/robot_information.cpp
@@ -61,7 +61,7 @@ bool RobotInformation::getRobotPose(geometry_msgs::msg::PoseStamped &robot_pose_
   const auto t_now = node_->now();
 
   std::string err_string;
-  if (!tf_buffer_->canTransform(robot_frame_, global_frame_, t_now, tf_timeout_, &err_string))
+  if (!tf_buffer_->canTransform(robot_frame_, global_frame_, rclcpp::Time(0), tf_timeout_, &err_string))
   {
     RCLCPP_ERROR_STREAM(node_->get_logger(), "Failed to get robot pose. Reason: " << err_string);
     return false;
@@ -72,7 +72,7 @@ bool RobotInformation::getRobotPose(geometry_msgs::msg::PoseStamped &robot_pose_
   robot_pose_robotFrame.header.frame_id = robot_frame_;
   tf_buffer_->transform(robot_pose_robotFrame, robot_pose_globalFrame, global_frame_);
   const auto t_end = node_->now();
-  RCLCPP_INFO(node_->get_logger(), "Robot pose query took: %lu", (t_end - t_now).nanoseconds());
+  RCLCPP_INFO(node_->get_logger(), "Robot pose query took: %lu ns", (t_end - t_now).nanoseconds());
   return true;
 }
 


### PR DESCRIPTION
I was using MeshNav on a real robot when I encountered a problem where the move_base_flex controller execution would print warnings, that calculating the control signal took too long, despite the calculation time measured inside the controller plugin being well below the loop cycle length. I eventually found out that the whole control loop was slowed down by the robot pose lookup: https://github.com/naturerobots/move_base_flex/blob/43173aa9b7b7cfeab9fb845448642f7fce2e33d1/mbf_abstract_nav/src/abstract_controller_execution.cpp#L480-L491

The `getRobotPose` method did a  TF-Lookup between the map and base frames at time `node->get_clock()->now()`, which then blocks until the transform is available. When using the now time TF2 waits until a newer transform is available and then interpolates to the requested time. In my case this took around 150 ms.
https://github.com/naturerobots/move_base_flex/blob/43173aa9b7b7cfeab9fb845448642f7fce2e33d1/mbf_utility/src/robot_information.cpp#L59-L75

So I tried using time point zero for the lookup, which requests the latest available transform from TF2. This did restore the 20 Hz control loop, however, this method returns the transform for the latest time, where all links in the transform chain have a transform available. So with a typical robot setup with a transform chain `base_link` -> `odom` -> `map`, the total transform is only updated with the frequency of the slowest transform. In my case this is the `odom` -> `map` transform, since it is only updated with the LiDAR frequency, which is below the 20 Hz control rate. This can lead to degraded control performance since the control algorithm uses an outdated pose estimate.

For the control loop I would expect to always use the latest estimate of the robot position inside the map. This would be using the latest available `odom` -> `map` transform chained with the latest `base_link` -> `odom` transform, since the odometry updates at a much higher frequency. This method has the additional advantage that no interpolation is performed at any time.

Because TF2 cannot do this directly (at least to my knowledge) I implemented this as a two part lookup. I had to add a new parameter for the odom frame to the navigation server. With this change everything worked as expected.