### PR TITLE
Fix: Missing ament_cmake_ros Dependency

### DIFF
--- a/mbf_abstract_nav/package.xml
+++ b/mbf_abstract_nav/package.xml
@@ -30,8 +30,6 @@
   <test_depend>ament_cmake_gmock</test_depend> 
 
   <export>
-    <!-- TODO -->
-    <!--rosdoc config="rosdoc.yaml" /-->
     <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/mbf_abstract_nav/test/abstract_execution_base.cpp
+++ b/mbf_abstract_nav/test/abstract_execution_base.cpp
@@ -99,5 +99,7 @@ int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
-  return RUN_ALL_TESTS();
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/mbf_abstract_nav/test/planner_action.cpp
+++ b/mbf_abstract_nav/test/planner_action.cpp
@@ -287,5 +287,7 @@ int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
   testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
 }

--- a/mbf_msgs/CMakeLists.txt
+++ b/mbf_msgs/CMakeLists.txt
@@ -1,14 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(mbf_msgs)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)

--- a/mbf_simple_core/CMakeLists.txt
+++ b/mbf_simple_core/CMakeLists.txt
@@ -22,7 +22,7 @@ target_include_directories(${PROJECT_NAME} INTERFACE
 )
 
 target_link_libraries(${PROJECT_NAME} INTERFACE
-  rclcpp::rclcpp
+  ${rclcpp_TARGETS}
   ${mbf_utility_TARGETS}
   ${mbf_abstract_core_TARGETS}
   ${geometry_msgs_TARGETS}

--- a/mbf_simple_nav/CMakeLists.txt
+++ b/mbf_simple_nav/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(mbf_simple_nav)
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 set(dependencies
   geometry_msgs
   mbf_abstract_core
@@ -23,7 +23,7 @@ foreach(dep IN LISTS dependencies)
 endforeach()
 
 
-add_library(${PROJECT_NAME}_lib
+add_library(${PROJECT_NAME}_lib SHARED
   src/simple_navigation_server.cpp
 )
 target_compile_features(${PROJECT_NAME}_lib PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
@@ -31,6 +31,8 @@ target_include_directories(${PROJECT_NAME}_lib PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 target_link_libraries(${PROJECT_NAME}_lib PUBLIC
+  ${rclcpp_TARGETS}
+  ${rclcpp_action_TARGETS}
   ${geometry_msgs_TARGETS}
   ${mbf_abstract_core_TARGETS}
   ${mbf_abstract_nav_TARGETS}
@@ -39,8 +41,6 @@ target_link_libraries(${PROJECT_NAME}_lib PUBLIC
   ${mbf_utility_TARGETS}
   ${nav_msgs_TARGETS}
   ${pluginlib_TARGETS}
-  ${rclcpp_TARGETS}
-  ${rclcpp_action_TARGETS}
   ${std_msgs_TARGETS}
   ${std_srvs_TARGETS}
   ${tf2_TARGETS}
@@ -53,12 +53,12 @@ add_library(${PROJECT_NAME}::${PROJECT_NAME}_lib ALIAS ${PROJECT_NAME}_lib)
 add_executable(${PROJECT_NAME}_node
   src/simple_server_node.cpp
 )
-target_compile_features(${PROJECT_NAME}_node PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 target_include_directories(${PROJECT_NAME}_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 target_link_libraries(${PROJECT_NAME}_node PUBLIC
-  ${PROJECT_NAME}_lib
+  ${rclcpp_TARGETS}
+  ${rclcpp_action_TARGETS}
   ${geometry_msgs_TARGETS}
   ${mbf_abstract_core_TARGETS}
   ${mbf_abstract_nav_TARGETS}
@@ -67,12 +67,11 @@ target_link_libraries(${PROJECT_NAME}_node PUBLIC
   ${mbf_utility_TARGETS}
   ${nav_msgs_TARGETS}
   ${pluginlib_TARGETS}
-  ${rclcpp_TARGETS}
-  ${rclcpp_action_TARGETS}
   ${std_msgs_TARGETS}
   ${std_srvs_TARGETS}
   ${tf2_TARGETS}
   ${tf2_ros_TARGETS}
+  ${PROJECT_NAME}_lib
 )
 
 install(DIRECTORY include/ DESTINATION include)
@@ -89,7 +88,7 @@ install(TARGETS ${PROJECT_NAME}_node
 
 if(BUILD_TESTING)
   # Add test lib with plugin(s)
-  add_library(${PROJECT_NAME}_test_plugins
+  add_library(${PROJECT_NAME}_test_plugins SHARED
     test/plugins/test_planner.cpp
     test/plugins/test_plan_refiner.cpp
     test/plugins/test_controller.cpp
@@ -111,10 +110,6 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(mbf_test_utility REQUIRED)
   ament_add_gmock(${PROJECT_NAME}_integration_test test/simple_nav_integration_test.cpp)
-  target_include_directories(${PROJECT_NAME}_integration_test PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-  )
   target_link_libraries(${PROJECT_NAME}_integration_test
     ${PROJECT_NAME}_lib
     ${mbf_test_utility_TARGETS}
@@ -122,6 +117,7 @@ if(BUILD_TESTING)
   )
 endif()
 
+# backwards compatibility for old style cmake
 ament_export_include_directories(include)
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(${dependencies})

--- a/mbf_simple_nav/package.xml
+++ b/mbf_simple_nav/package.xml
@@ -37,7 +37,6 @@
   <test_depend>ament_cmake_gmock</test_depend>
 
   <export>
-      <!-- TODO <rosdoc config="rosdoc.yaml" /> -->
       <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/mbf_test_utility/CMakeLists.txt
+++ b/mbf_test_utility/CMakeLists.txt
@@ -6,15 +6,20 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # find dependencies
-find_package(ament_cmake_ros REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(mbf_msgs REQUIRED)
-find_package(nav_msgs REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
-find_package(tf2_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
+set(dependencies
+  geometry_msgs
+  mbf_msgs
+  nav_msgs
+  rclcpp
+  tf2_geometry_msgs
+  tf2_ros
+)
+foreach(dep IN LISTS dependencies)
+  find_package(${dep} REQUIRED)
+endforeach()
 
-add_library(${PROJECT_NAME}_sim
+add_library(${PROJECT_NAME}_sim SHARED
   src/robot_simulator.cpp
 )
 target_compile_features(${PROJECT_NAME}_sim PUBLIC
@@ -23,8 +28,8 @@ target_compile_features(${PROJECT_NAME}_sim PUBLIC
 target_include_directories(${PROJECT_NAME}_sim PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-target_link_libraries(${PROJECT_NAME}_sim
-  rclcpp::rclcpp
+target_link_libraries(${PROJECT_NAME}_sim PUBLIC
+  ${rclcpp_TARGETS}
   ${geometry_msgs_TARGETS}
   ${mbf_msgs_TARGETS}
   ${nav_msgs_TARGETS}
@@ -38,9 +43,6 @@ add_library(${PROJECT_NAME}::${PROJECT_NAME}_sim ALIAS ${PROJECT_NAME}_sim)
 add_executable(${PROJECT_NAME}_sim_node
   src/robot_simulator_node.cpp
 )
-target_compile_features(${PROJECT_NAME}_sim_node PUBLIC
-  c_std_99
-  cxx_std_17)  # Require C99 and C++17
 target_include_directories(${PROJECT_NAME}_sim_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
@@ -68,7 +70,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(rclcpp geometry_msgs nav_msgs tf2_ros)
+ament_export_dependencies(${dependencies})
 
 set(mbf_test_utility_TARGETS mbf_test_utility_sim)
 ament_package()

--- a/rviz_mbf_plugins/CMakeLists.txt
+++ b/rviz_mbf_plugins/CMakeLists.txt
@@ -40,7 +40,7 @@ target_include_directories(rviz_mbf_plugins PUBLIC
 )
 
 target_link_libraries(rviz_mbf_plugins PUBLIC
-  rclcpp::rclcpp
+  ${rclcpp_TARGETS}
   ${rclcpp_action_TARGETS}
   ${pluginlib_TARGETS}
   ${geometry_msgs_TARGETS}


### PR DESCRIPTION
Original issue was: Jenkins build failed because `ament_cmake_ros` was written in the CMakeLists.txt but not in the package.xml. So there are two options to fix that:
1. add missing `ament_cmake_ros` to package.xml
2. change `ament_cmake_ros` to `ament_cmake` in CMakeLists.txt

I decided to go for option 2 if the package is not using any feature of `ament_cmake_ros`. That is the case for every package, so I replaced every `ament_cmake_ros` dependency with `ament_cmake`. Problem was, `ament_cmake_ros` silently sets the build of a library to SHARED. So just replacing it changes the build process. Therefore I added the explicit SHARED keyword to all the libraries that didn't have it yet.

Additionally, I did some consistency cleanups and removed obsolete things from the CMakeLists.