### PR TITLE
ROS 2 Lyrical Compatibility 

### DIFF
--- a/.github/workflows/humble.yaml
+++ b/.github/workflows/humble.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   humble_build_and_test:
-    uses: naturerobots/github_automation_public/.github/workflows/ros_ci.yaml@main
+    uses: naturerobots/github_automation_public/.github/workflows/ros_ci.yaml@cc7fc175054179167e8a676c0e5e11bbbfe60d4e
     secrets: inherit
     with:
       ros_distro: humble

--- a/.github/workflows/jazzy.yaml
+++ b/.github/workflows/jazzy.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   jazzy_build_and_test:
-    uses: naturerobots/github_automation_public/.github/workflows/ros_ci.yaml@main
+    uses: naturerobots/github_automation_public/.github/workflows/ros_ci.yaml@cc7fc175054179167e8a676c0e5e11bbbfe60d4e
     secrets: inherit
     with:
       ros_distro: jazzy

--- a/.github/workflows/lyrical.yaml
+++ b/.github/workflows/lyrical.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   lyrical_build_and_test:
-    uses: naturerobots/github_automation_public/.github/workflows/ros_ci.yaml@upgrade-ros-action-ci
+    uses: naturerobots/github_automation_public/.github/workflows/ros_ci.yaml@cc7fc175054179167e8a676c0e5e11bbbfe60d4e
     secrets: inherit
     with:
       ros_distro: lyrical

--- a/.github/workflows/lyrical.yaml
+++ b/.github/workflows/lyrical.yaml
@@ -1,0 +1,18 @@
+name: Lyrical CI
+
+on:
+  push:
+    branches:
+      - 'lyrical'
+      - 'ros2'
+  pull_request:
+  workflow_dispatch:
+    branches:
+      - '*'
+
+jobs:
+  lyrical_build_and_test:
+    uses: naturerobots/github_automation_public/.github/workflows/ros_ci.yaml@main
+    secrets: inherit
+    with:
+      ros_distro: lyrical

--- a/.github/workflows/lyrical.yaml
+++ b/.github/workflows/lyrical.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   lyrical_build_and_test:
-    uses: naturerobots/github_automation_public/.github/workflows/ros_ci.yaml@main
+    uses: naturerobots/github_automation_public/.github/workflows/ros_ci.yaml@upgrade-ros-action-ci
     secrets: inherit
     with:
       ros_distro: lyrical

--- a/mbf_abstract_core/CMakeLists.txt
+++ b/mbf_abstract_core/CMakeLists.txt
@@ -1,19 +1,45 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(mbf_abstract_core)
 
 find_package(ament_cmake REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 
+# Create an INTERFACE library target for this header-only library
+add_library(${PROJECT_NAME} INTERFACE)
+
+# Set include directories for the target
+target_include_directories(${PROJECT_NAME} INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+# Link interface dependencies
+target_link_libraries(${PROJECT_NAME} INTERFACE
+  ${std_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+)
+
+# Create namespaced alias for modern CMake style
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+# Install the target
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+)
+
+# Install headers
+install(DIRECTORY include/
+  DESTINATION include
+)
 
 ament_export_include_directories(include)
 ament_export_dependencies(
   std_msgs
   geometry_msgs
 )
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
-install(DIRECTORY include/
-DESTINATION include
-)
-
+set(mbf_abstract_core_TARGETS mbf_abstract_core)
 ament_package()

--- a/mbf_abstract_nav/CMakeLists.txt
+++ b/mbf_abstract_nav/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(mbf_abstract_nav)
 
 find_package(ament_cmake REQUIRED)
@@ -17,12 +17,7 @@ foreach(dep IN LISTS dependencies)
   find_package(${dep} REQUIRED)
 endforeach()
 
-include_directories(
-  include
-)
-
-set(MBF_ABSTRACT_SERVER_LIB mbf_abstract_server)
-add_library(${MBF_ABSTRACT_SERVER_LIB} SHARED
+add_library(mbf_abstract_server SHARED
   src/controller_action.cpp
   src/planner_action.cpp
   src/plan_refiner_action.cpp
@@ -35,9 +30,29 @@ add_library(${MBF_ABSTRACT_SERVER_LIB} SHARED
   src/abstract_controller_execution.cpp
   src/abstract_recovery_execution.cpp
 )
-ament_target_dependencies(${MBF_ABSTRACT_SERVER_LIB} ${dependencies})
 
-install(TARGETS ${MBF_ABSTRACT_SERVER_LIB}
+target_include_directories(mbf_abstract_server PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(mbf_abstract_server PUBLIC
+  ${rclcpp_TARGETS}
+  ${rclcpp_action_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${mbf_abstract_core_TARGETS}
+  ${mbf_msgs_TARGETS}
+  ${mbf_utility_TARGETS}
+  ${nav_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  ${std_srvs_TARGETS}
+)
+
+# Create namespaced alias for modern CMake style
+add_library(${PROJECT_NAME}::mbf_abstract_server ALIAS mbf_abstract_server)
+
+install(TARGETS mbf_abstract_server
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -50,12 +65,12 @@ install(DIRECTORY include/
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
-  ament_add_gtest(${MBF_ABSTRACT_SERVER_LIB}_gtest test/abstract_execution_base.cpp)
-  target_include_directories(${MBF_ABSTRACT_SERVER_LIB}_gtest PUBLIC
+  ament_add_gtest(mbf_abstract_server_gtest test/abstract_execution_base.cpp)
+  target_include_directories(mbf_abstract_server_gtest PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
-  target_link_libraries(${MBF_ABSTRACT_SERVER_LIB}_gtest ${MBF_ABSTRACT_SERVER_LIB})
+  target_link_libraries(mbf_abstract_server_gtest mbf_abstract_server)
 
   find_package(ament_cmake_gmock REQUIRED)
   ament_add_gmock(abstract_action_base_test test/abstract_action_base.cpp)
@@ -63,33 +78,35 @@ if(BUILD_TESTING)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
-  target_link_libraries(abstract_action_base_test ${MBF_ABSTRACT_SERVER_LIB})
+  target_link_libraries(abstract_action_base_test mbf_abstract_server)
 
   ament_add_gmock(abstract_controller_execution_test test/abstract_controller_execution.cpp)
   target_include_directories(abstract_controller_execution_test PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
-  target_link_libraries(abstract_controller_execution_test ${MBF_ABSTRACT_SERVER_LIB})
+  target_link_libraries(abstract_controller_execution_test mbf_abstract_server)
 
   ament_add_gmock(abstract_planner_execution_test
     test/abstract_planner_execution.cpp)
-  target_link_libraries(abstract_planner_execution_test ${MBF_ABSTRACT_SERVER_LIB})
+  target_link_libraries(abstract_planner_execution_test mbf_abstract_server)
 
   ament_add_gmock(abstract_plan_refiner_execution_test
     test/abstract_plan_refiner_execution.cpp)
-  target_link_libraries(abstract_plan_refiner_execution_test ${MBF_ABSTRACT_SERVER_LIB})
+  target_link_libraries(abstract_plan_refiner_execution_test mbf_abstract_server)
 
   ament_add_gmock(planner_action_test
     test/planner_action.cpp)
-  target_link_libraries(planner_action_test ${MBF_ABSTRACT_SERVER_LIB})
+  target_link_libraries(planner_action_test mbf_abstract_server)
 
   ament_add_gmock(abstract_plugin_manager_test
     test/abstract_plugin_manager.cpp)
-  target_link_libraries(abstract_plugin_manager_test ${MBF_ABSTRACT_SERVER_LIB})
+  target_link_libraries(abstract_plugin_manager_test mbf_abstract_server)
 endif()
 
-ament_export_include_directories(include) 
-ament_export_libraries(${MBF_ABSTRACT_SERVER_LIB})
+ament_export_include_directories(include)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(${dependencies})
+
+set(mbf_abstract_nav_TARGETS mbf_abstract_server)
 ament_package()

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -42,7 +42,7 @@
 
 #include "mbf_abstract_nav/abstract_controller_execution.h"
 
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 #include <rclcpp/parameter_value.hpp>
 
 namespace mbf_abstract_nav

--- a/mbf_msgs/CMakeLists.txt
+++ b/mbf_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(mbf_msgs)
 
 # Default to C++14

--- a/mbf_simple_core/CMakeLists.txt
+++ b/mbf_simple_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(mbf_simple_core)
 
 find_package(ament_cmake REQUIRED)
@@ -13,11 +13,36 @@ foreach(dep IN LISTS dependencies)
   find_package(${dep} REQUIRED)
 endforeach()
 
+# Create INTERFACE library target
+add_library(${PROJECT_NAME} INTERFACE)
+
+target_include_directories(${PROJECT_NAME} INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(${PROJECT_NAME} INTERFACE
+  rclcpp::rclcpp
+  ${mbf_utility_TARGETS}
+  ${mbf_abstract_core_TARGETS}
+  ${geometry_msgs_TARGETS}
+)
+
+# Create namespaced alias for modern CMake style
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+)
 
 install(DIRECTORY include/
   DESTINATION include
 )
 
 ament_export_include_directories(include)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(${dependencies})
+
+set(mbf_simple_core_TARGETS mbf_simple_core)
 ament_package()

--- a/mbf_simple_nav/CMakeLists.txt
+++ b/mbf_simple_nav/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(mbf_simple_nav)
 
 find_package(ament_cmake_ros REQUIRED)
@@ -30,7 +30,25 @@ target_compile_features(${PROJECT_NAME}_lib PUBLIC c_std_99 cxx_std_17)  # Requi
 target_include_directories(${PROJECT_NAME}_lib PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-ament_target_dependencies(${PROJECT_NAME}_lib ${dependencies})
+target_link_libraries(${PROJECT_NAME}_lib PUBLIC
+  ${geometry_msgs_TARGETS}
+  ${mbf_abstract_core_TARGETS}
+  ${mbf_abstract_nav_TARGETS}
+  ${mbf_msgs_TARGETS}
+  ${mbf_simple_core_TARGETS}
+  ${mbf_utility_TARGETS}
+  ${nav_msgs_TARGETS}
+  ${pluginlib_TARGETS}
+  ${rclcpp_TARGETS}
+  ${rclcpp_action_TARGETS}
+  ${std_msgs_TARGETS}
+  ${std_srvs_TARGETS}
+  ${tf2_TARGETS}
+  ${tf2_ros_TARGETS}
+)
+
+# Create namespaced alias for modern CMake style
+add_library(${PROJECT_NAME}::${PROJECT_NAME}_lib ALIAS ${PROJECT_NAME}_lib)
 
 add_executable(${PROJECT_NAME}_node
   src/simple_server_node.cpp
@@ -39,8 +57,23 @@ target_compile_features(${PROJECT_NAME}_node PUBLIC c_std_99 cxx_std_17)  # Requ
 target_include_directories(${PROJECT_NAME}_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME}_lib)
-ament_target_dependencies(${PROJECT_NAME}_node ${dependencies})
+target_link_libraries(${PROJECT_NAME}_node PUBLIC
+  ${PROJECT_NAME}_lib
+  ${geometry_msgs_TARGETS}
+  ${mbf_abstract_core_TARGETS}
+  ${mbf_abstract_nav_TARGETS}
+  ${mbf_msgs_TARGETS}
+  ${mbf_simple_core_TARGETS}
+  ${mbf_utility_TARGETS}
+  ${nav_msgs_TARGETS}
+  ${pluginlib_TARGETS}
+  ${rclcpp_TARGETS}
+  ${rclcpp_action_TARGETS}
+  ${std_msgs_TARGETS}
+  ${std_srvs_TARGETS}
+  ${tf2_TARGETS}
+  ${tf2_ros_TARGETS}
+)
 
 install(DIRECTORY include/ DESTINATION include)
 install(TARGETS 
@@ -62,7 +95,10 @@ if(BUILD_TESTING)
     test/plugins/test_controller.cpp
     test/plugins/test_recovery.cpp
   )
-  ament_target_dependencies(${PROJECT_NAME}_test_plugins pluginlib mbf_simple_core)
+  target_link_libraries(${PROJECT_NAME}_test_plugins PUBLIC
+    ${pluginlib_TARGETS}
+    ${mbf_simple_core_TARGETS}
+  )
   pluginlib_export_plugin_description_file(mbf_simple_core test/plugins/mbf_simple_nav_test_plugins.xml)
   install(TARGETS 
     ${PROJECT_NAME}_test_plugins
@@ -79,11 +115,16 @@ if(BUILD_TESTING)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
-  ament_target_dependencies(${PROJECT_NAME}_integration_test mbf_test_utility rclcpp)
-  target_link_libraries(${PROJECT_NAME}_integration_test ${PROJECT_NAME}_lib)
+  target_link_libraries(${PROJECT_NAME}_integration_test
+    ${PROJECT_NAME}_lib
+    ${mbf_test_utility_TARGETS}
+    ${rclcpp_TARGETS}
+  )
 endif()
 
+ament_export_include_directories(include)
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(${dependencies})
 
+set(mbf_simple_nav_TARGETS mbf_simple_nav_lib)
 ament_package()

--- a/mbf_simple_nav/src/simple_server_node.cpp
+++ b/mbf_simple_nav/src/simple_server_node.cpp
@@ -42,7 +42,7 @@
 
 #include <mbf_utility/types.h>
 #include <rclcpp/rclcpp.hpp>
-#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/transform_listener.hpp>
 
 int main(int argc, char **argv)
 {

--- a/mbf_simple_nav/test/simple_nav_integration_test.cpp
+++ b/mbf_simple_nav/test/simple_nav_integration_test.cpp
@@ -6,8 +6,8 @@
 #include <thread>
 #include <rclcpp_action/client.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <tf2_ros/create_timer_ros.h>
-#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/create_timer_ros.hpp>
+#include <tf2_ros/transform_listener.hpp>
 
 using namespace ::testing;
 

--- a/mbf_test_utility/CMakeLists.txt
+++ b/mbf_test_utility/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 project(mbf_test_utility)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -17,20 +17,35 @@ find_package(tf2_ros REQUIRED)
 add_library(${PROJECT_NAME}_sim
   src/robot_simulator.cpp
 )
-target_compile_features(${PROJECT_NAME}_sim PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+target_compile_features(${PROJECT_NAME}_sim PUBLIC
+  c_std_99
+  cxx_std_17)  # Require C99 and C++17
 target_include_directories(${PROJECT_NAME}_sim PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-ament_target_dependencies(${PROJECT_NAME}_sim geometry_msgs mbf_msgs nav_msgs rclcpp tf2_ros tf2_geometry_msgs)
+target_link_libraries(${PROJECT_NAME}_sim
+  rclcpp::rclcpp
+  ${geometry_msgs_TARGETS}
+  ${mbf_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  ${tf2_ros_TARGETS}
+  ${tf2_geometry_msgs_TARGETS}
+)
+
+# Create namespaced alias for modern CMake style
+add_library(${PROJECT_NAME}::${PROJECT_NAME}_sim ALIAS ${PROJECT_NAME}_sim)
 
 add_executable(${PROJECT_NAME}_sim_node
   src/robot_simulator_node.cpp
 )
-target_compile_features(${PROJECT_NAME}_sim_node PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+target_compile_features(${PROJECT_NAME}_sim_node PUBLIC
+  c_std_99
+  cxx_std_17)  # Require C99 and C++17
 target_include_directories(${PROJECT_NAME}_sim_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-target_link_libraries(${PROJECT_NAME}_sim_node ${PROJECT_NAME}_sim)
+target_link_libraries(${PROJECT_NAME}_sim_node
+  ${PROJECT_NAME}_sim)
 
 install(DIRECTORY include/ DESTINATION include)
 install(TARGETS ${PROJECT_NAME}_sim
@@ -55,4 +70,5 @@ endif()
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(rclcpp geometry_msgs nav_msgs tf2_ros)
 
+set(mbf_test_utility_TARGETS mbf_test_utility_sim)
 ament_package()

--- a/mbf_test_utility/include/mbf_test_utility/robot_simulator.hpp
+++ b/mbf_test_utility/include/mbf_test_utility/robot_simulator.hpp
@@ -34,7 +34,7 @@
 #include <mbf_msgs/srv/set_test_robot_state.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_broadcaster.hpp>
 
 namespace mbf_test_utility
 {

--- a/mbf_utility/CMakeLists.txt
+++ b/mbf_utility/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(mbf_utility)
 
 find_package(ament_cmake REQUIRED)
@@ -14,18 +14,31 @@ foreach(dep IN LISTS dependencies)
   find_package(${dep} REQUIRED)
 endforeach()
 
-include_directories(
-  include
+add_library(${PROJECT_NAME} SHARED
+  src/navigation_utility.cpp
+  src/robot_information.cpp
+  src/odometry_helper.cpp
 )
 
-add_library(${PROJECT_NAME} SHARED
-   src/navigation_utility.cpp
-   src/robot_information.cpp
-   src/odometry_helper.cpp
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${geometry_msgs_TARGETS}
+  ${mbf_msgs_TARGETS}
+  ${rclcpp_TARGETS}
+  ${tf2_TARGETS}
+  ${tf2_ros_TARGETS}
+  ${tf2_geometry_msgs_TARGETS}
+)
+
+# Create namespaced alias for modern CMake style
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 install(TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -36,6 +49,8 @@ install(DIRECTORY include/
 )
 
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(${dependencies})
+
+set(mbf_utility_TARGETS mbf_utility)
 ament_package()

--- a/mbf_utility/include/mbf_utility/navigation_utility.h
+++ b/mbf_utility/include/mbf_utility/navigation_utility.h
@@ -47,8 +47,8 @@
 #include <rclcpp/time.hpp>
 #include <rclcpp/node.hpp>
 #include <string>
-#include <tf2/convert.h>
-#include <tf2_ros/buffer.h>
+#include <tf2/convert.hpp>
+#include <tf2_ros/buffer.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include "mbf_utility/types.h"

--- a/mbf_utility/include/mbf_utility/types.h
+++ b/mbf_utility/include/mbf_utility/types.h
@@ -40,10 +40,10 @@
 #define MBF_UTILITY__TYPES_H_
 
 #include <memory>
-#include <tf2_ros/buffer.h>
+#include <tf2_ros/buffer.hpp>
 
 typedef std::shared_ptr<tf2_ros::Buffer> TFPtr;
 typedef tf2_ros::Buffer TF;
 typedef tf2::TransformException TFException;
 
-#endif
+#endif // MBF_UTILITY__TYPES_H_

--- a/move_base_flex/CMakeLists.txt
+++ b/move_base_flex/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(move_base_flex)
 find_package(ament_cmake REQUIRED)
 ament_package()

--- a/rviz_mbf_plugins/CMakeLists.txt
+++ b/rviz_mbf_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 project(rviz_mbf_plugins)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -14,16 +14,20 @@ find_package(geometry_msgs REQUIRED)
 find_package(mbf_msgs REQUIRED)
 find_package(rviz_common REQUIRED)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
-
-
-set(rviz_mbf_plugins_headers_to_moc
-  include/rviz_mbf_plugins/mbf_goal_actions_panel.hpp
-)
-
-foreach(header "${rviz_mbf_plugins_headers_to_moc}")
-  qt5_wrap_cpp(rviz_mbf_plugins_moc_files "${header}")
-endforeach()
+# Now detect which Qt version rviz_common brought in
+if(TARGET Qt6::Core)
+  find_package(Qt6 REQUIRED COMPONENTS Widgets)
+  set(QT_TARGET Qt6::Widgets)
+  qt6_wrap_cpp(rviz_mbf_plugins_moc_files
+    include/rviz_mbf_plugins/mbf_goal_actions_panel.hpp
+  )
+elseif(TARGET Qt5::Core) # humble compatibility
+  find_package(Qt5 REQUIRED COMPONENTS Widgets)
+  set(QT_TARGET Qt5::Widgets)
+  qt5_wrap_cpp(rviz_mbf_plugins_moc_files
+    include/rviz_mbf_plugins/mbf_goal_actions_panel.hpp
+  )
+endif()
 
 add_library(rviz_mbf_plugins SHARED
   ${rviz_mbf_plugins_moc_files}
@@ -35,18 +39,18 @@ target_include_directories(rviz_mbf_plugins PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 
-ament_target_dependencies(rviz_mbf_plugins
-  rclcpp
-  rclcpp_action
-  pluginlib
-  geometry_msgs
-  mbf_msgs
-  rviz_common
+target_link_libraries(rviz_mbf_plugins PUBLIC
+  rclcpp::rclcpp
+  ${rclcpp_action_TARGETS}
+  ${pluginlib_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${mbf_msgs_TARGETS}
+  ${rviz_common_TARGETS}
+  ${QT_TARGET}
 )
 
-target_link_libraries(rviz_mbf_plugins
-  Qt5::Widgets
-)
+# Create namespaced alias for modern CMake style
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS rviz_mbf_plugins)
 
 target_compile_definitions(rviz_mbf_plugins PRIVATE "RVIZ_MBF_PLUGINS_BUILDING_LIBRARY")
 
@@ -73,4 +77,5 @@ install(
 ament_export_include_directories(include)
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
+set(rviz_mbf_plugins_TARGETS rviz_mbf_plugins)
 ament_package()

--- a/rviz_mbf_plugins/package.xml
+++ b/rviz_mbf_plugins/package.xml
@@ -23,12 +23,19 @@
   <depend>rviz_common</depend>
   <depend>geometry_msgs</depend>
 
-  <build_depend>qt-base-dev</build_depend>
-  <build_export_depend>qt-base-dev</build_export_depend>
+  <!-- From humble, we cannot resolve the version-less keys -->
+  <build_depend condition="$ROS_DISTRO == humble">qtbase5-dev</build_depend>
+  <build_export_depend condition="$ROS_DISTRO == humble">qtbase5-dev</build_export_depend>
+  <exec_depend condition="$ROS_DISTRO == humble">libqt5-widgets</exec_depend>
+  <exec_depend condition="$ROS_DISTRO == humble">libqt5-gui</exec_depend>
+  <exec_depend condition="$ROS_DISTRO == humble">libqt5-core</exec_depend>
 
-  <exec_depend>libqtwidgets</exec_depend>
-  <exec_depend>libqtgui</exec_depend>
-  <exec_depend>libqtcore</exec_depend>
+  <!-- From > humble, we can the generic versions -->
+  <build_depend condition="$ROS_DISTRO != humble">qt-base-dev</build_depend>
+  <build_export_depend condition="$ROS_DISTRO != humble">qt-base-dev</build_export_depend>
+  <exec_depend condition="$ROS_DISTRO != humble">libqtwidgets</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != humble">libqtgui</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != humble">libqtcore</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rviz_mbf_plugins/package.xml
+++ b/rviz_mbf_plugins/package.xml
@@ -23,12 +23,12 @@
   <depend>rviz_common</depend>
   <depend>geometry_msgs</depend>
 
-  <build_depend>qtbase5-dev</build_depend>
-  <build_export_depend>qtbase5-dev</build_export_depend>
+  <build_depend>qt-base-dev</build_depend>
+  <build_export_depend>qt-base-dev</build_export_depend>
 
-  <exec_depend>libqt5-widgets</exec_depend>
-  <exec_depend>libqt5-gui</exec_depend>
-  <exec_depend>libqt5-core</exec_depend>
+  <exec_depend>libqtwidgets</exec_depend>
+  <exec_depend>libqtgui</exec_depend>
+  <exec_depend>libqtcore</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
- removed `ament_target_dependencies`
- new cmake-target-based CMakeLists. Kept also old style "_TARGETS" variable for backwards compatibility
- compiled with humble, jazzy, lyrical
- tested with MeshNav under jazzy